### PR TITLE
feat: npm publish workflow and package metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+
+      - name: Set version from release tag
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          cd packages/cli
+          npm version "$VERSION" --no-git-tag-version
+
+      - name: Publish
+        run: cd packages/cli && npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Vercel Professional Services
+Copyright (c) 2026 Chris Williams <voodootikigod@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,8 +27,13 @@
 	],
 	"author": "Vercel Professional Services <dept-solution-engineering@vercel.com>",
 	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/voodootikigod/skill-versions.git",
+		"directory": "packages/cli"
+	},
+	"homepage": "https://skill-versions.com",
 	"dependencies": {
-		"@skill-versions/schema": "*",
 		"ai": "^6.0.0",
 		"chalk": "^5.4.1",
 		"commander": "^14.0.0",
@@ -43,6 +48,7 @@
 		"@ai-sdk/openai": "^3.0.0"
 	},
 	"devDependencies": {
+		"@skill-versions/schema": "*",
 		"@types/node": "^22.0.0",
 		"@types/semver": "^7.7.0",
 		"tsup": "^8.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
 		"npm-outdated",
 		"cli"
 	],
-	"author": "Vercel Professional Services <dept-solution-engineering@vercel.com>",
+	"author": "Chris Williams <voodootikigod@gmail.com>",
 	"license": "MIT",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- Move `@skill-versions/schema` from `dependencies` to `devDependencies` (types-only, erased at build time — not needed at runtime)
- Add `repository` and `homepage` fields to CLI package.json for npm metadata
- Add `.github/workflows/publish.yml` — automated npm publishing triggered by GitHub releases

## Usage

1. Add `NPM_TOKEN` secret to repo settings
2. Create a GitHub release with tag `v0.1.0`
3. Workflow builds, tests, sets version from tag, and publishes with provenance

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `grep "@skill-versions/schema" packages/cli/dist/index.js` returns nothing (not in bundle)
- [ ] After merge: create release `v0.1.0`, verify package appears on npm