### PR TITLE
feat: AI-assisted refresh and GitHub Action for staleness checks

### DIFF
--- a/.github/scripts/upsert-issue.sh
+++ b/.github/scripts/upsert-issue.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# upsert-issue.sh — Create or update a GitHub issue for skill staleness.
+#
+# Environment variables:
+#   GH_TOKEN      — GitHub token with issues:write permission
+#   ISSUE_LABEL   — Label used for deduplication (e.g. "skill-staleness")
+#   REPORT_BODY   — Markdown body for the issue
+#   GITHUB_OUTPUT — GitHub Actions output file
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${ISSUE_LABEL:?ISSUE_LABEL is required}"
+: "${REPORT_BODY:?REPORT_BODY is required}"
+
+TITLE="Skill staleness detected — $(date -u +%Y-%m-%d)"
+
+# Search for an existing open issue with the staleness label
+EXISTING=$(gh issue list \
+  --label "$ISSUE_LABEL" \
+  --state open \
+  --limit 1 \
+  --json number \
+  --jq '.[0].number // empty' 2>/dev/null || true)
+
+if [ -n "$EXISTING" ]; then
+  gh issue edit "$EXISTING" \
+    --title "$TITLE" \
+    --body "$REPORT_BODY"
+  echo "Updated existing issue #${EXISTING}"
+  ISSUE_NUMBER="$EXISTING"
+else
+  ISSUE_NUMBER=$(gh issue create \
+    --title "$TITLE" \
+    --body "$REPORT_BODY" \
+    --label "$ISSUE_LABEL" \
+    --json number \
+    --jq '.number')
+  echo "Created new issue #${ISSUE_NUMBER}"
+fi
+
+echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skill-versions.json"
+      - "packages/cli/src/**"
+      - "packages/schema/src/**"
+      - "packages/web/**"
+      - "package.json"
+      - "package-lock.json"
+  pull_request:
+    branches: [main]
+    paths:
+      - "skill-versions.json"
+      - "packages/cli/src/**"
+      - "packages/schema/src/**"
+      - "packages/web/**"
+      - "package.json"
+      - "package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test
+
+  validate-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check skill freshness
+        run: npx skill-versions check --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,4 @@ jobs:
         run: npm run build
 
       - name: Check skill freshness
-        run: npx skill-versions check --ci
+        run: node packages/cli/dist/index.js check --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
     paths:
-      - "skill-versions.json"
       - "packages/cli/src/**"
       - "packages/schema/src/**"
       - "packages/web/**"
@@ -13,7 +12,6 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "skill-versions.json"
       - "packages/cli/src/**"
       - "packages/schema/src/**"
       - "packages/web/**"
@@ -51,23 +49,3 @@ jobs:
       - name: Test
         run: npm run test
 
-  validate-registry:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Check skill freshness
-        run: node packages/cli/dist/index.js check --ci

--- a/.github/workflows/skill-staleness.yml
+++ b/.github/workflows/skill-staleness.yml
@@ -1,0 +1,29 @@
+name: Skill Staleness Check
+
+on:
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      open-issues:
+        description: "Open or update a GitHub issue"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  staleness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check skill staleness
+        uses: ./
+        with:
+          open-issues: ${{ github.event.inputs.open-issues || 'true' }}
+          fail-on-stale: "false"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ skill-versions.json
 .turbo/
 .next/
 packages/web/public/schema.json
+packages/web/tsconfig.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -178,8 +178,84 @@ The `init` command reads this field and groups skills by shared version + name p
 
 ## CI Integration
 
+### GitHub Action
+
+Add `skill-versions` as a reusable action in your workflow:
+
 ```yaml
-# GitHub Actions
+- uses: voodootikigod/skill-versions@v1
+  with:
+    registry: skill-versions.json  # default
+    open-issues: "true"            # create/update issue on staleness
+    fail-on-stale: "false"         # set "true" to block PRs
+```
+
+The action requires `issues: write` permission when `open-issues` is enabled.
+
+#### Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `registry` | `skill-versions.json` | Path to registry file |
+| `node-version` | `20` | Node.js version |
+| `open-issues` | `true` | Open/update GitHub issue on staleness |
+| `issue-label` | `skill-staleness` | Label for issue deduplication |
+| `fail-on-stale` | `false` | Exit non-zero when stale |
+| `token` | `${{ github.token }}` | GitHub token (needs `issues: write`) |
+
+#### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `stale-count` | Number of stale products (0 if current) |
+| `issue-number` | Issue number created/updated (empty if none) |
+| `report` | Full markdown report |
+
+#### Weekly cron example
+
+```yaml
+name: Skill Staleness Check
+on:
+  schedule:
+    - cron: "0 9 * * 1"   # Monday 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  staleness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: voodootikigod/skill-versions@v1
+        with:
+          fail-on-stale: "false"
+```
+
+#### PR gate example
+
+```yaml
+- uses: voodootikigod/skill-versions@v1
+  with:
+    open-issues: "false"
+    fail-on-stale: "true"
+```
+
+#### Setup
+
+Create the deduplication label once:
+
+```bash
+gh label create skill-staleness --color "#e4e669" --description "Skill version drift detected"
+```
+
+### Inline check
+
+For simpler setups, use the CLI directly:
+
+```yaml
 - name: Check skill freshness
   run: npx skill-versions check --ci
 ```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,40 @@ Generate a full staleness report.
 | `-r, --registry <path>` | Path to registry file |
 | `-f, --format <type>` | Output format: `json` or `markdown` (default: `markdown`) |
 
+### `skill-versions refresh [skills-dir]`
+
+Use an LLM to propose targeted updates to stale skill files. Fetches changelogs, generates diffs, and optionally applies changes.
+
+| Flag | Description |
+|------|-------------|
+| `-r, --registry <path>` | Path to registry file |
+| `-p, --product <name>` | Refresh a single product |
+| `--provider <name>` | LLM provider: `anthropic`, `openai`, `google` |
+| `--model <id>` | Specific model ID (e.g. `claude-sonnet-4-20250514`) |
+| `-y, --yes` | Auto-apply without confirmation |
+| `--dry-run` | Show proposed changes, write nothing |
+
+**Provider setup:** Install a provider SDK and set the API key:
+
+```bash
+# Anthropic (Claude)
+npm install @ai-sdk/anthropic
+export ANTHROPIC_API_KEY=sk-...
+
+# OpenAI
+npm install @ai-sdk/openai
+export OPENAI_API_KEY=sk-...
+
+# Google (Gemini)
+npm install @ai-sdk/google
+export GOOGLE_GENERATIVE_AI_API_KEY=...
+```
+
+The skills directory is resolved in priority order:
+1. CLI argument: `skill-versions refresh ./my-skills`
+2. Registry field: `"skillsDir": "./skills"` in skill-versions.json
+3. Default: `./skills`
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ The `skill-versions.json` file maps products to npm packages:
       "verifiedVersion": "6.0.105",
       "verifiedAt": "2026-02-28T00:00:00Z",
       "changelog": "https://github.com/vercel/ai/releases",
-      "skills": ["ai-sdk-core", "ai-sdk-tools", "ai-sdk-react"]
+      "skills": ["ai-sdk-core", "ai-sdk-tools", "ai-sdk-react"],
+      "agents": ["ai-sdk-engineer"]
     }
   }
 }

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,101 @@
+name: "Skill Versions Check"
+description: "Check skill freshness and optionally open GitHub issues for stale products"
+author: "voodootikigod"
+
+branding:
+  icon: "refresh-cw"
+  color: "yellow"
+
+inputs:
+  registry:
+    description: "Path to the skill-versions.json registry file"
+    default: "skill-versions.json"
+  node-version:
+    description: "Node.js version to use"
+    default: "20"
+  open-issues:
+    description: "Open or update a GitHub issue when staleness is detected"
+    default: "true"
+  issue-label:
+    description: "Label used for issue deduplication"
+    default: "skill-staleness"
+  fail-on-stale:
+    description: "Exit with non-zero code when stale products are found"
+    default: "false"
+  token:
+    description: "GitHub token (needs issues: write permission)"
+    default: ${{ github.token }}
+
+outputs:
+  stale-count:
+    description: "Number of stale products (0 if all current)"
+    value: ${{ steps.check.outputs.stale_count }}
+  issue-number:
+    description: "Issue number created or updated (empty if none)"
+    value: ${{ steps.upsert.outputs.issue_number }}
+  report:
+    description: "Full markdown report"
+    value: ${{ steps.report.outputs.report }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Check skill freshness
+      id: check
+      shell: bash
+      run: |
+        set +e
+        OUTPUT=$(npx --yes skill-versions check --registry "${{ inputs.registry }}" --json --ci 2>&1)
+        EXIT_CODE=$?
+        set -e
+
+        if [ "$EXIT_CODE" -eq 2 ]; then
+          echo "::error::skill-versions configuration error"
+          echo "$OUTPUT"
+          exit 2
+        fi
+
+        # Count stale products from JSON output
+        STALE_COUNT=0
+        if [ "$EXIT_CODE" -eq 1 ]; then
+          STALE_COUNT=$(echo "$OUTPUT" | jq '[.[] | select(.stale == true)] | length' 2>/dev/null || echo "1")
+        fi
+
+        echo "stale_count=${STALE_COUNT}" >> "$GITHUB_OUTPUT"
+        echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+    - name: Generate report
+      id: report
+      if: steps.check.outputs.exit_code == '1'
+      shell: bash
+      run: |
+        REPORT=$(npx --yes skill-versions report --registry "${{ inputs.registry }}" --format markdown 2>/dev/null)
+
+        # Write multiline output
+        {
+          echo "report<<SKILL_VERSIONS_EOF"
+          echo "$REPORT"
+          echo "SKILL_VERSIONS_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Upsert issue
+      id: upsert
+      if: steps.check.outputs.exit_code == '1' && inputs.open-issues == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        ISSUE_LABEL: ${{ inputs.issue-label }}
+        REPORT_BODY: ${{ steps.report.outputs.report }}
+      run: bash "${GITHUB_ACTION_PATH}/.github/scripts/upsert-issue.sh"
+
+    - name: Fail on stale
+      if: steps.check.outputs.exit_code == '1' && inputs.fail-on-stale == 'true'
+      shell: bash
+      run: |
+        echo "::error::${{ steps.check.outputs.stale_count }} stale product(s) detected"
+        exit 1

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "skill-versions.json"
   node-version:
     description: "Node.js version to use"
-    default: "20"
+    default: "22"
   open-issues:
     description: "Open or update a GitHub issue when staleness is detected"
     default: "true"

--- a/biome.json
+++ b/biome.json
@@ -1,23 +1,21 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true
-    }
-  },
-  "formatter": {
-    "enabled": true,
-    "indentStyle": "tab",
-    "lineWidth": 100
-  },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "double",
-      "semicolons": "always"
-    }
-  }
+	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"lineWidth": 100
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always"
+		}
+	}
 }

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+	"files": {
+		"includes": ["**", "!!**/dist", "!!**/.next"]
+	},
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,103 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@ai-sdk/anthropic": {
+			"version": "3.0.50",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.50.tgz",
+			"integrity": "sha512-BkCUgGTp/iZJuuFBF1wv7GGnrEJg7X7hqbaa+/t4HTBt9dZn3e6NFn5NhPUvo2p5SreUeHEl0As0r2uaVn3K9Q==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.8",
+				"@ai-sdk/provider-utils": "4.0.16"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/gateway": {
+			"version": "3.0.59",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.59.tgz",
+			"integrity": "sha512-MbtheWHgEFV/8HL1Z6E3hOAsmP73zZlNFg0F0nJAD0Adnjp4J/plqNK00Y896d+dWTw+r0OXzyov9/2wCFjH0Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.8",
+				"@ai-sdk/provider-utils": "4.0.16",
+				"@vercel/oidc": "3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/google": {
+			"version": "3.0.34",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.34.tgz",
+			"integrity": "sha512-1tXUr1W5YACXPgtHYWIU3raqMsayp6cMI8NUT4EEzzZSpvHzkkiNWHEr+bGxEGurSUukfo+pE1RKpLwBFOZtJg==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.8",
+				"@ai-sdk/provider-utils": "4.0.16"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/openai": {
+			"version": "3.0.37",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.37.tgz",
+			"integrity": "sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.8",
+				"@ai-sdk/provider-utils": "4.0.16"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/provider": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+			"integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@ai-sdk/provider-utils": {
+			"version": "4.0.16",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.16.tgz",
+			"integrity": "sha512-kBvDqNkt5EwlzF9FujmNhhtl8FYg3e8FO8P5uneKliqfRThWemzBj+wfYr7ZCymAQhTRnwSSz1/SOqhOAwmx9g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.8",
+				"@standard-schema/spec": "^1.1.0",
+				"eventsource-parser": "^3.0.6"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
 		"node_modules/@biomejs/biome": {
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.4.tgz",
@@ -1271,6 +1368,15 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -1633,7 +1739,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@swc/helpers": {
@@ -1713,6 +1818,15 @@
 			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@vercel/oidc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+			"integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 20"
+			}
 		},
 		"node_modules/@vitest/expect": {
 			"version": "4.0.18",
@@ -1836,6 +1950,24 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ai": {
+			"version": "6.0.105",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.105.tgz",
+			"integrity": "sha512-rp+exWtZS3J0DDvZIfetpKCIg7D3cCsvBPoFN3I67IDTs9aoBZDbpecoIkmNLT+U9RBkoEial3OGHRvme23HCw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/gateway": "3.0.59",
+				"@ai-sdk/provider": "3.0.8",
+				"@ai-sdk/provider-utils": "4.0.16",
+				"@opentelemetry/api": "1.9.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/any-promise": {
@@ -2027,6 +2159,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -2097,6 +2238,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+			"integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/expect-type": {
@@ -2225,6 +2375,12 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"license": "(AFL-2.1 OR BSD-3-Clause)"
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -3363,16 +3519,28 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
 		"packages/cli": {
 			"name": "skill-versions",
 			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@skill-versions/schema": "*",
+				"ai": "^6.0.0",
 				"chalk": "^5.4.1",
 				"commander": "^14.0.0",
+				"diff": "^8.0.0",
 				"gray-matter": "^4.0.3",
-				"semver": "^7.7.0"
+				"semver": "^7.7.0",
+				"zod": "^3.24.0"
 			},
 			"bin": {
 				"skill-versions": "dist/index.js"
@@ -3387,6 +3555,11 @@
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@ai-sdk/anthropic": "^3.0.0",
+				"@ai-sdk/google": "^3.0.0",
+				"@ai-sdk/openai": "^3.0.0"
 			}
 		},
 		"packages/schema": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"typescript": "^5.8.0"
 	},
 	"engines": {
-		"node": ">=18"
+		"node": ">=22"
 	},
 	"packageManager": "npm@10.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
 	"name": "skill-versions-monorepo",
 	"private": true,
-	"workspaces": ["packages/*"],
+	"workspaces": [
+		"packages/*"
+	],
 	"scripts": {
 		"build": "turbo run build",
 		"dev": "turbo run dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,9 @@
 	"bin": {
 		"skill-versions": "./dist/index.js"
 	},
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build": "tsup",
 		"dev": "tsx src/index.ts",
@@ -27,10 +29,18 @@
 	"license": "MIT",
 	"dependencies": {
 		"@skill-versions/schema": "*",
+		"ai": "^6.0.0",
 		"chalk": "^5.4.1",
 		"commander": "^14.0.0",
+		"diff": "^8.0.0",
 		"gray-matter": "^4.0.3",
-		"semver": "^7.7.0"
+		"semver": "^7.7.0",
+		"zod": "^3.24.0"
+	},
+	"optionalDependencies": {
+		"@ai-sdk/anthropic": "^3.0.0",
+		"@ai-sdk/google": "^3.0.0",
+		"@ai-sdk/openai": "^3.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/packages/cli/src/changelog.test.ts
+++ b/packages/cli/src/changelog.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { extractChangelogSection, parseGitHubUrl } from "./changelog.js";
+
+describe("changelog", () => {
+	describe("parseGitHubUrl", () => {
+		it("parses https GitHub URL", () => {
+			const result = parseGitHubUrl("https://github.com/vercel/next.js");
+			expect(result).toEqual({ owner: "vercel", repo: "next.js" });
+		});
+
+		it("parses git+https URL with .git suffix", () => {
+			const result = parseGitHubUrl("git+https://github.com/vercel/ai.git");
+			expect(result).toEqual({ owner: "vercel", repo: "ai" });
+		});
+
+		it("parses SSH URL", () => {
+			const result = parseGitHubUrl("git@github.com:vercel/next.js.git");
+			expect(result).toEqual({ owner: "vercel", repo: "next.js" });
+		});
+
+		it("returns null for non-GitHub URL", () => {
+			expect(parseGitHubUrl("https://gitlab.com/foo/bar")).toBeNull();
+		});
+
+		it("returns null for empty string", () => {
+			expect(parseGitHubUrl("")).toBeNull();
+		});
+	});
+
+	describe("extractChangelogSection", () => {
+		const sampleChangelog = `# Changelog
+
+## 3.0.0
+
+Breaking changes here.
+
+## 2.1.0
+
+New features added.
+
+## 2.0.0
+
+Major release notes.
+
+## 1.5.0
+
+Old stuff.
+`;
+
+		it("extracts sections between two versions", () => {
+			const result = extractChangelogSection(sampleChangelog, "2.0.0", "3.0.0");
+			expect(result).toContain("Breaking changes here.");
+			expect(result).toContain("## 3.0.0");
+			expect(result).toContain("New features added.");
+			expect(result).toContain("## 2.1.0");
+			expect(result).not.toContain("Major release notes.");
+		});
+
+		it("extracts single version section", () => {
+			const result = extractChangelogSection(sampleChangelog, "2.0.0", "2.1.0");
+			expect(result).toContain("New features added.");
+			expect(result).not.toContain("Breaking changes");
+		});
+
+		it("returns null when no matching sections found", () => {
+			const result = extractChangelogSection(sampleChangelog, "4.0.0", "5.0.0");
+			expect(result).toBeNull();
+		});
+
+		it("handles changelog with different heading levels", () => {
+			const changelog = `### 2.0.0
+
+Changes for v2.
+
+### 1.0.0
+
+Initial release.
+`;
+			const result = extractChangelogSection(changelog, "1.0.0", "2.0.0");
+			expect(result).toContain("Changes for v2.");
+		});
+	});
+});

--- a/packages/cli/src/changelog.ts
+++ b/packages/cli/src/changelog.ts
@@ -1,0 +1,224 @@
+import * as semver from "semver";
+import { fetchPackageMetadata } from "./npm.js";
+
+const MAX_CHANGELOG_LENGTH = 8000;
+
+interface GitHubRelease {
+	tag_name: string;
+	name: string;
+	body: string;
+	published_at: string;
+}
+
+/**
+ * Fetch changelog/release notes between two versions of a package.
+ *
+ * Waterfall strategy:
+ * 1. Registry changelog URL (if provided) — fetch and return raw content
+ * 2. npm metadata → derive GitHub owner/repo → GitHub Releases API
+ * 3. GitHub raw CHANGELOG.md → extract relevant section
+ * 4. Return null if all fail
+ */
+export async function fetchChangelog(
+	packageName: string,
+	fromVersion: string,
+	toVersion: string,
+	changelogUrl?: string,
+): Promise<string | null> {
+	// Strategy 1: Direct changelog URL from registry
+	if (changelogUrl) {
+		const content = await fetchUrl(changelogUrl);
+		if (content) return truncate(content);
+	}
+
+	// Strategy 2 & 3: Derive GitHub repo from npm metadata
+	const repo = await resolveGitHubRepo(packageName);
+	if (!repo) return null;
+
+	// Strategy 2: GitHub Releases API
+	const releases = await fetchGitHubReleases(repo.owner, repo.repo, fromVersion, toVersion);
+	if (releases) return truncate(releases);
+
+	// Strategy 3: Raw CHANGELOG.md
+	const changelog = await fetchRawChangelog(repo.owner, repo.repo, fromVersion, toVersion);
+	if (changelog) return truncate(changelog);
+
+	return null;
+}
+
+/**
+ * Resolve a GitHub owner/repo from npm package metadata.
+ */
+export async function resolveGitHubRepo(
+	packageName: string,
+): Promise<{ owner: string; repo: string } | null> {
+	try {
+		const metadata = await fetchPackageMetadata(packageName);
+		if (!metadata.repository?.url) return null;
+
+		return parseGitHubUrl(metadata.repository.url);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Parse a GitHub URL into owner/repo components.
+ * Handles: git+https://github.com/owner/repo.git, https://github.com/owner/repo, etc.
+ */
+export function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
+	const match = url.match(/github\.com[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
+	if (!match) return null;
+	return { owner: match[1], repo: match[2] };
+}
+
+/**
+ * Fetch releases between two versions from GitHub Releases API.
+ */
+async function fetchGitHubReleases(
+	owner: string,
+	repo: string,
+	fromVersion: string,
+	toVersion: string,
+): Promise<string | null> {
+	try {
+		const headers: Record<string, string> = {
+			Accept: "application/vnd.github+json",
+		};
+
+		const token = process.env.GITHUB_TOKEN;
+		if (token) {
+			headers.Authorization = `Bearer ${token}`;
+		}
+
+		const response = await fetch(
+			`https://api.github.com/repos/${owner}/${repo}/releases?per_page=50`,
+			{ headers },
+		);
+
+		if (!response.ok) return null;
+
+		const releases = (await response.json()) as GitHubRelease[];
+		const relevant = releases.filter((r) => {
+			const version = semver.valid(semver.coerce(r.tag_name));
+			if (!version) return false;
+			return semver.gt(version, fromVersion) && semver.lte(version, toVersion);
+		});
+
+		if (relevant.length === 0) return null;
+
+		return relevant
+			.sort((a, b) => {
+				const va = semver.valid(semver.coerce(a.tag_name)) ?? "0.0.0";
+				const vb = semver.valid(semver.coerce(b.tag_name)) ?? "0.0.0";
+				return semver.compare(vb, va);
+			})
+			.map((r) => `## ${r.tag_name}\n\n${r.body}`)
+			.join("\n\n---\n\n");
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Fetch and extract relevant section from a raw CHANGELOG.md on GitHub.
+ */
+async function fetchRawChangelog(
+	owner: string,
+	repo: string,
+	fromVersion: string,
+	toVersion: string,
+): Promise<string | null> {
+	try {
+		const headers: Record<string, string> = {};
+		const token = process.env.GITHUB_TOKEN;
+		if (token) {
+			headers.Authorization = `Bearer ${token}`;
+		}
+
+		const response = await fetch(
+			`https://raw.githubusercontent.com/${owner}/${repo}/main/CHANGELOG.md`,
+			{ headers },
+		);
+
+		if (!response.ok) return null;
+
+		const content = await response.text();
+		return extractChangelogSection(content, fromVersion, toVersion);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Extract the relevant section from a CHANGELOG.md between two versions.
+ * Looks for markdown headings that contain version numbers.
+ */
+export function extractChangelogSection(
+	changelog: string,
+	fromVersion: string,
+	toVersion: string,
+): string | null {
+	const lines = changelog.split("\n");
+	const sections: string[] = [];
+	let capturing = false;
+	let currentSection: string[] = [];
+
+	for (const line of lines) {
+		const headingMatch = line.match(/^#{1,3}\s+.*?(\d+\.\d+\.\d+)/);
+		if (headingMatch) {
+			// Save previous section if we were capturing
+			if (capturing && currentSection.length > 0) {
+				sections.push(currentSection.join("\n"));
+			}
+
+			const version = semver.valid(semver.coerce(headingMatch[1]));
+			if (version) {
+				if (semver.gt(version, fromVersion) && semver.lte(version, toVersion)) {
+					capturing = true;
+					currentSection = [line];
+					continue;
+				}
+				if (semver.lte(version, fromVersion)) {
+					// Past our range, stop
+					break;
+				}
+			}
+			capturing = false;
+			currentSection = [];
+			continue;
+		}
+
+		if (capturing) {
+			currentSection.push(line);
+		}
+	}
+
+	// Don't forget the last section if still capturing
+	if (capturing && currentSection.length > 0) {
+		sections.push(currentSection.join("\n"));
+	}
+
+	return sections.length > 0 ? sections.join("\n\n") : null;
+}
+
+/**
+ * Fetch URL content as text, returning null on failure.
+ */
+async function fetchUrl(url: string): Promise<string | null> {
+	try {
+		const response = await fetch(url);
+		if (!response.ok) return null;
+		return await response.text();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Truncate changelog to stay within context budgets.
+ */
+function truncate(content: string): string {
+	if (content.length <= MAX_CHANGELOG_LENGTH) return content;
+	return `${content.slice(0, MAX_CHANGELOG_LENGTH)}\n\n... (truncated)`;
+}

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -135,9 +135,7 @@ export async function checkCommand(options: CheckOptions): Promise<number> {
 
 	if (stale.length > 0) {
 		console.log();
-		console.log(
-			chalk.dim('Run "skill-versions report --format markdown" for a full report.'),
-		);
+		console.log(chalk.dim('Run "skill-versions report --format markdown" for a full report.'));
 	}
 
 	console.log();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,9 +1,9 @@
-import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
 import chalk from "chalk";
 import { saveRegistry } from "../registry.js";
 import { groupSkills, scanSkills } from "../scanner.js";
-import type { Registry, RegistryProduct, ScannedSkill } from "../types.js";
+import type { Registry, RegistryProduct } from "../types.js";
 
 interface InitOptions {
 	yes?: boolean;
@@ -107,9 +107,7 @@ export async function initCommand(dir: string, options: InitOptions): Promise<nu
 
 			if (!detected) {
 				console.log(
-					chalk.yellow(
-						`  Skipping "${productKey}" (v${version}) — cannot auto-detect npm package`,
-					),
+					chalk.yellow(`  Skipping "${productKey}" (v${version}) — cannot auto-detect npm package`),
 				);
 				continue;
 			}
@@ -182,9 +180,7 @@ export async function initCommand(dir: string, options: InitOptions): Promise<nu
 					continue;
 				}
 
-				const nameAnswer = await rl.question(
-					`    display name [${defaultName}]: `,
-				);
+				const nameAnswer = await rl.question(`    display name [${defaultName}]: `);
 				const displayName = nameAnswer.trim() || defaultName;
 
 				packageToKey.set(packageName, productKey);

--- a/packages/cli/src/commands/refresh.ts
+++ b/packages/cli/src/commands/refresh.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { generateObject } from "ai";
 import chalk from "chalk";
+import matter from "gray-matter";
 import { fetchChangelog } from "../changelog.js";
 import { diffStats, formatDiff } from "../diff.js";
 import { buildSystemPrompt, buildUserPrompt } from "../llm/prompts.js";
@@ -233,6 +234,22 @@ export async function refreshCommand(
 
 			if (shouldApply) {
 				await writeSkillFile(skillPath, llmResult.updatedContent);
+
+				// Verify the LLM actually bumped the frontmatter product-version
+				const written = await readSkillFile(skillPath);
+				const writtenVersion = written.frontmatter["product-version"] as string | undefined;
+
+				if (writtenVersion !== result.latestVersion) {
+					console.log(
+						chalk.yellow(
+							`  ⚠ LLM did not bump product-version (got "${writtenVersion ?? "missing"}", expected "${result.latestVersion}") — patching`,
+						),
+					);
+					written.frontmatter["product-version"] = result.latestVersion;
+					const patched = matter.stringify(written.content, written.frontmatter);
+					await writeSkillFile(skillPath, patched);
+				}
+
 				console.log(chalk.green(`  ✓ Updated ${skillPath}`));
 				totalApplied++;
 			} else {

--- a/packages/cli/src/commands/refresh.ts
+++ b/packages/cli/src/commands/refresh.ts
@@ -1,0 +1,296 @@
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { generateObject } from "ai";
+import chalk from "chalk";
+import { fetchChangelog } from "../changelog.js";
+import { diffStats, formatDiff } from "../diff.js";
+import { buildSystemPrompt, buildUserPrompt } from "../llm/prompts.js";
+import { resolveModel } from "../llm/providers.js";
+import { RefreshResultSchema } from "../llm/schemas.js";
+import { fetchLatestVersions } from "../npm.js";
+import { loadRegistry, saveRegistry } from "../registry.js";
+import { getSeverity, normalizeVersion } from "../severity.js";
+import { readSkillFile, writeSkillFile } from "../skill-io.js";
+import type { CheckResult } from "../types.js";
+
+interface RefreshOptions {
+	registry?: string;
+	product?: string;
+	provider?: string;
+	model?: string;
+	yes?: boolean;
+	dryRun?: boolean;
+}
+
+/**
+ * Refresh stale skill files using an LLM to propose targeted updates.
+ */
+export async function refreshCommand(
+	skillsDir: string | undefined,
+	options: RefreshOptions,
+): Promise<number> {
+	// Load registry
+	const registry = await loadRegistry(options.registry);
+
+	// Resolve skills directory: CLI arg > registry field > default
+	const resolvedSkillsDir = skillsDir ?? registry.skillsDir ?? "./skills";
+
+	// Filter to single product if requested
+	const productEntries = Object.entries(registry.products).filter(
+		([key]) => !options.product || key === options.product,
+	);
+
+	if (options.product && productEntries.length === 0) {
+		console.error(chalk.red(`Product "${options.product}" not found in registry.`));
+		return 2;
+	}
+
+	// Fetch latest versions
+	const packageNames = productEntries.map(([, p]) => p.package);
+	const latestVersions = await fetchLatestVersions(packageNames);
+
+	// Build stale results
+	const staleResults: CheckResult[] = [];
+
+	for (const [key, product] of productEntries) {
+		// Skip platform-versioned products
+		if (product.verifiedVersion === "platform") {
+			console.log(chalk.dim(`  Skipping "${product.displayName}" (platform-versioned)`));
+			continue;
+		}
+
+		const latest = latestVersions.get(product.package);
+
+		if (latest instanceof Error) {
+			console.error(chalk.yellow(`  Warning: ${latest.message}`));
+			continue;
+		}
+
+		if (!latest) {
+			console.error(chalk.yellow(`  Warning: No version data for "${product.package}"`));
+			continue;
+		}
+
+		const verifiedNorm = normalizeVersion(product.verifiedVersion);
+		const latestNorm = normalizeVersion(latest);
+
+		if (!verifiedNorm || !latestNorm) continue;
+
+		const severity = getSeverity(verifiedNorm.version, latestNorm.version);
+		if (severity === "current") continue;
+
+		staleResults.push({
+			product: key,
+			displayName: product.displayName,
+			package: product.package,
+			verifiedVersion: product.verifiedVersion,
+			latestVersion: latest,
+			skills: product.skills,
+			changelog: product.changelog,
+			stale: true,
+			severity,
+		});
+	}
+
+	if (staleResults.length === 0) {
+		console.log(chalk.green("\nAll products are current. Nothing to refresh."));
+		return 0;
+	}
+
+	console.log(chalk.bold(`\nFound ${staleResults.length} stale product(s) to refresh:\n`));
+	for (const result of staleResults) {
+		const severityColor =
+			result.severity === "major"
+				? chalk.red
+				: result.severity === "minor"
+					? chalk.yellow
+					: chalk.blue;
+		console.log(
+			`  ${chalk.bold(result.displayName.padEnd(24))} ${result.verifiedVersion} ${chalk.dim("→")} ${severityColor(result.latestVersion)} ${chalk.dim(`(${result.severity})`)}`,
+		);
+	}
+	console.log();
+
+	// Resolve LLM model
+	console.log(chalk.dim("Resolving LLM provider..."));
+	const model = await resolveModel(options.provider, options.model);
+	console.log(chalk.dim(`Using model: ${options.model ?? "default"}\n`));
+
+	// Process each stale product
+	const systemPrompt = buildSystemPrompt();
+	let totalApplied = 0;
+	let totalSkipped = 0;
+	let applyAll = options.yes;
+
+	for (const result of staleResults) {
+		console.log(chalk.bold.underline(`\n${result.displayName}`));
+		console.log(
+			chalk.dim(`  ${result.package}: ${result.verifiedVersion} → ${result.latestVersion}`),
+		);
+
+		// Fetch changelog
+		console.log(chalk.dim("  Fetching changelog..."));
+		const changelog = await fetchChangelog(
+			result.package,
+			result.verifiedVersion,
+			result.latestVersion,
+			result.changelog,
+		);
+
+		if (changelog) {
+			console.log(chalk.dim(`  Changelog found (${changelog.length} chars)`));
+		} else {
+			console.log(chalk.dim("  No changelog found — LLM will proceed with low confidence"));
+		}
+
+		// Process each skill file for this product
+		const product = registry.products[result.product];
+
+		for (const skillName of product.skills) {
+			const skillPath = join(resolvedSkillsDir, skillName, "SKILL.md");
+
+			let skillFile: Awaited<ReturnType<typeof readSkillFile>>;
+			try {
+				skillFile = await readSkillFile(skillPath);
+			} catch {
+				console.error(chalk.yellow(`  Could not read ${skillPath}, skipping`));
+				continue;
+			}
+
+			console.log(chalk.dim(`\n  Processing: ${skillPath}`));
+			console.log(chalk.dim("  Calling LLM..."));
+
+			// Call LLM
+			const { object: llmResult } = await generateObject({
+				model,
+				schema: RefreshResultSchema,
+				system: systemPrompt,
+				prompt: buildUserPrompt({
+					skillContent: skillFile.raw,
+					displayName: result.displayName,
+					fromVersion: result.verifiedVersion,
+					toVersion: result.latestVersion,
+					changelog,
+				}),
+			});
+
+			// Display results
+			console.log();
+			console.log(`  ${chalk.bold("Summary:")} ${llmResult.summary}`);
+			console.log(
+				`  ${chalk.bold("Confidence:")} ${confidenceColor(llmResult.confidence)(llmResult.confidence)}`,
+			);
+			if (llmResult.breakingChanges) {
+				console.log(`  ${chalk.red.bold("⚠ Breaking changes detected")}`);
+			}
+
+			if (llmResult.changes.length > 0) {
+				console.log(`  ${chalk.bold("Changes:")}`);
+				for (const change of llmResult.changes) {
+					console.log(`    • ${chalk.cyan(change.section)}: ${change.description}`);
+				}
+			}
+
+			// Show diff
+			const stats = diffStats(skillFile.raw, llmResult.updatedContent);
+			if (stats.additions === 0 && stats.removals === 0) {
+				console.log(chalk.dim("\n  No changes detected."));
+				continue;
+			}
+
+			console.log(
+				`\n  ${chalk.green(`+${stats.additions}`)} ${chalk.red(`-${stats.removals}`)} lines changed\n`,
+			);
+			console.log(formatDiff(skillFile.raw, llmResult.updatedContent, skillPath));
+
+			// Apply or skip
+			if (options.dryRun) {
+				console.log(chalk.dim("\n  --dry-run: changes not applied"));
+				totalSkipped++;
+				continue;
+			}
+
+			let shouldApply = applyAll;
+
+			if (!shouldApply) {
+				const answer = await promptUser(
+					"\n  Apply this change? [y]es / [n]o / [a]ll / [s]kip product: ",
+				);
+
+				if (answer === "a") {
+					applyAll = true;
+					shouldApply = true;
+				} else if (answer === "y") {
+					shouldApply = true;
+				} else if (answer === "s") {
+					console.log(chalk.dim("  Skipping remaining skills for this product"));
+					totalSkipped += product.skills.length;
+					break;
+				} else {
+					shouldApply = false;
+				}
+			}
+
+			if (shouldApply) {
+				await writeSkillFile(skillPath, llmResult.updatedContent);
+				console.log(chalk.green(`  ✓ Updated ${skillPath}`));
+				totalApplied++;
+			} else {
+				console.log(chalk.dim("  Skipped"));
+				totalSkipped++;
+			}
+		}
+
+		// Update registry if any skills were applied for this product
+		if (!options.dryRun && (applyAll || totalApplied > 0)) {
+			product.verifiedVersion = result.latestVersion;
+			product.verifiedAt = new Date().toISOString();
+		}
+	}
+
+	// Save registry
+	if (!options.dryRun && totalApplied > 0) {
+		registry.lastCheck = new Date().toISOString();
+		const savedPath = await saveRegistry(registry, options.registry);
+		console.log(chalk.dim(`\nRegistry updated: ${savedPath}`));
+	}
+
+	// Summary
+	console.log(chalk.bold("\n--- Refresh Summary ---"));
+	console.log(`  Applied: ${chalk.green(String(totalApplied))}`);
+	console.log(`  Skipped: ${chalk.dim(String(totalSkipped))}`);
+	console.log();
+
+	return 0;
+}
+
+/**
+ * Get chalk color for confidence level.
+ */
+function confidenceColor(confidence: "high" | "medium" | "low") {
+	switch (confidence) {
+		case "high":
+			return chalk.green;
+		case "medium":
+			return chalk.yellow;
+		case "low":
+			return chalk.red;
+	}
+}
+
+/**
+ * Prompt user for input via readline.
+ */
+function promptUser(question: string): Promise<string> {
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+
+	return new Promise((resolve) => {
+		rl.question(question, (answer) => {
+			rl.close();
+			resolve(answer.trim().toLowerCase() || "n");
+		});
+	});
+}

--- a/packages/cli/src/diff.test.ts
+++ b/packages/cli/src/diff.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { diffStats, formatDiff } from "./diff.js";
+
+describe("diff", () => {
+	describe("formatDiff", () => {
+		it("shows additions in green markers", () => {
+			const result = formatDiff("line1\n", "line1\nnew line\n");
+			expect(result).toContain("+ new line");
+		});
+
+		it("shows removals in red markers", () => {
+			const result = formatDiff("old line\nkept\n", "kept\n");
+			expect(result).toContain("- old line");
+		});
+
+		it("shows file path header when provided", () => {
+			const result = formatDiff("a\n", "b\n", "skills/test/SKILL.md");
+			expect(result).toContain("skills/test/SKILL.md");
+		});
+
+		it("returns unchanged lines with dim markers", () => {
+			const result = formatDiff("same\n", "same\n");
+			expect(result).toContain("same");
+		});
+	});
+
+	describe("diffStats", () => {
+		it("counts additions and removals", () => {
+			const stats = diffStats("line1\nline2\n", "line1\nline3\nline4\n");
+			expect(stats.additions).toBeGreaterThan(0);
+			expect(stats.removals).toBeGreaterThan(0);
+		});
+
+		it("returns zero for identical content", () => {
+			const stats = diffStats("same\n", "same\n");
+			expect(stats.additions).toBe(0);
+			expect(stats.removals).toBe(0);
+		});
+	});
+});

--- a/packages/cli/src/diff.ts
+++ b/packages/cli/src/diff.ts
@@ -1,0 +1,54 @@
+import chalk from "chalk";
+import { diffLines } from "diff";
+
+/**
+ * Generate a colored diff between two strings.
+ * Returns the formatted diff string for terminal output.
+ */
+export function formatDiff(oldContent: string, newContent: string, filePath?: string): string {
+	const changes = diffLines(oldContent, newContent);
+	const lines: string[] = [];
+
+	if (filePath) {
+		lines.push(chalk.bold(`--- ${filePath}`));
+		lines.push(chalk.bold(`+++ ${filePath} (updated)`));
+		lines.push("");
+	}
+
+	for (const change of changes) {
+		const text = change.value.replace(/\n$/, "");
+		const textLines = text.split("\n");
+
+		for (const line of textLines) {
+			if (change.added) {
+				lines.push(chalk.green(`+ ${line}`));
+			} else if (change.removed) {
+				lines.push(chalk.red(`- ${line}`));
+			} else {
+				lines.push(chalk.dim(`  ${line}`));
+			}
+		}
+	}
+
+	return lines.join("\n");
+}
+
+/**
+ * Count the number of additions and removals in a diff.
+ */
+export function diffStats(
+	oldContent: string,
+	newContent: string,
+): { additions: number; removals: number } {
+	const changes = diffLines(oldContent, newContent);
+	let additions = 0;
+	let removals = 0;
+
+	for (const change of changes) {
+		const count = change.value.split("\n").length - 1;
+		if (change.added) additions += count;
+		if (change.removed) removals += count;
+	}
+
+	return { additions, removals };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { Command } from "commander";
 import { checkCommand } from "./commands/check.js";
 import { initCommand } from "./commands/init.js";
+import { refreshCommand } from "./commands/refresh.js";
 import { reportCommand } from "./commands/report.js";
 
 const require = createRequire(import.meta.url);
@@ -27,9 +28,7 @@ program
 			const code = await checkCommand(options);
 			process.exit(code);
 		} catch (error) {
-			console.error(
-				`Error: ${error instanceof Error ? error.message : String(error)}`,
-			);
+			console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
 			process.exit(2);
 		}
 	});
@@ -45,9 +44,27 @@ program
 			const code = await initCommand(dir, options);
 			process.exit(code);
 		} catch (error) {
-			console.error(
-				`Error: ${error instanceof Error ? error.message : String(error)}`,
-			);
+			console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+			process.exit(2);
+		}
+	});
+
+program
+	.command("refresh")
+	.description("Use an LLM to propose targeted updates to stale skill files")
+	.argument("[skills-dir]", "path to skills directory")
+	.option("-r, --registry <path>", "path to skill-versions.json")
+	.option("-p, --product <name>", "refresh a single product")
+	.option("--provider <name>", "LLM provider: anthropic, openai, google")
+	.option("--model <id>", "specific model ID (e.g. claude-sonnet-4-20250514)")
+	.option("-y, --yes", "auto-apply without confirmation")
+	.option("--dry-run", "show proposed changes, write nothing")
+	.action(async (skillsDir, options) => {
+		try {
+			const code = await refreshCommand(skillsDir, options);
+			process.exit(code);
+		} catch (error) {
+			console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
 			process.exit(2);
 		}
 	});
@@ -62,9 +79,7 @@ program
 			const code = await reportCommand(options);
 			process.exit(code);
 		} catch (error) {
-			console.error(
-				`Error: ${error instanceof Error ? error.message : String(error)}`,
-			);
+			console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
 			process.exit(2);
 		}
 	});

--- a/packages/cli/src/llm/prompts.test.ts
+++ b/packages/cli/src/llm/prompts.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemPrompt, buildUserPrompt } from "./prompts.js";
+
+describe("prompts", () => {
+	describe("buildSystemPrompt", () => {
+		it("contains role instruction", () => {
+			const prompt = buildSystemPrompt();
+			expect(prompt).toContain("expert technical writer");
+		});
+
+		it("contains preservation rules", () => {
+			const prompt = buildSystemPrompt();
+			expect(prompt).toContain("Preserve structure and style");
+		});
+
+		it("contains confidence guidelines", () => {
+			const prompt = buildSystemPrompt();
+			expect(prompt).toContain("high");
+			expect(prompt).toContain("medium");
+			expect(prompt).toContain("low");
+		});
+	});
+
+	describe("buildUserPrompt", () => {
+		it("includes skill content", () => {
+			const prompt = buildUserPrompt({
+				skillContent: "---\nname: test\n---\n\n# Test Skill",
+				displayName: "Next.js",
+				fromVersion: "14.0.0",
+				toVersion: "15.0.0",
+				changelog: "## 15.0.0\n\nBreaking changes.",
+			});
+
+			expect(prompt).toContain("# Test Skill");
+			expect(prompt).toContain("Next.js");
+			expect(prompt).toContain("14.0.0");
+			expect(prompt).toContain("15.0.0");
+			expect(prompt).toContain("Breaking changes.");
+		});
+
+		it("handles null changelog", () => {
+			const prompt = buildUserPrompt({
+				skillContent: "# Skill",
+				displayName: "React",
+				fromVersion: "18.0.0",
+				toVersion: "19.0.0",
+				changelog: null,
+			});
+
+			expect(prompt).toContain("No changelog available");
+		});
+
+		it("includes changelog when provided", () => {
+			const prompt = buildUserPrompt({
+				skillContent: "# Skill",
+				displayName: "React",
+				fromVersion: "18.0.0",
+				toVersion: "19.0.0",
+				changelog: "New hooks added.",
+			});
+
+			expect(prompt).toContain("New hooks added.");
+			expect(prompt).not.toContain("No changelog available");
+		});
+	});
+});

--- a/packages/cli/src/llm/prompts.ts
+++ b/packages/cli/src/llm/prompts.ts
@@ -1,0 +1,54 @@
+/**
+ * Build the system prompt for the skill refresh task.
+ */
+export function buildSystemPrompt(): string {
+	return `You are an expert technical writer who updates AI agent skill files to reflect new versions of software products.
+
+## Your Task
+Given a SKILL.md file and information about a version update, produce an updated version of the skill file that accurately reflects the new version.
+
+## Rules
+1. **Preserve structure and style**: Keep the same markdown formatting, heading hierarchy, frontmatter layout, and writing tone as the original.
+2. **Update code examples**: Modify code snippets to use new APIs, function signatures, or patterns introduced in the version update.
+3. **Update API references**: Fix any deprecated methods, renamed functions, or changed parameters.
+4. **Bump the frontmatter version**: Update the \`product-version\` field in the frontmatter to match the new version.
+5. **Don't add speculative information**: Only include changes you can verify from the changelog. If the changelog is unavailable, make minimal updates (version bump + any commonly-known changes).
+6. **Don't remove content**: Don't delete sections unless the changelog explicitly indicates a feature was removed.
+7. **Mark confidence based on changelog quality**:
+   - \`high\`: Changelog was detailed and clear
+   - \`medium\`: Changelog was available but incomplete, or changes were inferred
+   - \`low\`: No changelog was available, only the version bump was applied
+8. **Include the full file content**: Your \`updatedContent\` must contain the complete SKILL.md including the frontmatter delimiters (\`---\`).
+9. **Flag breaking changes**: Set \`breakingChanges\` to true if the changelog mentions breaking changes, removed APIs, or migration requirements.`;
+}
+
+/**
+ * Build the user prompt for a specific skill file refresh.
+ */
+export function buildUserPrompt(params: {
+	skillContent: string;
+	displayName: string;
+	fromVersion: string;
+	toVersion: string;
+	changelog: string | null;
+}): string {
+	const changelogSection = params.changelog
+		? `## Changelog (${params.fromVersion} → ${params.toVersion})\n\n${params.changelog}`
+		: `## Changelog\n\nNo changelog available. Apply the version bump and only make changes you are confident about.`;
+
+	return `## Product
+${params.displayName}
+
+## Version Update
+${params.fromVersion} → ${params.toVersion}
+
+${changelogSection}
+
+## Current SKILL.md Content
+
+\`\`\`markdown
+${params.skillContent}
+\`\`\`
+
+Update this skill file to reflect the version change from ${params.fromVersion} to ${params.toVersion}. Return the full updated content.`;
+}

--- a/packages/cli/src/llm/providers.test.ts
+++ b/packages/cli/src/llm/providers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getProviderIds } from "./providers.js";
+
+describe("providers", () => {
+	describe("getProviderIds", () => {
+		it("returns known provider IDs", () => {
+			const ids = getProviderIds();
+			expect(ids).toContain("anthropic");
+			expect(ids).toContain("openai");
+			expect(ids).toContain("google");
+		});
+
+		it("returns at least 3 providers", () => {
+			const ids = getProviderIds();
+			expect(ids.length).toBeGreaterThanOrEqual(3);
+		});
+	});
+});

--- a/packages/cli/src/llm/providers.ts
+++ b/packages/cli/src/llm/providers.ts
@@ -1,0 +1,142 @@
+import type { LanguageModel } from "ai";
+
+interface ProviderConfig {
+	id: string;
+	envVar: string;
+	pkg: string;
+	factory: string;
+	defaultModel: string;
+}
+
+const PROVIDERS: ProviderConfig[] = [
+	{
+		id: "anthropic",
+		envVar: "ANTHROPIC_API_KEY",
+		pkg: "@ai-sdk/anthropic",
+		factory: "anthropic",
+		defaultModel: "claude-sonnet-4-20250514",
+	},
+	{
+		id: "openai",
+		envVar: "OPENAI_API_KEY",
+		pkg: "@ai-sdk/openai",
+		factory: "openai",
+		defaultModel: "gpt-4o",
+	},
+	{
+		id: "google",
+		envVar: "GOOGLE_GENERATIVE_AI_API_KEY",
+		pkg: "@ai-sdk/google",
+		factory: "google",
+		defaultModel: "gemini-2.5-flash",
+	},
+];
+
+export interface DetectedProvider {
+	id: string;
+	hasApiKey: boolean;
+	hasSdk: boolean;
+}
+
+/**
+ * Detect which LLM providers are available based on env vars and installed SDKs.
+ */
+export async function detectProviders(): Promise<DetectedProvider[]> {
+	const results: DetectedProvider[] = [];
+
+	for (const provider of PROVIDERS) {
+		const hasApiKey = !!process.env[provider.envVar];
+		let hasSdk = false;
+
+		try {
+			await import(provider.pkg);
+			hasSdk = true;
+		} catch {
+			// SDK not installed
+		}
+
+		results.push({ id: provider.id, hasApiKey, hasSdk });
+	}
+
+	return results;
+}
+
+/**
+ * Resolve a LanguageModel instance based on provider and model flags.
+ * Auto-detects if no explicit provider is given.
+ *
+ * @throws Error if no provider is available or SDK is missing.
+ */
+export async function resolveModel(
+	providerFlag?: string,
+	modelFlag?: string,
+): Promise<LanguageModel> {
+	// Find the provider config
+	let config: ProviderConfig | undefined;
+
+	if (providerFlag) {
+		config = PROVIDERS.find((p) => p.id === providerFlag);
+		if (!config) {
+			const valid = PROVIDERS.map((p) => p.id).join(", ");
+			throw new Error(`Unknown provider "${providerFlag}". Valid providers: ${valid}`);
+		}
+	} else {
+		// Auto-detect: find first provider with both API key and SDK
+		for (const provider of PROVIDERS) {
+			if (process.env[provider.envVar]) {
+				try {
+					await import(provider.pkg);
+					config = provider;
+					break;
+				} catch {
+					// SDK not installed, try next
+				}
+			}
+		}
+
+		if (!config) {
+			throw new Error(
+				"No LLM provider detected. Set up a provider:\n\n" +
+					"  1. Install a provider SDK:\n" +
+					"     npm install @ai-sdk/anthropic    # for Claude\n" +
+					"     npm install @ai-sdk/openai       # for GPT\n" +
+					"     npm install @ai-sdk/google       # for Gemini\n\n" +
+					"  2. Set the API key environment variable:\n" +
+					"     export ANTHROPIC_API_KEY=sk-...\n" +
+					"     export OPENAI_API_KEY=sk-...\n" +
+					"     export GOOGLE_GENERATIVE_AI_API_KEY=...\n",
+			);
+		}
+	}
+
+	// Verify API key is set
+	if (!process.env[config.envVar]) {
+		throw new Error(
+			`API key not found. Set ${config.envVar} environment variable for ${config.id}.`,
+		);
+	}
+
+	// Dynamically import the provider SDK
+	let providerModule: Record<string, unknown>;
+	try {
+		providerModule = (await import(config.pkg)) as Record<string, unknown>;
+	} catch {
+		throw new Error(`Provider SDK not installed. Run: npm install ${config.pkg}`);
+	}
+
+	// Get the provider factory function
+	const factory = providerModule[config.factory];
+	if (typeof factory !== "function") {
+		throw new Error(`Could not load provider factory from ${config.pkg}`);
+	}
+
+	const modelId = modelFlag ?? config.defaultModel;
+	return factory(modelId) as LanguageModel;
+}
+
+/**
+ * Get the provider config list (useful for help text).
+ */
+export function getProviderIds(): string[] {
+	return PROVIDERS.map((p) => p.id);
+}

--- a/packages/cli/src/llm/schemas.test.ts
+++ b/packages/cli/src/llm/schemas.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { RefreshResultSchema } from "./schemas.js";
+
+describe("RefreshResultSchema", () => {
+	it("validates a correct response", () => {
+		const input = {
+			updatedContent: "---\nname: test\nproduct-version: '2.0.0'\n---\n\n# Test\n",
+			summary: "Updated version from 1.0.0 to 2.0.0",
+			changes: [{ section: "frontmatter", description: "Bumped product-version" }],
+			confidence: "high",
+			breakingChanges: false,
+		};
+
+		const result = RefreshResultSchema.safeParse(input);
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects missing updatedContent", () => {
+		const input = {
+			summary: "Updated version",
+			changes: [],
+			confidence: "high",
+			breakingChanges: false,
+		};
+
+		const result = RefreshResultSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects invalid confidence level", () => {
+		const input = {
+			updatedContent: "content",
+			summary: "summary",
+			changes: [],
+			confidence: "very-high",
+			breakingChanges: false,
+		};
+
+		const result = RefreshResultSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+
+	it("validates all confidence levels", () => {
+		for (const confidence of ["high", "medium", "low"]) {
+			const input = {
+				updatedContent: "content",
+				summary: "summary",
+				changes: [],
+				confidence,
+				breakingChanges: false,
+			};
+
+			const result = RefreshResultSchema.safeParse(input);
+			expect(result.success).toBe(true);
+		}
+	});
+
+	it("validates changes array structure", () => {
+		const input = {
+			updatedContent: "content",
+			summary: "summary",
+			changes: [
+				{ section: "code-examples", description: "Updated API usage" },
+				{ section: "frontmatter", description: "Bumped version" },
+			],
+			confidence: "medium",
+			breakingChanges: true,
+		};
+
+		const result = RefreshResultSchema.safeParse(input);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.changes).toHaveLength(2);
+			expect(result.data.breakingChanges).toBe(true);
+		}
+	});
+});

--- a/packages/cli/src/llm/schemas.ts
+++ b/packages/cli/src/llm/schemas.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/**
+ * Schema for the LLM's structured response when refreshing a skill file.
+ */
+export const RefreshResultSchema = z.object({
+	updatedContent: z
+		.string()
+		.describe("The full updated SKILL.md content including frontmatter delimiters (---)"),
+	summary: z.string().describe("A concise summary of what was changed and why"),
+	changes: z
+		.array(
+			z.object({
+				section: z.string().describe("The section or area of the skill file that was changed"),
+				description: z.string().describe("What was changed in this section"),
+			}),
+		)
+		.describe("Breakdown of changes by section"),
+	confidence: z
+		.enum(["high", "medium", "low"])
+		.describe(
+			"Confidence level: high if changelog was clear, medium if inferred, low if no changelog available",
+		),
+	breakingChanges: z.boolean().describe("Whether the version update includes breaking changes"),
+});
+
+export type RefreshResultOutput = z.infer<typeof RefreshResultSchema>;

--- a/packages/cli/src/npm.ts
+++ b/packages/cli/src/npm.ts
@@ -2,6 +2,35 @@ import type { NpmDistTags } from "./types.js";
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
 
+export interface NpmPackageMetadata {
+	name: string;
+	repository?: {
+		type: string;
+		url: string;
+		directory?: string;
+	};
+}
+
+/**
+ * Fetch full package metadata from npm (includes repository URL).
+ * Uses the full (non-abbreviated) metadata endpoint.
+ */
+export async function fetchPackageMetadata(packageName: string): Promise<NpmPackageMetadata> {
+	const url = `${NPM_REGISTRY}/${packageName.replace("/", "%2F")}`;
+	const response = await fetch(url, {
+		headers: {
+			Accept: "application/json",
+		},
+	});
+
+	if (!response.ok) {
+		throw new Error(`npm registry returned ${response.status} for "${packageName}"`);
+	}
+
+	const data = (await response.json()) as NpmPackageMetadata;
+	return { name: data.name, repository: data.repository };
+}
+
 /**
  * Fetch the latest version of a package from the npm registry.
  * Uses the abbreviated metadata endpoint for speed.
@@ -48,7 +77,11 @@ export async function fetchLatestVersions(
 				const version = await fetchLatestVersion(name);
 				return { name, version, error: undefined };
 			} catch (error) {
-				return { name, version: undefined, error: error instanceof Error ? error : new Error(String(error)) };
+				return {
+					name,
+					version: undefined,
+					error: error instanceof Error ? error : new Error(String(error)),
+				};
 			}
 		}),
 	);
@@ -58,8 +91,8 @@ export async function fetchLatestVersions(
 			const { name, version, error } = result.value;
 			if (error) {
 				results.set(name, error);
-			} else {
-				results.set(name, version!);
+			} else if (version) {
+				results.set(name, version);
 			}
 		}
 	}

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadRegistry, saveRegistry } from "./registry.js";
 

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -75,7 +75,7 @@ function validateRegistry(data: unknown, filePath: string): Registry {
  */
 export async function saveRegistry(registry: Registry, path?: string): Promise<string> {
 	const filePath = path ?? REGISTRY_FILENAME;
-	const content = JSON.stringify(registry, null, 2) + "\n";
+	const content = `${JSON.stringify(registry, null, 2)}\n`;
 	await writeFile(filePath, content, "utf-8");
 	return filePath;
 }

--- a/packages/cli/src/scanner.test.ts
+++ b/packages/cli/src/scanner.test.ts
@@ -13,7 +13,7 @@ describe("groupSkills", () => {
 		const groups = groupSkills(skills);
 		expect(groups.size).toBe(1);
 		expect(groups.has("ai-sdk")).toBe(true);
-		expect(groups.get("ai-sdk")!.length).toBe(3);
+		expect(groups.get("ai-sdk")?.length).toBe(3);
 	});
 
 	it("separates skills with same prefix but different versions", () => {
@@ -30,9 +30,7 @@ describe("groupSkills", () => {
 	});
 
 	it("uses full name for standalone skills", () => {
-		const skills: ScannedSkill[] = [
-			{ name: "mermaid", path: "/a", productVersion: "10.0.0" },
-		];
+		const skills: ScannedSkill[] = [{ name: "mermaid", path: "/a", productVersion: "10.0.0" }];
 
 		const groups = groupSkills(skills);
 		expect(groups.size).toBe(1);
@@ -65,8 +63,8 @@ describe("groupSkills", () => {
 
 		const groups = groupSkills(skills);
 		expect(groups.size).toBe(3);
-		expect(groups.get("ai-sdk")!.length).toBe(2);
-		expect(groups.get("payload")!.length).toBe(2);
-		expect(groups.get("mermaid")!.length).toBe(1);
+		expect(groups.get("ai-sdk")?.length).toBe(2);
+		expect(groups.get("payload")?.length).toBe(2);
+		expect(groups.get("mermaid")?.length).toBe(1);
 	});
 });

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, stat } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import matter from "gray-matter";
 import type { ScannedSkill } from "./types.js";
@@ -87,9 +87,7 @@ export async function scanSkills(skillsDir: string): Promise<ScannedSkill[]> {
  *
  * Returns Map<productKey, ScannedSkill[]>
  */
-export function groupSkills(
-	skills: ScannedSkill[],
-): Map<string, ScannedSkill[]> {
+export function groupSkills(skills: ScannedSkill[]): Map<string, ScannedSkill[]> {
 	// Build version lookup: name -> version
 	const versionMap = new Map<string, string>();
 	for (const skill of skills) {

--- a/packages/cli/src/severity.test.ts
+++ b/packages/cli/src/severity.test.ts
@@ -32,8 +32,8 @@ describe("normalizeVersion", () => {
 	it("coerces non-standard version strings", () => {
 		const result = normalizeVersion("v3-beta");
 		expect(result).not.toBeNull();
-		expect(result!.coerced).toBe(true);
-		expect(result!.version).toBe("3.0.0");
+		expect(result?.coerced).toBe(true);
+		expect(result?.version).toBe("3.0.0");
 	});
 
 	it("returns null for unparseable strings", () => {
@@ -44,7 +44,7 @@ describe("normalizeVersion", () => {
 		// semver.valid handles "v1.2.3" -> null, so it will be coerced
 		const result = normalizeVersion("v1.2.3");
 		expect(result).not.toBeNull();
-		expect(result!.version).toBe("1.2.3");
+		expect(result?.version).toBe("1.2.3");
 	});
 
 	it("prefers strict parsing over coercion", () => {

--- a/packages/cli/src/skill-io.test.ts
+++ b/packages/cli/src/skill-io.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readSkillFile, writeSkillFile } from "./skill-io.js";
+
+describe("skill-io", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skill-io-test-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true });
+	});
+
+	describe("readSkillFile", () => {
+		it("parses frontmatter and content", async () => {
+			const content = `---
+name: test-skill
+product-version: "1.0.0"
+---
+
+# Test Skill
+
+Some content here.
+`;
+			const filePath = join(tempDir, "SKILL.md");
+			await writeFile(filePath, content, "utf-8");
+
+			const result = await readSkillFile(filePath);
+
+			expect(result.path).toBe(filePath);
+			expect(result.frontmatter.name).toBe("test-skill");
+			expect(result.frontmatter["product-version"]).toBe("1.0.0");
+			expect(result.content).toContain("# Test Skill");
+			expect(result.raw).toBe(content);
+		});
+
+		it("handles files without frontmatter", async () => {
+			const content = "# No Frontmatter\n\nJust content.\n";
+			const filePath = join(tempDir, "SKILL.md");
+			await writeFile(filePath, content, "utf-8");
+
+			const result = await readSkillFile(filePath);
+
+			expect(result.frontmatter).toEqual({});
+			expect(result.content).toContain("# No Frontmatter");
+		});
+
+		it("throws for missing file", async () => {
+			await expect(readSkillFile(join(tempDir, "missing.md"))).rejects.toThrow();
+		});
+	});
+
+	describe("writeSkillFile", () => {
+		it("writes content to file", async () => {
+			const filePath = join(tempDir, "output.md");
+			const content = "---\nname: updated\n---\n\n# Updated\n";
+
+			await writeSkillFile(filePath, content);
+			const result = await readSkillFile(filePath);
+
+			expect(result.frontmatter.name).toBe("updated");
+		});
+	});
+});

--- a/packages/cli/src/skill-io.ts
+++ b/packages/cli/src/skill-io.ts
@@ -1,0 +1,31 @@
+import { readFile, writeFile } from "node:fs/promises";
+import matter from "gray-matter";
+
+export interface SkillFile {
+	path: string;
+	frontmatter: Record<string, unknown>;
+	content: string;
+	raw: string;
+}
+
+/**
+ * Read a SKILL.md file and parse its frontmatter.
+ */
+export async function readSkillFile(filePath: string): Promise<SkillFile> {
+	const raw = await readFile(filePath, "utf-8");
+	const { data, content } = matter(raw);
+
+	return {
+		path: filePath,
+		frontmatter: data,
+		content,
+		raw,
+	};
+}
+
+/**
+ * Write updated content to a SKILL.md file.
+ */
+export async function writeSkillFile(filePath: string, content: string): Promise<void> {
+	await writeFile(filePath, content, "utf-8");
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -34,6 +34,20 @@ export interface NpmDistTags {
 }
 
 /**
+ * Result of refreshing a single skill file via LLM
+ */
+export interface RefreshResult {
+	product: string;
+	skillPath: string;
+	updatedContent: string;
+	summary: string;
+	changes: Array<{ section: string; description: string }>;
+	confidence: "high" | "medium" | "low";
+	breakingChanges: boolean;
+	applied: boolean;
+}
+
+/**
  * Exit codes for CLI
  */
 export const ExitCode = {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -10,7 +10,9 @@
 		},
 		"./schema.json": "./dist/schema.json"
 	},
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build": "tsup && tsx src/generate.ts",
 		"typecheck": "tsc --noEmit"

--- a/packages/schema/src/generate.ts
+++ b/packages/schema/src/generate.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { createGenerator } from "ts-json-schema-generator";
 

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -5,6 +5,7 @@ export interface Registry {
 	$schema?: string;
 	version: number;
 	lastCheck?: string;
+	skillsDir?: string;
 	products: Record<string, RegistryProduct>;
 }
 

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -16,4 +16,5 @@ export interface RegistryProduct {
 	verifiedAt: string;
 	changelog?: string;
 	skills: string[];
+	agents?: string[];
 }

--- a/packages/web/app/docs/page.tsx
+++ b/packages/web/app/docs/page.tsx
@@ -189,13 +189,158 @@ Your skill content here...`}
 
 					<section>
 						<h2 id="ci">CI Integration</h2>
+
+						<h3>GitHub Action</h3>
 						<p>
-							Add a staleness check to your CI pipeline using the <code>--ci</code> flag:
+							Use the reusable GitHub Action to check freshness and optionally open issues when
+							skills drift:
 						</p>
 						<pre>
 							<code>
-								{`# GitHub Actions example
-- name: Check skill freshness
+								{`- uses: voodootikigod/skill-versions@v1
+  with:
+    registry: skill-versions.json  # default
+    open-issues: "true"            # create/update issue on staleness
+    fail-on-stale: "false"         # set "true" to block PRs`}
+							</code>
+						</pre>
+						<p>
+							The action requires <code>issues: write</code> permission when{" "}
+							<code>open-issues</code> is enabled. It deduplicates issues using the{" "}
+							<code>issue-label</code> input (default: <code>skill-staleness</code>).
+						</p>
+
+						<h4>Inputs</h4>
+						<table>
+							<thead>
+								<tr>
+									<th>Input</th>
+									<th>Default</th>
+									<th>Description</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code>registry</code>
+									</td>
+									<td>
+										<code>skill-versions.json</code>
+									</td>
+									<td>Path to registry file</td>
+								</tr>
+								<tr>
+									<td>
+										<code>node-version</code>
+									</td>
+									<td>
+										<code>20</code>
+									</td>
+									<td>Node.js version</td>
+								</tr>
+								<tr>
+									<td>
+										<code>open-issues</code>
+									</td>
+									<td>
+										<code>true</code>
+									</td>
+									<td>Open/update GitHub issue on staleness</td>
+								</tr>
+								<tr>
+									<td>
+										<code>issue-label</code>
+									</td>
+									<td>
+										<code>skill-staleness</code>
+									</td>
+									<td>Label for issue deduplication</td>
+								</tr>
+								<tr>
+									<td>
+										<code>fail-on-stale</code>
+									</td>
+									<td>
+										<code>false</code>
+									</td>
+									<td>Exit non-zero when stale</td>
+								</tr>
+								<tr>
+									<td>
+										<code>token</code>
+									</td>
+									{/* biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions expression syntax */}
+									<td>
+										<code>{"${{ github.token }}"}</code>
+									</td>
+									<td>
+										GitHub token (needs <code>issues: write</code>)
+									</td>
+								</tr>
+							</tbody>
+						</table>
+
+						<h4>Outputs</h4>
+						<table>
+							<thead>
+								<tr>
+									<th>Output</th>
+									<th>Description</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code>stale-count</code>
+									</td>
+									<td>Number of stale products (0 if current)</td>
+								</tr>
+								<tr>
+									<td>
+										<code>issue-number</code>
+									</td>
+									<td>Issue number created/updated (empty if none)</td>
+								</tr>
+								<tr>
+									<td>
+										<code>report</code>
+									</td>
+									<td>Full markdown report</td>
+								</tr>
+							</tbody>
+						</table>
+
+						<h4>Weekly cron example</h4>
+						<pre>
+							<code>
+								{`name: Skill Staleness Check
+on:
+  schedule:
+    - cron: "0 9 * * 1"   # Monday 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  staleness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: voodootikigod/skill-versions@v1
+        with:
+          fail-on-stale: "false"`}
+							</code>
+						</pre>
+
+						<h3>Inline check</h3>
+						<p>
+							For simpler setups, use the CLI directly with the <code>--ci</code> flag:
+						</p>
+						<pre>
+							<code>
+								{`- name: Check skill freshness
   run: npx skill-versions check --ci`}
 							</code>
 						</pre>

--- a/packages/web/app/docs/page.tsx
+++ b/packages/web/app/docs/page.tsx
@@ -159,7 +159,8 @@ export GOOGLE_GENERATIVE_AI_API_KEY=...`}
       "package": "ai",
       "verifiedVersion": "4.2.0",
       "verifiedAt": "2026-01-15T00:00:00Z",
-      "skills": ["ai-sdk-core", "ai-sdk-tools"]
+      "skills": ["ai-sdk-core", "ai-sdk-tools"],
+      "agents": ["ai-sdk-engineer"]
     }
   }
 }`}

--- a/packages/web/app/docs/page.tsx
+++ b/packages/web/app/docs/page.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
+import { Header } from "@/components/header";
 import styles from "./docs.module.css";
 
 export const metadata: Metadata = {
 	title: "Docs",
 	description:
-		"CLI reference for skill-versions: init, check, and report commands. Registry format, SKILL.md frontmatter spec, and CI integration guide.",
+		"CLI reference for skill-versions: init, check, report, and refresh commands. Registry format, SKILL.md frontmatter spec, AI-assisted refresh, and CI integration guide.",
 	alternates: {
 		canonical: "https://skill-versions.com/docs",
 	},
@@ -24,9 +24,9 @@ export default function DocsPage() {
 					<section>
 						<h2 id="overview">Overview</h2>
 						<p>
-							<code>skill-versions</code> is a freshness checker for Agent Skills. It
-							compares the <code>product-version</code> in your SKILL.md frontmatter
-							against the npm registry and flags stale skills.
+							<code>skill-versions</code> is a freshness checker for Agent Skills. It compares the{" "}
+							<code>product-version</code> in your SKILL.md frontmatter against the npm registry and
+							flags stale skills.
 						</p>
 					</section>
 
@@ -95,14 +95,58 @@ npx skill-versions report
 npx skill-versions report --format json`}
 							</code>
 						</pre>
+
+						<h3>
+							<code>refresh [skills-dir]</code>
+						</h3>
+						<p>
+							Use an LLM to propose targeted updates to stale skill files. Fetches changelogs,
+							generates diffs, and optionally applies changes.
+						</p>
+						<pre>
+							<code>
+								{`# Interactive mode — review each change
+npx skill-versions refresh ./skills
+
+# Auto-apply all changes
+npx skill-versions refresh -y
+
+# Preview only (no writes)
+npx skill-versions refresh --dry-run
+
+# Use a specific provider/model
+npx skill-versions refresh --provider anthropic --model claude-sonnet-4-20250514
+
+# Refresh a single product
+npx skill-versions refresh -p ai-sdk`}
+							</code>
+						</pre>
+						<p>
+							<strong>Provider setup:</strong> Install one of the provider SDKs and set the
+							corresponding API key:
+						</p>
+						<pre>
+							<code>
+								{`# Anthropic (Claude)
+npm install @ai-sdk/anthropic
+export ANTHROPIC_API_KEY=sk-...
+
+# OpenAI
+npm install @ai-sdk/openai
+export OPENAI_API_KEY=sk-...
+
+# Google (Gemini)
+npm install @ai-sdk/google
+export GOOGLE_GENERATIVE_AI_API_KEY=...`}
+							</code>
+						</pre>
 					</section>
 
 					<section>
 						<h2 id="registry">Registry Format</h2>
 						<p>
 							The <code>skill-versions.json</code> file follows a{" "}
-							<Link href="/schema.json">JSON Schema</Link> that editors can validate
-							against:
+							<Link href="/schema.json">JSON Schema</Link> that editors can validate against:
 						</p>
 						<pre>
 							<code>
@@ -126,8 +170,8 @@ npx skill-versions report --format json`}
 					<section>
 						<h2 id="frontmatter">SKILL.md Frontmatter</h2>
 						<p>
-							Each SKILL.md file should include a <code>product-version</code> field
-							in its YAML frontmatter:
+							Each SKILL.md file should include a <code>product-version</code> field in its YAML
+							frontmatter:
 						</p>
 						<pre>
 							<code>
@@ -146,8 +190,7 @@ Your skill content here...`}
 					<section>
 						<h2 id="ci">CI Integration</h2>
 						<p>
-							Add a staleness check to your CI pipeline using the{" "}
-							<code>--ci</code> flag:
+							Add a staleness check to your CI pipeline using the <code>--ci</code> flag:
 						</p>
 						<pre>
 							<code>
@@ -156,9 +199,7 @@ Your skill content here...`}
   run: npx skill-versions check --ci`}
 							</code>
 						</pre>
-						<p>
-							This exits with code 1 if any skills are stale, failing the pipeline.
-						</p>
+						<p>This exits with code 1 if any skills are stale, failing the pipeline.</p>
 					</section>
 				</article>
 			</main>

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -57,11 +57,7 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function RootLayout({
-	children,
-}: {
-	children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
 			<body style={{ fontFamily: "var(--font-sans)" }}>{children}</body>

--- a/packages/web/app/opengraph-image.tsx
+++ b/packages/web/app/opengraph-image.tsx
@@ -7,60 +7,58 @@ export const contentType = "image/png";
 
 export default function OGImage() {
 	return new ImageResponse(
-		(
+		<div
+			style={{
+				background: "#0a0a0a",
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				fontFamily: "monospace",
+			}}
+		>
 			<div
 				style={{
-					background: "#0a0a0a",
-					width: "100%",
-					height: "100%",
+					fontSize: 72,
+					fontWeight: 700,
+					color: "#ffffff",
+					letterSpacing: "-0.03em",
 					display: "flex",
-					flexDirection: "column",
-					alignItems: "center",
-					justifyContent: "center",
-					fontFamily: "monospace",
+					textShadow:
+						"0 0 7px rgba(80,227,194,0.7), 0 0 20px rgba(80,227,194,0.4), 0 0 40px rgba(80,227,194,0.2), 0 0 80px rgba(80,227,194,0.1)",
 				}}
 			>
-				<div
-					style={{
-						fontSize: 72,
-						fontWeight: 700,
-						color: "#ffffff",
-						letterSpacing: "-0.03em",
-						display: "flex",
-						textShadow:
-							"0 0 7px rgba(80,227,194,0.7), 0 0 20px rgba(80,227,194,0.4), 0 0 40px rgba(80,227,194,0.2), 0 0 80px rgba(80,227,194,0.1)",
-					}}
-				>
-					skill-versions
-				</div>
-				<div
-					style={{
-						fontSize: 28,
-						color: "#888888",
-						marginTop: 24,
-						display: "flex",
-					}}
-				>
-					Freshness checker for Agent Skills
-				</div>
-				<div
-					style={{
-						display: "flex",
-						alignItems: "center",
-						gap: 12,
-						marginTop: 40,
-						background: "#0d0d0d",
-						border: "1px solid #222222",
-						borderRadius: 8,
-						padding: "12px 20px",
-					}}
-				>
-					<div style={{ fontSize: 20, color: "#50e3c2", display: "flex" }}>
-						npx skill-versions check
-					</div>
+				skill-versions
+			</div>
+			<div
+				style={{
+					fontSize: 28,
+					color: "#888888",
+					marginTop: 24,
+					display: "flex",
+				}}
+			>
+				Freshness checker for Agent Skills
+			</div>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: 12,
+					marginTop: 40,
+					background: "#0d0d0d",
+					border: "1px solid #222222",
+					borderRadius: 8,
+					padding: "12px 20px",
+				}}
+			>
+				<div style={{ fontSize: 20, color: "#50e3c2", display: "flex" }}>
+					npx skill-versions check
 				</div>
 			</div>
-		),
+		</div>,
 		{ ...size },
 	);
 }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,7 +1,7 @@
+import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
 import { Hero } from "@/components/hero";
 import { Quickstart } from "@/components/quickstart";
-import { Footer } from "@/components/footer";
 
 const jsonLd = {
 	"@context": "https://schema.org",
@@ -31,6 +31,7 @@ export default function Home() {
 		<>
 			<script
 				type="application/ld+json"
+				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data requires innerHTML
 				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
 			/>
 			<Header />

--- a/packages/web/components/copy-button.tsx
+++ b/packages/web/components/copy-button.tsx
@@ -20,7 +20,7 @@ export function CopyButton({ text }: { text: string }) {
 			type="button"
 		>
 			{copied ? (
-				<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
 					<path
 						d="M13.5 4.5L6 12L2.5 8.5"
 						stroke="var(--success)"
@@ -30,7 +30,7 @@ export function CopyButton({ text }: { text: string }) {
 					/>
 				</svg>
 			) : (
-				<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
 					<rect
 						x="5"
 						y="5"

--- a/packages/web/components/footer.tsx
+++ b/packages/web/components/footer.tsx
@@ -20,7 +20,11 @@ export function Footer() {
 					<Link href="/schema.json">Schema</Link>
 				</div>
 				<div className={styles.right}>
-					<a href="https://npmjs.com/package/skill-versions" target="_blank" rel="noopener noreferrer">
+					<a
+						href="https://npmjs.com/package/skill-versions"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
 						npm
 					</a>
 				</div>

--- a/packages/web/components/hero.module.css
+++ b/packages/web/components/hero.module.css
@@ -37,7 +37,8 @@
 }
 
 @keyframes breathe {
-	0%, 100% {
+	0%,
+	100% {
 		text-shadow:
 			0 0 7px rgba(80, 227, 194, 0.7),
 			0 0 20px rgba(80, 227, 194, 0.4),

--- a/packages/web/components/hero.tsx
+++ b/packages/web/components/hero.tsx
@@ -1,5 +1,5 @@
-import styles from "./hero.module.css";
 import { CopyButton } from "./copy-button";
+import styles from "./hero.module.css";
 
 export function Hero() {
 	return (

--- a/packages/web/components/quickstart.tsx
+++ b/packages/web/components/quickstart.tsx
@@ -1,5 +1,5 @@
-import styles from "./quickstart.module.css";
 import { CopyButton } from "./copy-button";
+import styles from "./quickstart.module.css";
 
 const steps = [
 	{
@@ -20,6 +20,12 @@ const steps = [
 		description: "Get a full markdown report for your team or CI pipeline.",
 		command: "npx skill-versions report",
 	},
+	{
+		number: "4",
+		title: "AI-assisted refresh",
+		description: "Use an LLM to propose targeted updates to stale skill files.",
+		command: "npx skill-versions refresh",
+	},
 ];
 
 export function Quickstart() {
@@ -27,7 +33,7 @@ export function Quickstart() {
 		<section className={styles.section}>
 			<div className={styles.container}>
 				<h2 className={styles.heading}>Quickstart</h2>
-				<p className={styles.subtitle}>Three commands to keep your agent skills fresh.</p>
+				<p className={styles.subtitle}>Four commands to keep your agent skills fresh.</p>
 				<div className={styles.steps}>
 					{steps.map((step) => (
 						<div key={step.number} className={styles.step}>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
 		"prebuild": "mkdir -p public && cp ../schema/dist/schema.json public/schema.json",
 		"build": "next build",
 		"dev": "next dev",
-		"lint": "next lint",
+		"lint": "biome check app components",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,41 +1,33 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": [
-        "./*"
-      ]
-    }
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "react-jsx",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
+		"paths": {
+			"@/*": ["./*"]
+		}
+	},
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts",
+		".next/dev/types/**/*.ts"
+	],
+	"exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
 	"files": [],
-	"references": [
-		{ "path": "packages/cli" },
-		{ "path": "packages/schema" }
-	]
+	"references": [{ "path": "packages/cli" }, { "path": "packages/schema" }]
 }


### PR DESCRIPTION
## Summary

- **AI-assisted refresh command** (`skill-versions refresh`): Uses an LLM to propose targeted updates to stale skill files — fetches changelogs, generates diffs, and optionally applies changes. Supports Anthropic, OpenAI, and Google providers.
- **GitHub Action for staleness checks** (`action.yml`): Composite action that runs `skill-versions check`, generates markdown reports, and creates/updates GitHub issues with deduplication. Includes weekly cron workflow and CI workflow for PR/push validation.
- **Biome 2.4.4 migration**: Updated config and fixed all lint issues across the monorepo.
- **Docs updates**: Expanded README and web docs with refresh command reference, GitHub Action usage/inputs/outputs tables, and workflow examples.

## New files

| File | Purpose |
|------|---------|
| `packages/cli/src/commands/refresh.ts` | AI-assisted refresh command |
| `packages/cli/src/changelog.ts` | Changelog fetching for refresh |
| `packages/cli/src/diff.ts` | Diff utilities for refresh output |
| `packages/cli/src/skill-io.ts` | Skill file read/write helpers |
| `packages/cli/src/llm/prompts.ts` | LLM prompt construction |
| `packages/cli/src/llm/providers.ts` | LLM provider resolution |
| `packages/cli/src/llm/schemas.ts` | Zod schema for LLM output |
| `action.yml` | Composite GitHub Action |
| `.github/scripts/upsert-issue.sh` | Issue create/update dedup |
| `.github/workflows/skill-staleness.yml` | Weekly cron workflow |
| `.github/workflows/ci.yml` | PR/push CI workflow |

## Test plan

- [ ] `npx turbo build` passes
- [ ] `npx turbo lint` passes (0 errors)
- [ ] `npx turbo typecheck` passes
- [ ] `npx turbo test` passes
- [ ] Trigger `skill-staleness.yml` via `workflow_dispatch` — verify issue created
- [ ] Re-trigger — verify existing issue updated (not duplicated)
- [ ] `npx skill-versions refresh --dry-run` shows proposed changes
- [ ] `npx skill-versions check --ci` exits 1 on stale, 0 on current