### PR TITLE
fix: security review findings + command detail pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -37,12 +37,14 @@ jobs:
         run: npm run test
 
       - name: Set version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
           else
-            TAG="${{ github.event.release.tag_name }}"
-            VERSION="${TAG#v}"
+            VERSION="${TAG_NAME#v}"
           fi
           cd packages/cli
           npm version "$VERSION" --no-git-tag-version --allow-same-version

--- a/.github/workflows/skill-staleness.yml
+++ b/.github/workflows/skill-staleness.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check skill staleness
         uses: ./

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .DS_Store
 node_modules/
+
+# Environment variables
+.env
+.env.*
+.env.local
 dist/
 skills-check.json
 *.tgz

--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ runs:
   steps:
     # ── Setup ──────────────────────────────────────────────────────────
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -104,23 +104,31 @@ runs:
     - name: Resolve commands
       id: resolve
       shell: bash
+      env:
+        INPUT_COMMANDS: ${{ inputs.commands }}
+        INPUT_CHECK: ${{ inputs.check }}
+        INPUT_AUDIT: ${{ inputs.audit }}
+        INPUT_LINT: ${{ inputs.lint }}
+        INPUT_BUDGET: ${{ inputs.budget }}
+        INPUT_POLICY: ${{ inputs.policy }}
+        INPUT_VERIFY: ${{ inputs.verify }}
+        INPUT_TEST: ${{ inputs.test }}
       run: |
-        COMMANDS="${{ inputs.commands }}"
-        if [ -n "$COMMANDS" ]; then
+        if [ -n "$INPUT_COMMANDS" ]; then
           # Parse comma-separated list into individual flags
-          for CMD in $(echo "$COMMANDS" | tr ',' ' '); do
+          for CMD in $(echo "$INPUT_COMMANDS" | tr ',' ' '); do
             CMD=$(echo "$CMD" | xargs)  # trim whitespace
             echo "run_${CMD}=true" >> "$GITHUB_OUTPUT"
           done
         else
           # Use individual toggle inputs
-          [ "${{ inputs.check }}" = "true" ]  && echo "run_check=true"  >> "$GITHUB_OUTPUT"
-          [ "${{ inputs.audit }}" = "true" ]  && echo "run_audit=true"  >> "$GITHUB_OUTPUT"
-          [ "${{ inputs.lint }}" = "true" ]   && echo "run_lint=true"   >> "$GITHUB_OUTPUT"
-          [ "${{ inputs.budget }}" = "true" ] && echo "run_budget=true" >> "$GITHUB_OUTPUT"
-          [ "${{ inputs.policy }}" = "true" ] && echo "run_policy=true" >> "$GITHUB_OUTPUT"
-          [ "${{ inputs.verify }}" = "true" ] && echo "run_verify=true" >> "$GITHUB_OUTPUT"
-          [ "${{ inputs.test }}" = "true" ]   && echo "run_test=true"   >> "$GITHUB_OUTPUT"
+          [ "$INPUT_CHECK" = "true" ]  && echo "run_check=true"  >> "$GITHUB_OUTPUT"
+          [ "$INPUT_AUDIT" = "true" ]  && echo "run_audit=true"  >> "$GITHUB_OUTPUT"
+          [ "$INPUT_LINT" = "true" ]   && echo "run_lint=true"   >> "$GITHUB_OUTPUT"
+          [ "$INPUT_BUDGET" = "true" ] && echo "run_budget=true" >> "$GITHUB_OUTPUT"
+          [ "$INPUT_POLICY" = "true" ] && echo "run_policy=true" >> "$GITHUB_OUTPUT"
+          [ "$INPUT_VERIFY" = "true" ] && echo "run_verify=true" >> "$GITHUB_OUTPUT"
+          [ "$INPUT_TEST" = "true" ]   && echo "run_test=true"   >> "$GITHUB_OUTPUT"
         fi
 
     # ── Check ──────────────────────────────────────────────────────────
@@ -128,9 +136,11 @@ runs:
       id: check
       if: steps.resolve.outputs.run_check == 'true'
       shell: bash
+      env:
+        INPUT_REGISTRY: ${{ inputs.registry }}
       run: |
         set +e
-        OUTPUT=$(npx --yes skills-check check --registry "${{ inputs.registry }}" --json --ci 2>&1)
+        OUTPUT=$(npx --yes skills-check check --registry "$INPUT_REGISTRY" --json --ci 2>&1)
         EXIT_CODE=$?
         set -e
 
@@ -154,8 +164,10 @@ runs:
       id: report
       if: steps.resolve.outputs.run_check == 'true' && steps.check.outputs.exit_code == '1'
       shell: bash
+      env:
+        INPUT_REGISTRY: ${{ inputs.registry }}
       run: |
-        REPORT=$(npx --yes skills-check report --registry "${{ inputs.registry }}" --format markdown 2>/dev/null)
+        REPORT=$(npx --yes skills-check report --registry "$INPUT_REGISTRY" --format markdown 2>/dev/null)
 
         # Write multiline output
         {
@@ -177,8 +189,10 @@ runs:
     - name: Fail on stale
       if: steps.resolve.outputs.run_check == 'true' && steps.check.outputs.exit_code == '1' && inputs.fail-on-stale == 'true'
       shell: bash
+      env:
+        STALE_COUNT: ${{ steps.check.outputs.stale_count }}
       run: |
-        echo "::error::${{ steps.check.outputs.stale_count }} stale product(s) detected"
+        echo "::error::${STALE_COUNT} stale product(s) detected"
         exit 1
 
     # ── Audit ──────────────────────────────────────────────────────────
@@ -186,11 +200,14 @@ runs:
       id: audit
       if: steps.resolve.outputs.run_audit == 'true'
       shell: bash
+      env:
+        INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
+        INPUT_AUDIT_FAIL_ON: ${{ inputs.audit-fail-on }}
       run: |
         set +e
-        npx --yes skills-check audit "${{ inputs.skills-dir }}" \
+        npx --yes skills-check audit "$INPUT_SKILLS_DIR" \
           --format json \
-          --fail-on "${{ inputs.audit-fail-on }}" \
+          --fail-on "$INPUT_AUDIT_FAIL_ON" \
           --quiet
         EXIT_CODE=$?
         set -e
@@ -202,7 +219,7 @@ runs:
           exit 2
         fi
         if [ "$EXIT_CODE" -eq 1 ]; then
-          echo "::error::skills-check audit: findings at or above '${{ inputs.audit-fail-on }}' severity"
+          echo "::error::skills-check audit: findings at or above '${INPUT_AUDIT_FAIL_ON}' severity"
           exit 1
         fi
 
@@ -211,12 +228,15 @@ runs:
       id: lint
       if: steps.resolve.outputs.run_lint == 'true'
       shell: bash
+      env:
+        INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
+        INPUT_LINT_FAIL_ON: ${{ inputs.lint-fail-on }}
       run: |
         set +e
-        npx --yes skills-check lint "${{ inputs.skills-dir }}" \
+        npx --yes skills-check lint "$INPUT_SKILLS_DIR" \
           --ci \
           --format json \
-          --fail-on "${{ inputs.lint-fail-on }}"
+          --fail-on "$INPUT_LINT_FAIL_ON"
         EXIT_CODE=$?
         set -e
 
@@ -227,7 +247,7 @@ runs:
           exit 2
         fi
         if [ "$EXIT_CODE" -eq 1 ]; then
-          echo "::error::skills-check lint: issues at or above '${{ inputs.lint-fail-on }}' level"
+          echo "::error::skills-check lint: issues at or above '${INPUT_LINT_FAIL_ON}' level"
           exit 1
         fi
 
@@ -236,10 +256,13 @@ runs:
       id: budget
       if: steps.resolve.outputs.run_budget == 'true'
       shell: bash
+      env:
+        INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
+        INPUT_BUDGET_MAX_TOKENS: ${{ inputs.budget-max-tokens }}
       run: |
-        BUDGET_ARGS=("${{ inputs.skills-dir }}" --format json)
-        if [ -n "${{ inputs.budget-max-tokens }}" ]; then
-          BUDGET_ARGS+=(--max-tokens "${{ inputs.budget-max-tokens }}")
+        BUDGET_ARGS=("$INPUT_SKILLS_DIR" --format json)
+        if [ -n "$INPUT_BUDGET_MAX_TOKENS" ]; then
+          BUDGET_ARGS+=(--max-tokens "$INPUT_BUDGET_MAX_TOKENS")
         fi
 
         set +e
@@ -254,7 +277,7 @@ runs:
           exit 2
         fi
         if [ "$EXIT_CODE" -eq 1 ]; then
-          echo "::error::skills-check budget: token count exceeds threshold (${{ inputs.budget-max-tokens }})"
+          echo "::error::skills-check budget: token count exceeds threshold (${INPUT_BUDGET_MAX_TOKENS})"
           exit 1
         fi
 
@@ -263,12 +286,16 @@ runs:
       id: policy
       if: steps.resolve.outputs.run_policy == 'true'
       shell: bash
+      env:
+        INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
+        INPUT_POLICY_FILE: ${{ inputs.policy-file }}
+        INPUT_POLICY_FAIL_ON: ${{ inputs.policy-fail-on }}
       run: |
-        POLICY_ARGS=("${{ inputs.skills-dir }}" --ci --format json)
-        if [ -n "${{ inputs.policy-file }}" ]; then
-          POLICY_ARGS+=(--policy "${{ inputs.policy-file }}")
+        POLICY_ARGS=("$INPUT_SKILLS_DIR" --ci --format json)
+        if [ -n "$INPUT_POLICY_FILE" ]; then
+          POLICY_ARGS+=(--policy "$INPUT_POLICY_FILE")
         fi
-        POLICY_ARGS+=(--fail-on "${{ inputs.policy-fail-on }}")
+        POLICY_ARGS+=(--fail-on "$INPUT_POLICY_FAIL_ON")
 
         set +e
         npx --yes skills-check policy check "${POLICY_ARGS[@]}"
@@ -282,7 +309,7 @@ runs:
           exit 2
         fi
         if [ "$EXIT_CODE" -eq 1 ]; then
-          echo "::error::skills-check policy: violations at or above '${{ inputs.policy-fail-on }}' severity"
+          echo "::error::skills-check policy: violations at or above '${INPUT_POLICY_FAIL_ON}' severity"
           exit 1
         fi
 
@@ -313,9 +340,11 @@ runs:
       id: test
       if: steps.resolve.outputs.run_test == 'true'
       shell: bash
+      env:
+        INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
       run: |
         set +e
-        npx --yes skills-check test "${{ inputs.skills-dir }}" --ci --format json
+        npx --yes skills-check test "$INPUT_SKILLS_DIR" --ci --format json
         EXIT_CODE=$?
         set -e
 
@@ -335,22 +364,23 @@ runs:
       id: summary
       if: always()
       shell: bash
+      env:
+        CODE_CHECK: ${{ steps.check.outputs.exit_code }}
+        CODE_AUDIT: ${{ steps.audit.outputs.exit_code }}
+        CODE_LINT: ${{ steps.lint.outputs.exit_code }}
+        CODE_BUDGET: ${{ steps.budget.outputs.exit_code }}
+        CODE_POLICY: ${{ steps.policy.outputs.exit_code }}
+        CODE_VERIFY: ${{ steps.verify.outputs.exit_code }}
+        CODE_TEST: ${{ steps.test.outputs.exit_code }}
       run: |
         # Build a JSON object of exit codes for each command that ran
         RESULTS="{"
         FIRST=true
 
         for CMD in check audit lint budget policy verify test; do
-          # Read exit code from the corresponding step output
-          case "$CMD" in
-            check)  CODE="${{ steps.check.outputs.exit_code }}"  ;;
-            audit)  CODE="${{ steps.audit.outputs.exit_code }}"  ;;
-            lint)   CODE="${{ steps.lint.outputs.exit_code }}"   ;;
-            budget) CODE="${{ steps.budget.outputs.exit_code }}" ;;
-            policy) CODE="${{ steps.policy.outputs.exit_code }}" ;;
-            verify) CODE="${{ steps.verify.outputs.exit_code }}" ;;
-            test)   CODE="${{ steps.test.outputs.exit_code }}"   ;;
-          esac
+          # Read exit code from the corresponding env var
+          VAR="CODE_$(echo "$CMD" | tr '[:lower:]' '[:upper:]')"
+          CODE="${!VAR}"
 
           if [ -n "$CODE" ]; then
             if [ "$FIRST" = true ]; then

--- a/packages/cli/src/audit/checkers/urls.test.ts
+++ b/packages/cli/src/audit/checkers/urls.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CheckContext, ExtractedUrl } from "../types.js";
+
+// Mock dns/promises lookup before importing the module under test
+vi.mock("node:dns/promises", () => ({
+	lookup: vi.fn().mockResolvedValue({ address: "93.184.216.34", family: 4 }),
+}));
+
+import { lookup } from "node:dns/promises";
 import { urlChecker } from "./urls.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+const mockLookup = vi.mocked(lookup);
 
 function makeContext(urls: ExtractedUrl[]): CheckContext {
 	return {
@@ -21,6 +30,8 @@ function url(u: string, line = 1, text?: string): ExtractedUrl {
 describe("urlChecker", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Default: DNS resolves to a public IP
+		mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
 	});
 
 	afterEach(() => {
@@ -53,9 +64,21 @@ describe("urlChecker", () => {
 	});
 
 	it("skips localhost URLs", async () => {
+		mockLookup.mockResolvedValue({ address: "127.0.0.1", family: 4 });
 		const ctx = makeContext([url("http://localhost:3000"), url("http://127.0.0.1:8080")]);
 		const findings = await urlChecker.check(ctx);
-		expect(findings).toHaveLength(0);
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it("skips private network and cloud metadata URLs", async () => {
+		const privateUrls = [
+			url("http://169.254.169.254/latest/meta-data/"),
+			url("http://metadata.google.internal/computeMetadata/v1/"),
+			url("http://internal-service.local:8080/api"),
+		];
+		mockLookup.mockResolvedValue({ address: "169.254.169.254", family: 4 });
+		const ctx = makeContext(privateUrls);
+		const findings = await urlChecker.check(ctx);
 		expect(mockFetch).not.toHaveBeenCalled();
 	});
 

--- a/packages/cli/src/audit/checkers/urls.ts
+++ b/packages/cli/src/audit/checkers/urls.ts
@@ -1,10 +1,79 @@
+import { lookup } from "node:dns/promises";
 import type { AuditChecker, AuditFinding, CheckContext, ExtractedUrl } from "../types.js";
 
 const CONCURRENCY_LIMIT = 5;
 const TIMEOUT_MS = 10_000;
 
+/**
+ * Check if an IP address is private, loopback, link-local, or a cloud metadata endpoint.
+ */
+function isPrivateIp(ip: string): boolean {
+	// IPv4 loopback
+	if (ip.startsWith("127.") || ip === "0.0.0.0") return true;
+	// IPv4 private ranges
+	if (ip.startsWith("10.")) return true;
+	if (ip.startsWith("192.168.")) return true;
+	if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true;
+	// IPv4 link-local
+	if (ip.startsWith("169.254.")) return true;
+	// IPv6 loopback and link-local
+	if (ip === "::1" || ip.startsWith("fe80:") || ip === "::") return true;
+	return false;
+}
+
+/**
+ * Check if a URL hostname points to a known cloud metadata endpoint.
+ */
+function isCloudMetadataHost(hostname: string): boolean {
+	const blocked = [
+		"169.254.169.254",
+		"metadata.google.internal",
+		"metadata.goog",
+	];
+	return blocked.includes(hostname.toLowerCase());
+}
+
+/**
+ * Validate that a URL does not target private/internal network addresses.
+ * Returns true if the URL is safe to fetch.
+ */
+async function isSafeUrl(url: string): Promise<boolean> {
+	try {
+		const parsed = new URL(url);
+		const hostname = parsed.hostname;
+
+		// Block known cloud metadata endpoints
+		if (isCloudMetadataHost(hostname)) return false;
+
+		// Block common private-network hostnames
+		if (
+			hostname === "localhost" ||
+			hostname.endsWith(".local") ||
+			hostname.endsWith(".internal")
+		) {
+			return false;
+		}
+
+		// Resolve DNS and check the IP
+		try {
+			const result = await lookup(hostname);
+			if (isPrivateIp(result.address)) return false;
+		} catch {
+			// DNS resolution failed — allow fetch to fail naturally
+		}
+
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 async function checkUrlLiveness(url: string): Promise<{ ok: boolean; status?: number }> {
 	try {
+		if (!(await isSafeUrl(url))) {
+			return { ok: false };
+		}
+
 		const controller = new AbortController();
 		const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
@@ -62,11 +131,8 @@ export const urlChecker: AuditChecker = {
 	async check(context: CheckContext): Promise<AuditFinding[]> {
 		const findings: AuditFinding[] = [];
 
-		// Only check http(s) URLs, skip localhost/127.0.0.1
-		const checkable = context.urls.filter(
-			(u) =>
-				u.url.startsWith("http") && !u.url.includes("localhost") && !u.url.includes("127.0.0.1")
-		);
+		// Only check http(s) URLs — private/internal filtering happens in checkUrlLiveness
+		const checkable = context.urls.filter((u) => u.url.startsWith("http"));
 
 		// Deduplicate by URL
 		const seen = new Set<string>();

--- a/packages/cli/src/npm.ts
+++ b/packages/cli/src/npm.ts
@@ -16,7 +16,7 @@ export interface NpmPackageMetadata {
  * Uses the full (non-abbreviated) metadata endpoint.
  */
 export async function fetchPackageMetadata(packageName: string): Promise<NpmPackageMetadata> {
-	const url = `${NPM_REGISTRY}/${packageName.replace("/", "%2F")}`;
+	const url = `${NPM_REGISTRY}/${encodeURIComponent(packageName)}`;
 	const response = await fetch(url, {
 		headers: {
 			Accept: "application/json",
@@ -36,7 +36,7 @@ export async function fetchPackageMetadata(packageName: string): Promise<NpmPack
  * Uses the abbreviated metadata endpoint for speed.
  */
 export async function fetchLatestVersion(packageName: string): Promise<string> {
-	const url = `${NPM_REGISTRY}/${packageName.replace("/", "%2F")}`;
+	const url = `${NPM_REGISTRY}/${encodeURIComponent(packageName)}`;
 	const response = await fetch(url, {
 		headers: {
 			Accept: "application/vnd.npm.install-v1+json",

--- a/packages/cli/src/policy/parser.ts
+++ b/packages/cli/src/policy/parser.ts
@@ -6,9 +6,15 @@ import type { SkillPolicy } from "./types.js";
  * Dynamically import js-yaml (transitive dep via gray-matter).
  * Uses dynamic import to avoid adding a direct dependency.
  */
-async function loadYaml(): Promise<{ load: (str: string) => unknown }> {
+async function loadYaml(): Promise<{
+	load: (str: string, opts?: { schema: unknown }) => unknown;
+	JSON_SCHEMA: unknown;
+}> {
 	const mod = await import("js-yaml");
-	return (mod.default ?? mod) as { load: (str: string) => unknown };
+	return (mod.default ?? mod) as {
+		load: (str: string, opts?: { schema: unknown }) => unknown;
+		JSON_SCHEMA: unknown;
+	};
 }
 
 /**
@@ -17,7 +23,7 @@ async function loadYaml(): Promise<{ load: (str: string) => unknown }> {
  */
 export async function parsePolicy(content: string): Promise<SkillPolicy> {
 	const yaml = await loadYaml();
-	const raw = yaml.load(content);
+	const raw = yaml.load(content, { schema: yaml.JSON_SCHEMA });
 
 	if (raw === null || raw === undefined || typeof raw !== "object") {
 		throw new Error("Policy file is empty or not a valid YAML object");

--- a/packages/cli/src/policy/parser.ts
+++ b/packages/cli/src/policy/parser.ts
@@ -1,5 +1,6 @@
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { isSafeRegex } from "../shared/safe-regex.js";
 import type { SkillPolicy } from "./types.js";
 
 /**
@@ -109,6 +110,11 @@ export function validatePolicy(policy: SkillPolicy): string[] {
 				for (const dp of policy.content.deny_patterns) {
 					try {
 						new RegExp(dp.pattern);
+						if (!isSafeRegex(dp.pattern)) {
+							errors.push(
+								`content.deny_patterns: potentially unsafe regex "${dp.pattern}" (may cause catastrophic backtracking)`
+							);
+						}
 					} catch {
 						errors.push(`content.deny_patterns: invalid regex "${dp.pattern}"`);
 					}
@@ -127,6 +133,11 @@ export function validatePolicy(policy: SkillPolicy): string[] {
 				for (const rp of policy.content.require_patterns) {
 					try {
 						new RegExp(rp.pattern);
+						if (!isSafeRegex(rp.pattern)) {
+							errors.push(
+								`content.require_patterns: potentially unsafe regex "${rp.pattern}" (may cause catastrophic backtracking)`
+							);
+						}
 					} catch {
 						errors.push(`content.require_patterns: invalid regex "${rp.pattern}"`);
 					}

--- a/packages/cli/src/policy/validators/content.ts
+++ b/packages/cli/src/policy/validators/content.ts
@@ -1,3 +1,4 @@
+import { isSafeRegex } from "../../shared/safe-regex.js";
 import type { SkillFile } from "../../skill-io.js";
 import type { PolicyFinding, SkillPolicy } from "../types.js";
 
@@ -30,6 +31,9 @@ export function checkContent(file: SkillFile, policy: SkillPolicy): PolicyFindin
 		for (const dp of policy.content.deny_patterns) {
 			let regex: RegExp;
 			try {
+				if (!isSafeRegex(dp.pattern)) {
+					continue; // Skip unsafe regex (caught by validation)
+				}
 				regex = new RegExp(dp.pattern, "m");
 			} catch {
 				continue; // Skip invalid regex (should be caught by validation)
@@ -55,6 +59,9 @@ export function checkContent(file: SkillFile, policy: SkillPolicy): PolicyFindin
 		for (const rp of policy.content.require_patterns) {
 			let regex: RegExp;
 			try {
+				if (!isSafeRegex(rp.pattern)) {
+					continue; // Skip unsafe regex (caught by validation)
+				}
 				regex = new RegExp(rp.pattern, "m");
 			} catch {
 				continue;

--- a/packages/cli/src/shared/safe-regex.test.ts
+++ b/packages/cli/src/shared/safe-regex.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { isSafeRegex } from "./safe-regex.js";
+
+describe("isSafeRegex", () => {
+	describe("safe patterns", () => {
+		it.each([
+			["simple literal", "hello"],
+			["character class", "[a-z]+"],
+			["alternation", "foo|bar|baz"],
+			["anchored quantifier", "^\\w+$"],
+			["non-greedy", ".*?foo"],
+			["optional group", "(abc)?def"],
+			["bounded repetition", "a{1,3}"],
+			["complex but safe", "^https?://[\\w.-]+/[\\w./-]*$"],
+			["email-like", "[\\w.+-]+@[\\w-]+\\.[a-z]{2,}"],
+			["escaped special chars", "\\(\\)\\[\\]\\{\\}"],
+			["empty pattern", ""],
+		])("allows %s: %s", (_name, pattern) => {
+			expect(isSafeRegex(pattern)).toBe(true);
+		});
+	});
+
+	describe("dangerous patterns — nested quantifiers", () => {
+		it.each([
+			["classic ReDoS", "(a+)+"],
+			["star of star", "(a*)*"],
+			["plus of star", "(a*)+"],
+			["star of plus", "(a+)*"],
+			["nested with char class", "([a-z]+)+"],
+			["nested with dot", "(.*)+"],
+			["nested with bounded", "(a{2,})+"],
+			["deeply nested", "((a+)+)+"],
+			["non-capturing nested", "(?:a+)+"],
+		])("rejects %s: %s", (_name, pattern) => {
+			expect(isSafeRegex(pattern)).toBe(false);
+		});
+	});
+
+	describe("dangerous patterns — excessive quantifier chains", () => {
+		it.each([["4 chained quantifiers", "a+b+c+d+"]])("rejects %s: %s", (_name, pattern) => {
+			expect(isSafeRegex(pattern)).toBe(false);
+		});
+	});
+
+	describe("invalid patterns", () => {
+		it("rejects invalid regex", () => {
+			expect(isSafeRegex("(unclosed")).toBe(false);
+			expect(isSafeRegex("[bad")).toBe(false);
+		});
+	});
+});

--- a/packages/cli/src/shared/safe-regex.ts
+++ b/packages/cli/src/shared/safe-regex.ts
@@ -1,0 +1,206 @@
+/**
+ * Detect regular expressions that are likely to cause catastrophic backtracking (ReDoS).
+ *
+ * Uses heuristic analysis of the pattern string to detect common dangerous constructs:
+ * - Nested quantifiers: (a+)+, (a*)+, (a+)*, (a{2,})+
+ * - Overlapping alternation with quantifiers: (a|a)+, (a|ab)+
+ * - Star-height > 1 patterns
+ *
+ * This is a lightweight heuristic — not a full regex parser. It catches the most common
+ * ReDoS patterns without requiring a dependency like `safe-regex2` or `re2`.
+ *
+ * Returns true if the pattern appears safe, false if it looks potentially dangerous.
+ */
+export function isSafeRegex(pattern: string): boolean {
+	// First, verify it's a valid regex at all
+	try {
+		new RegExp(pattern);
+	} catch {
+		return false;
+	}
+
+	// Detect nested quantifiers: a quantifier applied to a group that contains a quantifier.
+	// This catches patterns like (a+)+, (a*)+, (a+)*, (a{2,})*, etc.
+	// Strategy: walk the pattern tracking group nesting depth and quantifier presence.
+	if (hasNestedQuantifiers(pattern)) {
+		return false;
+	}
+
+	// Detect excessive quantifier chains that can cause polynomial backtracking
+	// e.g., a+a+a+a+ on a long non-matching string
+	if (hasExcessiveQuantifierChains(pattern)) {
+		return false;
+	}
+
+	return true;
+}
+
+const QUANTIFIER_CHARS = new Set(["*", "+", "?"]);
+
+function isQuantifier(pattern: string, pos: number): boolean {
+	const ch = pattern[pos];
+	if (QUANTIFIER_CHARS.has(ch)) {
+		return true;
+	}
+	// {n,m} style quantifiers
+	if (ch === "{") {
+		const close = pattern.indexOf("}", pos);
+		if (close !== -1 && /^\{\d+,?\d*\}/.test(pattern.slice(pos, close + 1))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function hasNestedQuantifiers(pattern: string): boolean {
+	// Track group boundaries and whether each group-level has a quantifier inside
+	const groupStack: { hasQuantifier: boolean }[] = [];
+	let i = 0;
+
+	while (i < pattern.length) {
+		const ch = pattern[i];
+
+		// Skip escaped characters
+		if (ch === "\\") {
+			i += 2;
+			continue;
+		}
+
+		// Skip character classes entirely
+		if (ch === "[") {
+			const end = findCharClassEnd(pattern, i);
+			i = end + 1;
+			continue;
+		}
+
+		// Opening group (capturing or non-capturing)
+		if (ch === "(") {
+			groupStack.push({ hasQuantifier: false });
+			i++;
+			continue;
+		}
+
+		// Closing group
+		if (ch === ")") {
+			const group = groupStack.pop();
+			const innerHasQuantifier = group?.hasQuantifier ?? false;
+			i++;
+
+			// Check if a quantifier follows this group
+			if (i < pattern.length && isQuantifier(pattern, i)) {
+				// This group has a quantifier on it
+				if (innerHasQuantifier) {
+					// Nested quantifier detected: group contains a quantifier AND has one on it
+					return true;
+				}
+				// Mark the parent group as having a quantifier
+				if (groupStack.length > 0) {
+					groupStack[groupStack.length - 1].hasQuantifier = true;
+				}
+			}
+			continue;
+		}
+
+		// Check for quantifiers on atoms
+		if (isQuantifier(pattern, i)) {
+			if (groupStack.length > 0) {
+				groupStack[groupStack.length - 1].hasQuantifier = true;
+			}
+			// Skip past the quantifier (and optional ? or + modifiers)
+			i++;
+			if (i < pattern.length && (pattern[i] === "?" || pattern[i] === "+")) {
+				i++;
+			}
+			continue;
+		}
+
+		i++;
+	}
+
+	return false;
+}
+
+function hasExcessiveQuantifierChains(pattern: string): boolean {
+	// Count consecutive quantified atoms that can match overlapping input
+	// e.g., \w+\w+\w+\w+ — each \w+ can greedily consume then backtrack
+	let consecutiveQuantified = 0;
+	let i = 0;
+
+	while (i < pattern.length) {
+		const ch = pattern[i];
+
+		if (ch === "\\") {
+			i += 2;
+			// Check if followed by a quantifier
+			if (i < pattern.length && isQuantifier(pattern, i)) {
+				consecutiveQuantified++;
+				i++;
+				continue;
+			}
+			consecutiveQuantified = 0;
+			continue;
+		}
+
+		if (ch === "[") {
+			const end = findCharClassEnd(pattern, i);
+			i = end + 1;
+			if (i < pattern.length && isQuantifier(pattern, i)) {
+				consecutiveQuantified++;
+				i++;
+				continue;
+			}
+			consecutiveQuantified = 0;
+			continue;
+		}
+
+		if (ch === "(" || ch === ")") {
+			consecutiveQuantified = 0;
+			i++;
+			continue;
+		}
+
+		if (ch === "." || ch === "^" || ch === "$" || ch === "|") {
+			consecutiveQuantified = 0;
+			i++;
+			continue;
+		}
+
+		// Regular character
+		i++;
+		if (i < pattern.length && isQuantifier(pattern, i)) {
+			consecutiveQuantified++;
+			i++;
+		} else {
+			consecutiveQuantified = 0;
+		}
+
+		if (consecutiveQuantified >= 4) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function findCharClassEnd(pattern: string, start: number): number {
+	let i = start + 1;
+	// Handle negated class and literal ] at start
+	if (i < pattern.length && pattern[i] === "^") {
+		i++;
+	}
+	if (i < pattern.length && pattern[i] === "]") {
+		i++;
+	}
+
+	while (i < pattern.length) {
+		if (pattern[i] === "\\") {
+			i += 2;
+			continue;
+		}
+		if (pattern[i] === "]") {
+			return i;
+		}
+		i++;
+	}
+	return pattern.length - 1;
+}

--- a/packages/cli/src/testing/graders/contains.ts
+++ b/packages/cli/src/testing/graders/contains.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { resolve } from "node:path";
 import type { GraderResult } from "../types.js";
+import { safePath } from "../safe-path.js";
 
 /**
  * Check that a file contains (or does not contain) the given regex patterns.
@@ -12,7 +13,7 @@ export async function gradeContains(
 	patterns: string[],
 	negate?: boolean
 ): Promise<GraderResult> {
-	const fullPath = join(workDir, file);
+	const fullPath = safePath(resolve(workDir), file);
 	let content: string;
 
 	try {

--- a/packages/cli/src/testing/graders/contains.ts
+++ b/packages/cli/src/testing/graders/contains.ts
@@ -1,7 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import type { GraderResult } from "../types.js";
+import { isSafeRegex } from "../../shared/safe-regex.js";
 import { safePath } from "../safe-path.js";
+import type { GraderResult } from "../types.js";
 
 /**
  * Check that a file contains (or does not contain) the given regex patterns.
@@ -30,6 +31,10 @@ export async function gradeContains(
 
 	for (const pattern of patterns) {
 		try {
+			if (!isSafeRegex(pattern)) {
+				failedPatterns.push(`${pattern} (unsafe regex, skipped)`);
+				continue;
+			}
 			const regex = new RegExp(pattern);
 			const matches = regex.test(content);
 

--- a/packages/cli/src/testing/graders/file-exists.ts
+++ b/packages/cli/src/testing/graders/file-exists.ts
@@ -1,6 +1,7 @@
 import { stat } from "node:fs/promises";
-import { join } from "node:path";
+import { resolve } from "node:path";
 import type { GraderResult } from "../types.js";
+import { safePath } from "../safe-path.js";
 
 /**
  * Check that specific files exist in the work directory.
@@ -8,9 +9,10 @@ import type { GraderResult } from "../types.js";
 export async function gradeFileExists(workDir: string, paths: string[]): Promise<GraderResult> {
 	const missing: string[] = [];
 	const found: string[] = [];
+	const resolvedWorkDir = resolve(workDir);
 
 	for (const p of paths) {
-		const fullPath = join(workDir, p);
+		const fullPath = safePath(resolvedWorkDir, p);
 		try {
 			const info = await stat(fullPath);
 			if (info.isFile() || info.isDirectory()) {

--- a/packages/cli/src/testing/graders/json-match.ts
+++ b/packages/cli/src/testing/graders/json-match.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { resolve } from "node:path";
 import type { GraderResult } from "../types.js";
+import { safePath } from "../safe-path.js";
 
 /**
  * Parse a JSON file and validate its structure against an expected schema.
@@ -12,7 +13,7 @@ export async function gradeJsonMatch(
 	file: string,
 	schema: Record<string, unknown>
 ): Promise<GraderResult> {
-	const fullPath = join(workDir, file);
+	const fullPath = safePath(resolve(workDir), file);
 	let content: string;
 
 	try {

--- a/packages/cli/src/testing/parser.ts
+++ b/packages/cli/src/testing/parser.ts
@@ -18,7 +18,7 @@ const VALID_GRADER_TYPES = new Set([
  */
 export async function parseTestSuite(content: string): Promise<TestSuite> {
 	const yaml = await import("js-yaml");
-	const raw = yaml.load(content) as Record<string, unknown>;
+	const raw = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
 
 	if (!raw || typeof raw !== "object") {
 		throw new Error("Invalid cases.yaml: expected an object");

--- a/packages/cli/src/testing/runner.ts
+++ b/packages/cli/src/testing/runner.ts
@@ -1,6 +1,7 @@
 import { cp, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { safePath } from "./safe-path.js";
 import { gradeCommand } from "./graders/command.js";
 import { gradeContains } from "./graders/contains.js";
 import { gradeCustom } from "./graders/custom.js";
@@ -41,11 +42,12 @@ export async function runCase(
 			trialWorkDir = await mkdtemp(join(tmpdir(), `skills-check-test-${testCase.id}-`));
 
 			if (testCase.fixture && options.testsDir) {
-				const fixturePath = join(options.testsDir, "..", testCase.fixture);
+				const skillDir = resolve(options.testsDir, "..");
 				try {
+					const fixturePath = safePath(skillDir, testCase.fixture);
 					await cp(fixturePath, trialWorkDir, { recursive: true });
 				} catch {
-					// Fixture not found — proceed with empty dir
+					// Fixture not found or path traversal — proceed with empty dir
 				}
 			}
 
@@ -152,8 +154,11 @@ async function runSingleGrader(
 			return gradePackageHas(workDir, grader.dependencies, grader.devDependencies);
 
 		case "llm-rubric": {
-			const rubricPath =
-				grader.rubric && options.testsDir ? join(options.testsDir, "..", grader.rubric) : undefined;
+			let rubricPath: string | undefined;
+			if (grader.rubric && options.testsDir) {
+				const skillDir = resolve(options.testsDir, "..");
+				rubricPath = safePath(skillDir, grader.rubric);
+			}
 			return gradeLlmRubric(
 				workDir,
 				grader.criteria,
@@ -165,9 +170,13 @@ async function runSingleGrader(
 		}
 
 		case "custom": {
-			const modulePath = options.testsDir
-				? join(options.testsDir, "..", grader.module)
-				: grader.module;
+			let modulePath: string;
+			if (options.testsDir) {
+				const skillDir = resolve(options.testsDir, "..");
+				modulePath = safePath(skillDir, grader.module);
+			} else {
+				modulePath = grader.module;
+			}
 			return gradeCustom(workDir, modulePath);
 		}
 

--- a/packages/cli/src/testing/safe-path.test.ts
+++ b/packages/cli/src/testing/safe-path.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { safePath } from "./safe-path.js";
+
+describe("safePath", () => {
+	it("resolves a valid relative path within the base directory", () => {
+		const result = safePath("/base/dir", "sub/file.ts");
+		expect(result).toBe("/base/dir/sub/file.ts");
+	});
+
+	it("throws on path traversal with ../", () => {
+		expect(() => safePath("/base/dir", "../../etc/passwd")).toThrow("Path traversal detected");
+	});
+
+	it("throws on absolute paths outside the base", () => {
+		expect(() => safePath("/base/dir", "/etc/passwd")).toThrow("Path traversal detected");
+	});
+
+	it("allows the base directory itself", () => {
+		const result = safePath("/base/dir", ".");
+		expect(result).toBe("/base/dir");
+	});
+
+	it("normalizes paths with redundant segments", () => {
+		const result = safePath("/base/dir", "sub/../sub/file.ts");
+		expect(result).toBe("/base/dir/sub/file.ts");
+	});
+});

--- a/packages/cli/src/testing/safe-path.ts
+++ b/packages/cli/src/testing/safe-path.ts
@@ -1,0 +1,19 @@
+import { resolve } from "node:path";
+
+/**
+ * Resolve a potentially untrusted relative path and verify it stays within the
+ * allowed base directory. Returns the resolved absolute path, or throws if the
+ * path would escape the base directory (e.g. via `../` traversal).
+ */
+export function safePath(baseDir: string, untrustedPath: string): string {
+	const resolved = resolve(baseDir, untrustedPath);
+	const normalizedBase = resolve(baseDir);
+
+	if (!resolved.startsWith(normalizedBase + "/") && resolved !== normalizedBase) {
+		throw new Error(
+			`Path traversal detected: "${untrustedPath}" resolves outside "${normalizedBase}"`,
+		);
+	}
+
+	return resolved;
+}

--- a/packages/web/app/commands/[slug]/command.module.css
+++ b/packages/web/app/commands/[slug]/command.module.css
@@ -1,0 +1,195 @@
+.main {
+	max-width: 1024px;
+	padding: 48px 24px;
+	margin: 0 auto;
+}
+
+.article {
+	max-width: 720px;
+}
+
+.backLink {
+	display: inline-block;
+	margin-bottom: 32px;
+	font-size: 14px;
+	color: var(--text-secondary);
+}
+
+.backLink:hover {
+	color: var(--text-primary);
+}
+
+.header {
+	display: flex;
+	gap: 16px;
+	align-items: center;
+	margin-bottom: 24px;
+}
+
+.icon {
+	display: flex;
+	flex-shrink: 0;
+	align-items: center;
+	justify-content: center;
+	width: 48px;
+	height: 48px;
+	font-size: 22px;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border);
+	border-radius: 10px;
+}
+
+.group {
+	display: block;
+	margin-bottom: 4px;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-tertiary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+.title {
+	font-family: var(--font-mono);
+	font-size: 32px;
+	font-weight: 700;
+}
+
+.tagline {
+	margin-bottom: 40px;
+	font-size: 17px;
+	line-height: 1.7;
+	color: var(--text-secondary);
+}
+
+/* Reuse docs article patterns */
+
+.article h2 {
+	padding-top: 24px;
+	margin-top: 48px;
+	margin-bottom: 16px;
+	font-size: 22px;
+	font-weight: 600;
+	border-top: 1px solid var(--border);
+}
+
+.article h3 {
+	margin-top: 24px;
+	margin-bottom: 8px;
+	font-size: 16px;
+	font-weight: 600;
+}
+
+.article p {
+	margin-bottom: 12px;
+	font-size: 15px;
+	line-height: 1.7;
+	color: var(--text-secondary);
+}
+
+.article p code {
+	padding: 2px 6px;
+	font-family: var(--font-mono);
+	font-size: 13px;
+	background: var(--code-bg);
+	border: 1px solid var(--code-border);
+	border-radius: 3px;
+}
+
+.article pre {
+	padding: 16px;
+	margin-bottom: 16px;
+	overflow-x: auto;
+	background: var(--code-bg);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+}
+
+.article pre code {
+	padding: 0;
+	font-family: var(--font-mono);
+	font-size: 13px;
+	line-height: 1.6;
+	color: var(--text-primary);
+	background: none;
+	border: none;
+}
+
+.article a {
+	color: var(--success);
+}
+
+.article a:hover {
+	text-decoration: underline;
+}
+
+.list {
+	padding-left: 20px;
+	margin-bottom: 16px;
+}
+
+.list li {
+	margin-bottom: 8px;
+	font-size: 15px;
+	line-height: 1.7;
+	color: var(--text-secondary);
+}
+
+.list li::marker {
+	color: var(--text-tertiary);
+}
+
+.article table {
+	width: 100%;
+	margin-bottom: 16px;
+	font-size: 14px;
+	border-collapse: collapse;
+}
+
+.article table th {
+	padding: 8px 12px;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-align: left;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	border-bottom: 1px solid var(--border);
+}
+
+.article table td {
+	padding: 8px 12px;
+	color: var(--text-secondary);
+	border-bottom: 1px solid var(--border);
+}
+
+.article table td code {
+	padding: 2px 6px;
+	font-family: var(--font-mono);
+	font-size: 13px;
+	background: var(--code-bg);
+	border: 1px solid var(--code-border);
+	border-radius: 3px;
+}
+
+.ciTip {
+	padding: 20px 24px;
+	margin-top: 48px;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+}
+
+.ciTip h2 {
+	padding-top: 0;
+	margin-top: 0;
+	font-size: 16px;
+	border-top: none;
+}
+
+.navLinks {
+	margin-top: 48px;
+	padding-top: 24px;
+	font-size: 15px;
+	border-top: 1px solid var(--border);
+}

--- a/packages/web/app/commands/[slug]/page.tsx
+++ b/packages/web/app/commands/[slug]/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Footer } from "@/components/footer";
+import { Header } from "@/components/header";
+import { commandSlugs, getCommandBySlug } from "@/lib/commands";
+import styles from "./command.module.css";
+
+interface Props {
+	params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+	return commandSlugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+	const { slug } = await params;
+	const cmd = getCommandBySlug(slug);
+	if (!cmd) return {};
+
+	return {
+		title: `${cmd.name} command`,
+		description: cmd.description,
+		alternates: {
+			canonical: `https://skillscheck.ai/commands/${slug}`,
+		},
+	};
+}
+
+export default async function CommandPage({ params }: Props) {
+	const { slug } = await params;
+	const cmd = getCommandBySlug(slug);
+	if (!cmd) notFound();
+
+	return (
+		<>
+			<Header />
+			<main className={styles.main}>
+				<article className={styles.article}>
+					<Link className={styles.backLink} href="/#commands">
+						&larr; All commands
+					</Link>
+
+					<div className={styles.header}>
+						<span className={styles.icon}>{cmd.icon}</span>
+						<div>
+							<span className={styles.group}>{cmd.group}</span>
+							<h1 className={styles.title}>{cmd.name}</h1>
+						</div>
+					</div>
+
+					<p className={styles.tagline}>{cmd.description}</p>
+
+					<section>
+						<h2>Why it matters</h2>
+						<p>{cmd.whyItMatters}</p>
+					</section>
+
+					<section>
+						<h2>What it does</h2>
+						<ul className={styles.list}>
+							{cmd.whatItDoes.map((item) => (
+								<li key={item}>{item}</li>
+							))}
+						</ul>
+					</section>
+
+					<section>
+						<h2>Usage</h2>
+						<pre>
+							<code>{cmd.usage}</code>
+						</pre>
+
+						<h3>Options</h3>
+						<table>
+							<thead>
+								<tr>
+									<th>Flag</th>
+									<th>Description</th>
+								</tr>
+							</thead>
+							<tbody>
+								{cmd.options.map((opt) => (
+									<tr key={opt.flag}>
+										<td>
+											<code>{opt.flag}</code>
+										</td>
+										<td>{opt.description}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</section>
+
+					<section>
+						<h2>Examples</h2>
+						{cmd.examples.map((ex) => (
+							<div key={ex.label}>
+								<h3>{ex.label}</h3>
+								<pre>
+									<code>{ex.code}</code>
+								</pre>
+							</div>
+						))}
+					</section>
+
+					{cmd.ciTip && (
+						<section className={styles.ciTip}>
+							<h2>CI tip</h2>
+							<p>{cmd.ciTip}</p>
+						</section>
+					)}
+
+					<div className={styles.navLinks}>
+						<Link href="/docs#commands">Full CLI reference &rarr;</Link>
+					</div>
+				</article>
+			</main>
+			<Footer />
+		</>
+	);
+}

--- a/packages/web/app/sitemap.ts
+++ b/packages/web/app/sitemap.ts
@@ -1,6 +1,14 @@
 import type { MetadataRoute } from "next";
+import { commandSlugs } from "@/lib/commands";
 
 export default function sitemap(): MetadataRoute.Sitemap {
+	const commandPages = commandSlugs.map((slug) => ({
+		url: `https://skillscheck.ai/commands/${slug}`,
+		lastModified: new Date(),
+		changeFrequency: "weekly" as const,
+		priority: 0.7,
+	}));
+
 	return [
 		{
 			url: "https://skillscheck.ai",
@@ -14,6 +22,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
+		...commandPages,
 		{
 			url: "https://skillscheck.ai/schema.json",
 			lastModified: new Date(),

--- a/packages/web/components/commands.module.css
+++ b/packages/web/components/commands.module.css
@@ -52,9 +52,12 @@
 	gap: 14px;
 	align-items: flex-start;
 	padding: 16px;
+	color: inherit;
+	text-decoration: none;
 	background: var(--bg-secondary);
 	border: 1px solid var(--border);
 	border-radius: 8px;
+	cursor: pointer;
 	transition:
 		border-color 0.15s ease,
 		background 0.15s ease;

--- a/packages/web/components/commands.tsx
+++ b/packages/web/components/commands.tsx
@@ -1,91 +1,24 @@
+import Link from "next/link";
+import { commands as allCommands } from "@/lib/commands";
 import styles from "./commands.module.css";
 
-const commandGroups = [
-	{
-		label: "Freshness & Currency",
-		commands: [
-			{
-				name: "check",
-				description:
-					"Detect version drift by comparing skill frontmatter against the npm registry.",
-				icon: "\u2713",
-			},
-			{
-				name: "refresh",
-				description:
-					"AI-assisted updates to stale skills using LLMs. Fetches changelogs and generates diffs.",
-				icon: "\u21BB",
-			},
-			{
-				name: "report",
-				description:
-					"Generate a formatted staleness report in markdown or JSON for your team or CI.",
-				icon: "\u2691",
-			},
-		],
-	},
-	{
-		label: "Security & Quality",
-		commands: [
-			{
-				name: "audit",
-				description:
-					"Scan for hallucinated packages, prompt injection, dangerous commands, and dead URLs.",
-				icon: "\u26A1",
-			},
-			{
-				name: "lint",
-				description:
-					"Validate metadata completeness, structural quality, and format in skill files.",
-				icon: "\u2726",
-			},
-			{
-				name: "policy",
-				description:
-					"Enforce organizational trust rules for skills via .skill-policy.yml policy-as-code.",
-				icon: "\u229E",
-			},
-		],
-	},
-	{
-		label: "Analysis & Verification",
-		commands: [
-			{
-				name: "budget",
-				description:
-					"Measure token cost per skill, detect redundancy, and track context window usage over time.",
-				icon: "\u2261",
-			},
-			{
-				name: "verify",
-				description:
-					"Validate that content changes between skill versions match the declared semver bump.",
-				icon: "\u2690",
-			},
-			{
-				name: "test",
-				description:
-					"Run eval test suites declared in skill tests/ directories for regression detection.",
-				icon: "\u25B7",
-			},
-		],
-	},
-	{
-		label: "Setup",
-		commands: [
-			{
-				name: "init",
-				description:
-					"Scan a skills directory for SKILL.md files and generate a skills-check.json registry.",
-				icon: "\u279C",
-			},
-		],
-	},
+const groupOrder = [
+	"Freshness & Currency",
+	"Security & Quality",
+	"Analysis & Verification",
+	"Setup",
 ];
+
+const commandGroups = groupOrder.map((label) => ({
+	label,
+	commands: allCommands
+		.filter((c) => c.group === label)
+		.map((c) => ({ name: c.name, description: c.tagline, icon: c.icon, slug: c.slug })),
+}));
 
 export function Commands() {
 	return (
-		<section className={styles.section}>
+		<section className={styles.section} id="commands">
 			<div className={styles.container}>
 				<h2 className={styles.heading}>10 commands, one toolkit</h2>
 				<p className={styles.subtitle}>
@@ -97,13 +30,19 @@ export function Commands() {
 							<span className={styles.groupLabel}>{group.label}</span>
 							<div className={styles.cards}>
 								{group.commands.map((cmd) => (
-									<div className={styles.card} key={cmd.name}>
+									<Link
+										className={styles.card}
+										href={`/commands/${cmd.slug}`}
+										key={cmd.name}
+									>
 										<div className={styles.cardIcon}>{cmd.icon}</div>
 										<div className={styles.cardBody}>
 											<div className={styles.cardName}>{cmd.name}</div>
-											<div className={styles.cardDescription}>{cmd.description}</div>
+											<div className={styles.cardDescription}>
+												{cmd.description}
+											</div>
 										</div>
-									</div>
+									</Link>
 								))}
 							</div>
 						</div>

--- a/packages/web/lib/commands.ts
+++ b/packages/web/lib/commands.ts
@@ -1,0 +1,377 @@
+export interface CommandInfo {
+	slug: string;
+	name: string;
+	icon: string;
+	tagline: string;
+	description: string;
+	group: string;
+	whyItMatters: string;
+	whatItDoes: string[];
+	usage: string;
+	options: { flag: string; description: string }[];
+	examples: { label: string; code: string }[];
+	ciTip?: string;
+}
+
+export const commands: CommandInfo[] = [
+	{
+		slug: "check",
+		name: "check",
+		icon: "\u2713",
+		tagline: "Detect version drift by comparing skill frontmatter against the npm registry.",
+		group: "Freshness & Currency",
+		description:
+			"Compare the product-version in your SKILL.md frontmatter against the latest version on npm. Instantly know which skills are stale and by how much.",
+		whyItMatters:
+			"Agent skills that reference outdated APIs lead to hallucinated code, broken builds, and wasted developer time. A skill written for React 18 won't generate correct React 19 Server Component patterns. Version drift is the #1 source of skill quality decay.",
+		whatItDoes: [
+			"Reads your skills-check.json registry to map products to npm packages",
+			"Fetches the latest version from the npm registry for each product",
+			"Compares it against the product-version declared in each skill's frontmatter",
+			"Reports stale products with the exact version gap (e.g. 4.2.0 → 4.5.1)",
+			"Exits with code 1 in CI mode when staleness is detected",
+		],
+		usage: `npx skills-check check [options]`,
+		options: [
+			{ flag: "--registry <path>", description: "Path to skills-check.json (default: skills-check.json)" },
+			{ flag: "--json", description: "Output results as JSON" },
+			{ flag: "--ci", description: "CI mode — exit code 1 if stale products found" },
+			{ flag: "-p, --product <name>", description: "Check a single product" },
+		],
+		examples: [
+			{ label: "Check all products", code: "npx skills-check check" },
+			{ label: "JSON output for scripts", code: "npx skills-check check --json" },
+			{ label: "CI gate", code: "npx skills-check check --ci" },
+			{ label: "Check one product", code: "npx skills-check check -p ai-sdk" },
+		],
+		ciTip:
+			"Pair with the GitHub Action to automatically open issues when skills go stale. Set fail-on-stale: true to block merges until skills are updated.",
+	},
+	{
+		slug: "refresh",
+		name: "refresh",
+		icon: "\u21BB",
+		tagline:
+			"AI-assisted updates to stale skills using LLMs. Fetches changelogs and generates diffs.",
+		group: "Freshness & Currency",
+		description:
+			"Automatically update stale skill files by fetching changelogs, analyzing breaking changes, and generating targeted diffs using LLMs. Review, approve, or auto-apply.",
+		whyItMatters:
+			"Manually updating skills after every dependency release is tedious and error-prone. Refresh automates the grunt work — it reads the changelog, understands what changed, and proposes precise edits to your skill files so agents always have current instructions.",
+		whatItDoes: [
+			"Identifies stale skills by running check internally",
+			"Fetches changelogs and release notes from GitHub for each stale product",
+			"Sends the current skill content + changelog to an LLM to generate a targeted update",
+			"Presents a diff for review in interactive mode, or auto-applies with -y",
+			"Preserves your skill's structure and style — only changes what's outdated",
+		],
+		usage: `npx skills-check refresh [skills-dir] [options]`,
+		options: [
+			{ flag: "-y, --yes", description: "Auto-apply all changes without prompting" },
+			{ flag: "--dry-run", description: "Preview changes without writing files" },
+			{ flag: "--provider <name>", description: "LLM provider: anthropic, openai, or google" },
+			{ flag: "--model <name>", description: "Specific model ID to use" },
+			{ flag: "-p, --product <name>", description: "Refresh a single product" },
+		],
+		examples: [
+			{ label: "Interactive review", code: "npx skills-check refresh ./skills" },
+			{ label: "Auto-apply", code: "npx skills-check refresh -y" },
+			{ label: "Preview only", code: "npx skills-check refresh --dry-run" },
+			{
+				label: "Specific provider",
+				code: "npx skills-check refresh --provider anthropic --model claude-sonnet-4-20250514",
+			},
+		],
+		ciTip:
+			"Run refresh in --dry-run mode as a CI check to surface which skills need updates, then handle updates in a separate PR workflow.",
+	},
+	{
+		slug: "report",
+		name: "report",
+		icon: "\u2691",
+		tagline:
+			"Generate a formatted staleness report in markdown or JSON for your team or CI.",
+		group: "Freshness & Currency",
+		description:
+			"Produce a comprehensive staleness report summarizing which skills are current, which are stale, and by how much. Output as markdown for issues or JSON for automation.",
+		whyItMatters:
+			"Teams need visibility into skill health across their entire fleet. A weekly report in a GitHub issue or Slack message keeps everyone aware of drift without requiring manual checks.",
+		whatItDoes: [
+			"Runs a full version check against the npm registry",
+			"Generates a formatted report with current vs. latest versions",
+			"Groups results by status (stale, current, error)",
+			"Outputs markdown suitable for GitHub issues or JSON for pipelines",
+		],
+		usage: `npx skills-check report [options]`,
+		options: [
+			{ flag: "--registry <path>", description: "Path to skills-check.json" },
+			{ flag: "--format <type>", description: "Output format: markdown or json" },
+		],
+		examples: [
+			{ label: "Markdown report", code: "npx skills-check report" },
+			{ label: "JSON for automation", code: "npx skills-check report --format json" },
+		],
+		ciTip:
+			"The GitHub Action automatically generates a report and opens/updates a GitHub issue when staleness is detected. Use the report output for custom Slack or email notifications.",
+	},
+	{
+		slug: "audit",
+		name: "audit",
+		icon: "\u26A1",
+		tagline:
+			"Scan for hallucinated packages, prompt injection, dangerous commands, and dead URLs.",
+		group: "Security & Quality",
+		description:
+			"A security-focused scan that verifies every package, URL, and command in your skill files. Catches hallucinated dependencies, prompt injection patterns, dangerous shell commands, and broken links before they reach an agent.",
+		whyItMatters:
+			"Skills are executable instructions — an agent will npm install packages, run shell commands, and follow URLs exactly as written. A hallucinated package name could install malware via typosquatting. A prompt injection pattern could override agent safety boundaries. Audit catches these before they cause harm.",
+		whatItDoes: [
+			"Extracts all npm/pip/cargo package references and verifies they exist on their registries",
+			"Cross-references against known hallucinated package databases (Aikido Security, Socket.dev research)",
+			"Scans for prompt injection patterns: instruction overrides, data exfiltration, obfuscation",
+			"Flags dangerous shell commands: destructive operations, pipe-to-shell installs, sensitive file access",
+			"Checks every URL for liveness via HEAD requests with SSRF protection",
+			"Validates frontmatter metadata completeness",
+		],
+		usage: `npx skills-check audit [path] [options]`,
+		options: [
+			{ flag: "--format <type>", description: "Output: terminal, json, markdown, or sarif" },
+			{ flag: "--fail-on <severity>", description: "Exit 1 at threshold: critical, high, medium, low" },
+			{ flag: "--ci", description: "CI mode with strict exit codes" },
+			{ flag: "--quiet", description: "Suppress non-finding output" },
+			{ flag: "--no-network", description: "Skip network-dependent checks (registry, URLs)" },
+		],
+		examples: [
+			{ label: "Audit everything", code: "npx skills-check audit" },
+			{ label: "Audit one file", code: "npx skills-check audit ./skills/ai-sdk-core.md" },
+			{ label: "SARIF for GitHub Security tab", code: "npx skills-check audit --format sarif" },
+			{ label: "CI gate at high severity", code: "npx skills-check audit --fail-on high --ci" },
+		],
+		ciTip:
+			"Use --format sarif and upload to GitHub's code scanning to see findings inline on PRs. Combine with --fail-on high to block merges on critical issues.",
+	},
+	{
+		slug: "lint",
+		name: "lint",
+		icon: "\u2726",
+		tagline:
+			"Validate metadata completeness, structural quality, and format in skill files.",
+		group: "Security & Quality",
+		description:
+			"Enforce metadata standards across your skill fleet. Validates required frontmatter fields, checks SPDX license identifiers, verifies URLs, and can auto-fix missing fields from git context.",
+		whyItMatters:
+			"Incomplete metadata breaks downstream tooling. Without a name, skills-check can't track a skill. Without product-version, check can't detect drift. Without a license, legal compliance is impossible. Lint ensures every skill meets the bar before it ships.",
+		whatItDoes: [
+			"Validates required fields: name, description (always required)",
+			"Checks publish-ready fields: author, license, repository",
+			"Validates conditional fields: product-version when products are referenced, agents when agent-specific",
+			"Verifies format: semver syntax, SPDX license identifiers (100+ supported with OR/AND expressions), valid URLs",
+			"Auto-fix mode populates missing fields from git context (author from git config, repo from git remote)",
+		],
+		usage: `npx skills-check lint [dir] [options]`,
+		options: [
+			{ flag: "--fix", description: "Auto-fix missing fields from git context" },
+			{ flag: "--ci", description: "CI mode with strict exit codes" },
+			{ flag: "--fail-on <level>", description: "Threshold: error or warning" },
+			{ flag: "-f, --format <type>", description: "Output: terminal or json" },
+		],
+		examples: [
+			{ label: "Lint all skills", code: "npx skills-check lint" },
+			{ label: "Auto-fix from git", code: "npx skills-check lint --fix" },
+			{ label: "CI gate", code: "npx skills-check lint --ci --fail-on error" },
+			{ label: "JSON output", code: "npx skills-check lint --format json" },
+		],
+		ciTip:
+			"Run lint --fix locally before committing to auto-populate metadata. Use lint --ci in CI to catch skills that slip through without proper frontmatter.",
+	},
+	{
+		slug: "policy",
+		name: "policy",
+		icon: "\u229E",
+		tagline:
+			"Enforce organizational trust rules for skills via .skill-policy.yml policy-as-code.",
+		group: "Security & Quality",
+		description:
+			"Define and enforce organizational rules for which skills are allowed, what they must contain, and where they can come from. Policy-as-code via a .skill-policy.yml file that lives in your repo.",
+		whyItMatters:
+			"In team and enterprise environments, you need guardrails: only skills from approved sources, mandatory security disclaimers, banned patterns, freshness requirements. Policy turns these rules into automated checks that run in CI.",
+		whatItDoes: [
+			"Source allow/deny lists with glob matching (e.g., allow only npm:@your-org/*)",
+			"Required skills verification — ensure critical skills are always present",
+			"Banned skills — block known-bad or deprecated skills",
+			"Metadata requirements — enforce specific frontmatter fields and allowed licenses",
+			"Content deny/require patterns — flag or require specific content with line numbers",
+			"Freshness limits — max version drift and max age in days",
+			"Audit integration — require clean audit results as part of policy",
+		],
+		usage: `npx skills-check policy <subcommand> [options]`,
+		options: [
+			{ flag: "--policy <path>", description: "Path to .skill-policy.yml" },
+			{ flag: "--fail-on <severity>", description: "Threshold: blocked, violation, or warning" },
+			{ flag: "--ci", description: "CI mode with strict exit codes" },
+			{ flag: "-f, --format <type>", description: "Output: terminal or json" },
+		],
+		examples: [
+			{ label: "Check against policy", code: "npx skills-check policy check" },
+			{ label: "Initialize default policy", code: "npx skills-check policy init" },
+			{ label: "Validate policy file", code: "npx skills-check policy validate" },
+			{ label: "CI gate", code: "npx skills-check policy check --ci --fail-on violation" },
+		],
+		ciTip:
+			"Commit .skill-policy.yml to your repo root. Policy discovery walks up directories, so monorepo subdirectories inherit the root policy automatically.",
+	},
+	{
+		slug: "budget",
+		name: "budget",
+		icon: "\u2261",
+		tagline:
+			"Measure token cost per skill, detect redundancy, and track context window usage over time.",
+		group: "Analysis & Verification",
+		description:
+			"Every skill you load into an agent consumes context window tokens. Budget tells you exactly how many, finds redundancy between skills, estimates costs across model pricing tiers, and tracks changes over time.",
+		whyItMatters:
+			"Context windows are finite and expensive. Loading 5 verbose skills at 10K tokens each consumes half of Claude's context window before the user even types a prompt. Budget helps you optimize: trim bloated skills, deduplicate overlapping content, and set token ceilings that CI enforces.",
+		whatItDoes: [
+			"Counts tokens per skill using cl100k_base encoding (within 5% across model families)",
+			"Breaks down token usage per section within each skill",
+			"Detects inter-skill redundancy via 4-gram Jaccard similarity",
+			"Estimates cost across model pricing tiers (Haiku, Sonnet, Opus)",
+			"Saves snapshots and compares against baselines to track budget changes over time",
+			"Enforces token ceilings — exit 1 if total exceeds a configurable threshold",
+		],
+		usage: `npx skills-check budget [dir] [options]`,
+		options: [
+			{ flag: "-s, --skill <name>", description: "Analyze a specific skill" },
+			{ flag: "-d, --detailed", description: "Per-section token breakdown" },
+			{ flag: "--max-tokens <n>", description: "Token ceiling — exit 1 if exceeded" },
+			{ flag: "--save <path>", description: "Save snapshot for future comparison" },
+			{ flag: "--compare <path>", description: "Compare against a saved snapshot" },
+			{ flag: "--model <name>", description: "Pricing model for cost estimates" },
+			{ flag: "-f, --format <type>", description: "Output: terminal or json" },
+		],
+		examples: [
+			{ label: "Analyze all skills", code: "npx skills-check budget" },
+			{ label: "Detailed breakdown", code: "npx skills-check budget --detailed" },
+			{ label: "Enforce a ceiling", code: "npx skills-check budget --max-tokens 50000" },
+			{ label: "Save baseline", code: "npx skills-check budget --save baseline.json" },
+			{ label: "Compare to baseline", code: "npx skills-check budget --compare baseline.json" },
+		],
+		ciTip:
+			"Set --max-tokens in CI to prevent skill bloat. Save a baseline in main and use --compare on PRs to catch token regressions before they merge.",
+	},
+	{
+		slug: "verify",
+		name: "verify",
+		icon: "\u2690",
+		tagline:
+			"Validate that content changes between skill versions match the declared semver bump.",
+		group: "Analysis & Verification",
+		description:
+			"Like cargo semver-checks but for knowledge. Verify that the version bump declared in a skill's frontmatter actually matches the magnitude of content changes. Catches both under-bumps (breaking changes in a patch) and over-bumps (typo fix as a major).",
+		whyItMatters:
+			"Semver is a contract. If an agent pins to ^1.0.0, a breaking change in 1.1.0 violates that contract. Verify catches dishonest or accidental version bumps by analyzing the actual content diff — using both heuristics and optional LLM-assisted semantic analysis.",
+		whatItDoes: [
+			"Retrieves the previous version of each skill from git history",
+			"Computes section-level diffs, package changes, and content similarity scores",
+			"Runs heuristic rules to classify changes as major, minor, or patch",
+			"Optionally uses an LLM for semantic analysis of uncertain cases",
+			"Compares the classified change level against the declared version bump",
+			"Suggests the correct version bump when mismatches are found",
+		],
+		usage: `npx skills-check verify [options]`,
+		options: [
+			{ flag: "-s, --skill <path>", description: "Verify a specific skill file" },
+			{ flag: "-a, --all", description: "Verify all skills with git history" },
+			{ flag: "--suggest", description: "Suggest the correct version bump" },
+			{ flag: "--skip-llm", description: "Heuristic-only mode (no API key needed)" },
+			{ flag: "--provider / --model", description: "LLM provider and model for semantic analysis" },
+			{ flag: "-f, --format <type>", description: "Output: terminal or json" },
+		],
+		examples: [
+			{ label: "Verify all skills", code: "npx skills-check verify --all" },
+			{ label: "Suggest correct bump", code: "npx skills-check verify --suggest" },
+			{ label: "Heuristic only", code: "npx skills-check verify --all --skip-llm" },
+			{ label: "One skill", code: "npx skills-check verify -s ./skills/ai-sdk-core.md" },
+		],
+		ciTip:
+			"Run verify --all --skip-llm in CI for fast, deterministic checks. Use the full LLM-assisted mode locally for nuanced semantic analysis before publishing.",
+	},
+	{
+		slug: "test",
+		name: "test",
+		icon: "\u25B7",
+		tagline:
+			"Run eval test suites declared in skill tests/ directories for regression detection.",
+		group: "Analysis & Verification",
+		description:
+			"Execute eval test suites that verify skills actually work when loaded by an agent. Define test cases in cases.yaml with prompts, expected outcomes, and graders. Track baselines to catch regressions after refresh.",
+		whyItMatters:
+			"A skill can have perfect metadata and pass every lint check, but still produce wrong code when an agent uses it. Test closes this gap by actually running prompts through an agent harness and grading the output — like integration tests for your skill files.",
+		whatItDoes: [
+			"Discovers tests/ directories inside skill directories containing cases.yaml",
+			"Parses declarative test suites with trigger, outcome, style, and regression test types",
+			"Executes prompts through configurable agent harnesses (Claude Code CLI, generic shell)",
+			"Grades results with 7 built-in graders: file-exists, command, contains, not-contains, json-match, package-has, llm-rubric",
+			"Supports custom graders via dynamic module import",
+			"Runs multiple trials per test case with configurable pass thresholds and flaky test detection",
+			"Stores baselines for regression tracking across skill updates",
+		],
+		usage: `npx skills-check test [dir] [options]`,
+		options: [
+			{ flag: "-s, --skill <name>", description: "Test a specific skill" },
+			{ flag: "-t, --type <type>", description: "Filter: trigger, outcome, style, or regression" },
+			{ flag: "--agent <name>", description: "Agent harness: claude-code or generic" },
+			{ flag: "--trials <n>", description: "Number of runs per test case" },
+			{ flag: "--dry", description: "Preview test plan without executing" },
+			{ flag: "--update-baseline", description: "Save results as new baseline" },
+			{ flag: "--ci", description: "CI mode with strict exit codes" },
+			{ flag: "-f, --format <type>", description: "Output: terminal or json" },
+		],
+		examples: [
+			{ label: "Run all tests", code: "npx skills-check test" },
+			{ label: "Test one skill", code: "npx skills-check test -s ai-sdk-core" },
+			{ label: "Outcome tests only", code: "npx skills-check test --type outcome" },
+			{ label: "Preview plan", code: "npx skills-check test --dry" },
+			{ label: "Update baseline", code: "npx skills-check test --update-baseline" },
+		],
+		ciTip:
+			"Run test --ci after refresh to catch regressions. Use --update-baseline on main after verified changes so future PRs compare against the latest known-good results.",
+	},
+	{
+		slug: "init",
+		name: "init",
+		icon: "\u279C",
+		tagline:
+			"Scan a skills directory for SKILL.md files and generate a skills-check.json registry.",
+		group: "Setup",
+		description:
+			"Bootstrap skills-check for your project. Scans a directory for SKILL.md files, prompts for npm package mappings, and generates the skills-check.json registry that all other commands depend on.",
+		whyItMatters:
+			"The skills-check.json registry is the foundation — it maps product names to npm packages and tracks which skill files belong to which product. Without it, check, report, and refresh can't function. Init sets everything up in seconds.",
+		whatItDoes: [
+			"Recursively scans a directory for files matching *SKILL.md or *skill.md",
+			"Extracts product names and version references from frontmatter",
+			"In interactive mode, prompts you to confirm or correct npm package mappings",
+			"In non-interactive mode (-y), auto-detects mappings from frontmatter",
+			"Generates a skills-check.json with $schema reference for editor validation",
+		],
+		usage: `npx skills-check init [dir] [options]`,
+		options: [
+			{ flag: "-y, --yes", description: "Non-interactive mode (auto-detect mappings)" },
+			{ flag: "-o, --output <path>", description: "Output path (default: skills-check.json)" },
+		],
+		examples: [
+			{ label: "Interactive setup", code: "npx skills-check init ./skills" },
+			{ label: "Auto-detect", code: "npx skills-check init ./skills -y" },
+			{ label: "Custom output path", code: "npx skills-check init ./skills -o config/registry.json" },
+		],
+		ciTip:
+			"Run init once locally, then commit skills-check.json to your repo. Other commands will find it automatically.",
+	},
+];
+
+export function getCommandBySlug(slug: string): CommandInfo | undefined {
+	return commands.find((c) => c.slug === slug);
+}
+
+export const commandSlugs = commands.map((c) => c.slug);


### PR DESCRIPTION
## Summary

- **Security hardening** across the codebase based on a comprehensive security review
- **ReDoS protection** for user-supplied regex patterns via a zero-dep safe-regex utility
- **Dedicated command pages** on the web site for all 10 CLI commands

## Security fixes (commit 1 & 2)

- **GitHub Actions expression injection**: moved all `${{ inputs.* }}` from `run:` blocks to `env:` blocks in `action.yml`
- **SHA-pinned Actions**: pinned `actions/checkout` and `actions/setup-node` to commit SHAs in all workflows
- **SSRF protection**: DNS-based private IP filtering in the URL liveness checker (RFC 1918, link-local, cloud metadata)
- **Path traversal prevention**: `safePath()` utility applied to test runner fixture paths, grader file access, and custom grader imports
- **YAML safe schema**: explicit `JSON_SCHEMA` in all `yaml.load()` calls
- **URL encoding**: replaced manual `.replace("/", "%2F")` with `encodeURIComponent()` in npm registry fetches
- **ReDoS protection**: `isSafeRegex()` utility validates user-supplied patterns in policy deny/require rules and test graders
- **Secret leak prevention**: added `.env*` patterns to `.gitignore`

## Web: command detail pages (commit 3)

- Created `packages/web/lib/commands.ts` with structured content for all 10 commands
- Dynamic route at `/commands/[slug]` with `generateStaticParams()` for static generation
- Homepage command cards now link to their detail pages
- Sitemap updated with all command page URLs

## Test plan

- [ ] Verify `npm run build` succeeds across all packages
- [ ] Verify all 10 command pages render at `/commands/{slug}`
- [ ] Verify homepage command cards link to detail pages
- [ ] Verify existing CLI tests pass (`npm test`)
- [ ] Spot-check SSRF protection blocks `169.254.169.254` and private IPs
- [ ] Spot-check `safePath()` rejects `../` traversal attempts