### PR TITLE
Add markdown reporters and refactor threshold logic

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,231 @@
+# Codebase Review: Node.js Best Practices, Security, and Improvements
+
+**Date:** 2026-03-07
+**Scope:** Full codebase review of `skills-check` — packages/cli/src/ (215+ TypeScript files, 91 test files, 688 tests)
+
+---
+
+## Executive Summary
+
+The skills-check codebase is well-architected with strong separation of concerns (extractor/checker/reporter pattern), consistent async patterns, and thoughtful graceful degradation. However, the review identified **4 medium-severity security issues**, **10 Node.js best practice improvements**, and **16 functionality enhancement opportunities**. None are critical blockers, but several should be addressed before the next release.
+
+---
+
+## 1. Security Findings
+
+### 1.1 Medium Severity
+
+**Symlink following in directory walking** — `shared/discovery.ts:24`, `audit/index.ts:24-56`, `testing/runner.ts:47-48`
+- `stat()` follows symlinks, allowing an attacker to place symlinks pointing to arbitrary files outside the intended directory tree. Files get read or copied into test fixtures.
+- **Fix:** Use `lstat()` instead of `stat()`, or reject entries where `lstat()` reports a symlink.
+
+**Unsafe shell string construction in OCI isolation** — `isolation/providers/oci.ts:109, 134`
+- CLI options are interpolated into a `sh -c "..."` string. A malicious `--format` value like `json && rm -rf /` could break out.
+- **Fix:** Use `execFile()` with an args array instead of constructing shell strings.
+
+**Unvalidated `--agent-cmd` template in generic test harness** — `testing/harness/generic.ts:64-65`
+- The `--agent-cmd` template value is passed to `exec()` (which spawns a shell). Only the `{prompt}` placeholder is escaped — the rest of the template can contain arbitrary shell commands.
+- **Fix:** Validate the template structure or use `execFile()` with argument splitting.
+
+**No integrity checking on dynamic imports** — `llm/providers.ts:88, 122`, `testing/graders/custom.ts:9`
+- Dynamic imports of LLM SDKs and custom grader modules have no hash or signature verification. A compromised `node_modules` or malicious SKILL.md `tests/` directory could load arbitrary code.
+- **Fix:** For custom graders, add path validation (restrict to skill directory). For SDKs, document the trust boundary.
+
+### 1.2 Low Severity
+
+**No timeout on npm registry requests** — `npm.ts:20, 40`
+- `fetch()` calls to the npm registry lack an `AbortController` timeout, so they can hang indefinitely on slow networks.
+- **Fix:** Add a 30-second timeout matching the URL checker pattern.
+
+**Cache file permissions not verified** — `audit/cache.ts:34-36`
+- Cached JSON files are read without verifying file ownership. An attacker with local write access to `~/.cache/skills-check/audit/` could inject false "package exists" results.
+- **Fix:** Check `stat().uid === process.getuid()` on cache reads, or set directory permissions to `0700`.
+
+**Policy file discovery walks to filesystem root** — `policy/parser.ts:191-211`
+- The upward directory walk for `.skill-policy.yml` has no stop condition other than reaching `/`. A malicious policy file placed in a parent directory applies silently.
+- **Fix:** Stop at `.git` boundary or filesystem root, and add a `--no-discover-policy` flag.
+
+### 1.3 Positive Security Findings
+
+- SSRF mitigation in URL checker blocks cloud metadata endpoints, private IP ranges, and IPv6 loopback
+- `safePath()` function properly validates relative paths with `resolve()` and boundary checks
+- Only 7 direct dependencies — minimal attack surface
+- API keys checked via `process.env`, never logged or serialized
+- Container isolation mounts skills read-only with writable work directory
+- `safe-regex.ts` validates user-supplied regex patterns for catastrophic backtracking (ReDoS)
+- `mkdtemp()` creates secure temp directories, with best-effort cleanup
+
+---
+
+## 2. Node.js Best Practice Findings
+
+### 2.1 Error Handling
+
+| Issue | Location | Severity |
+|-------|----------|----------|
+| Silent cache failures — no warning if `~/.cache` creation fails | `audit/cache.ts:29, 65` | Medium |
+| Fixture loading silently swallows errors including path traversal | `testing/runner.ts:49-51` | Medium |
+| DNS resolution errors not distinguished (nonexistent vs. network) | `audit/checkers/urls.ts:70` | Low |
+| LLM provider auto-detection shows generic error, not which SDKs were tried | `llm/providers.ts:87-92` | Low |
+
+**Recommendation:** Add `console.warn()` calls in catch blocks where failures affect correctness (cache, fixtures). Preserve the silent-failure pattern only where it's truly advisory.
+
+### 2.2 Resource Leaks
+
+| Issue | Location | Severity |
+|-------|----------|----------|
+| `clearTimeout` not called in URL checker error path | `audit/checkers/urls.ts:98-102` | Medium |
+| Readline interface not closed on error in refresh prompt | `commands/refresh.ts:308-319` | Low |
+| No timeout for `execFile` git operations — can hang indefinitely | `verify/git.ts:13, 42, 51, 60` | Medium |
+
+**Recommendation:** Wrap readline in `try-finally`. Add `clearTimeout` to catch blocks. Add `{ timeout: 30_000 }` to `execFileAsync` calls.
+
+### 2.3 Async Patterns
+
+| Issue | Location | Severity |
+|-------|----------|----------|
+| Minor race condition in `withConcurrencyLimit` — reject can fire after resolve | `registry.ts:91-113, urls.ts:106-136` | Low |
+| File reads duplicated when filtering skills by name in policy | `policy/index.ts:46-50, 64` | Low |
+| Directory walking runs twice per test (before/after snapshots) | `testing/harness/*.ts` | Low |
+
+**Recommendation:** The concurrency limiter race is theoretical but could be fixed by tracking resolution state. The file read duplication is a simple caching opportunity.
+
+### 2.4 TypeScript Safety
+
+| Issue | Location | Severity |
+|-------|----------|----------|
+| Unsafe type assertion of cached data without validation | `audit/checkers/skills-sh-api.ts:103` | Medium |
+| `JSON.parse` can throw `SyntaxError` if cache is corrupted | `audit/cache.ts:47, 83` | Low |
+| Multiple `as Record<string, unknown>` casts without validation | `scanner.ts:54, 62` | Low |
+| Grader type coercion without validation | `testing/runner.ts:187` | Low |
+
+**Recommendation:** Add runtime validation (Zod or manual checks) for cached data and external inputs. The `JSON.parse` in `cache.ts` is already inside a try-catch, but the `skills-sh-api.ts` assertion is not.
+
+### 2.5 Performance
+
+| Issue | Location | Severity |
+|-------|----------|----------|
+| Double `stat()` calls per path in audit/policy discovery | `audit/index.ts:37, policy/index.ts:28` | Low |
+| Re-reading all files when filtering by skill name | `policy/index.ts:46-50` | Low |
+| `memoryCache` Map in registry checker never reset between test runs | `audit/checkers/registry.ts:10` | Low |
+
+**Recommendation:** Minor optimizations. The double-stat is the easiest win — cache the first stat result.
+
+### 2.6 What the Codebase Gets Right
+
+- Consistent ESM with `.js` extensions throughout
+- No circular dependencies — clean module hierarchy
+- `fs/promises` used everywhere (no sync I/O)
+- `path.join()` used correctly (no string concatenation)
+- Lazy initialization for expensive resources (tokenizer, cache dir)
+- Module-level state has proper `reset()` functions for test isolation
+- Proper `promisify` usage for `execFile`
+- Concurrency limiting for network calls (max 5 parallel)
+- Deduplication before network requests
+- `Promise.allSettled()` for non-blocking error collection
+
+---
+
+## 3. Functionality Improvements
+
+### 3.1 Critical: Test Coverage Gaps
+
+Four commands have **no test files** — approximately 750 lines of untested production code:
+
+| Command | File | Lines | Risk |
+|---------|------|-------|------|
+| `check` | `commands/check.ts` | 154 | HIGH — core command, used in action.yml |
+| `report` | `commands/report.ts` | 124 | HIGH — formatting, data aggregation |
+| `init` | `commands/init.ts` | 234 | CRITICAL — interactive mode, 27+ code paths |
+| `refresh` | `commands/refresh.ts` | 234 | CRITICAL — LLM integration, file mutations |
+
+**Recommendation:** Create `check.test.ts`, `report.test.ts`, `init.test.ts`, and `refresh.test.ts` following patterns from `audit.test.ts` and `budget.test.ts`.
+
+### 3.2 High: Reporter Format Inconsistency
+
+Not all commands support all output formats:
+
+| Command | Terminal | JSON | Markdown | SARIF |
+|---------|----------|------|----------|-------|
+| audit | Y | Y | Y | Y |
+| budget | Y | Y | Y | - |
+| lint | Y | Y | **-** | - |
+| verify | Y | Y | **-** | - |
+| policy | Y | Y | **-** | - |
+| test | Y | Y | Y | - |
+| report | - | Y | Y | - |
+
+**Recommendation:** Add markdown reporters for `lint`, `verify`, and `policy`. These are needed for GitHub Action PR comment workflows. SARIF support across commands would enable GitHub Security tab integration.
+
+### 3.3 High: Duplicated Threshold Logic
+
+Severity/threshold comparison logic is duplicated in 3 command files (`audit.ts`, `policy.ts`, `lint.ts`) with identical patterns. Output formatting boilerplate (format switch + file write) appears ~6 times.
+
+**Recommendation:** Create `shared/threshold.ts` with a generic threshold checker and `shared/output.ts` for format routing. Reduces ~180 lines of duplication.
+
+### 3.4 High: No Global Configuration File
+
+All settings require CLI flags. No `.skillscheckrc.yml` or equivalent exists for persisting project defaults.
+
+**Recommendation:** Implement a 3-level config cascade: CLI flags > project config > user config. This would eliminate repeated flag entry and simplify CI integration.
+
+### 3.5 Medium: Missing Progress Feedback
+
+Long-running commands (`audit` 30s+, `test` 1-5min, `verify` 30s+) provide no progress indicators. Even `--verbose` lacks step-by-step feedback.
+
+**Recommendation:** Add structured progress output: file counts, step indicators, completion percentages. Use the existing `chalk` dependency for terminal formatting.
+
+### 3.6 Medium: Inconsistent `--quiet`/`--verbose` Support
+
+Only `audit` and `verify` support both `--quiet` and `--verbose`. Other commands support neither or only one.
+
+**Recommendation:** Standardize across all commands. All should accept `--quiet` (suppress output) and `--verbose` (show progress), with mutual exclusion validation.
+
+### 3.7 Medium: Complex Orchestrator Functions
+
+5 orchestrator functions bypass Biome's cognitive complexity checks (`// biome-ignore`). The largest is `commands/refresh.ts` at 234 lines.
+
+**Recommendation:** Extract sub-steps into helper functions. For example, `runAudit()` could be split into `discoverAndLoadSkills()`, `selectCheckers()`, `processFiles()`, and `aggregateFindings()`.
+
+### 3.8 Medium: No Programmatic API
+
+The package only exports a CLI binary (`"bin": { "skills-check": ... }`). Core functions like `runAudit()`, `runBudget()`, etc. are not importable as a library.
+
+**Recommendation:** Add `"exports"` to `package.json` and create an API entry point. Enables IDE integrations, custom dashboards, and monorepo tooling.
+
+### 3.9 Low: Cross-Command Integration
+
+- **Health check composite**: A `skills-check health` command running `audit` + `lint` + `budget` + `policy` would serve as a single CI gate.
+- **Budget trending**: No way to compare multiple snapshots or track budget growth over time.
+- **Test baseline from CI**: No workflow for generating baselines in CI pipelines.
+
+### 3.10 Low: Incomplete Action Outputs
+
+The GitHub Action (`action.yml`) exposes only 4 outputs (`stale-count`, `issue-number`, `report`, `results`). Per-command structured outputs (finding counts, token totals, pass/fail) would enable richer workflow conditionals.
+
+---
+
+## Prioritized Improvement Roadmap
+
+### Phase 1 — Immediate (Security + Regression Risk)
+1. Replace `stat()` with `lstat()` in discovery/test runner (symlink fix)
+2. Use `execFile()` args array in OCI isolation provider (injection fix)
+3. Add `AbortController` timeout to npm registry fetch calls
+4. Write `check.test.ts` and `report.test.ts`
+5. Add `clearTimeout` to URL checker error path
+
+### Phase 2 — Next Release (Quality + UX)
+1. Write `init.test.ts` and `refresh.test.ts`
+2. Add markdown reporters for `lint`, `policy`, `verify`
+3. Extract duplicated threshold logic to `shared/threshold.ts`
+4. Add git operation timeouts in `verify/git.ts`
+5. Add readline try-finally in `commands/refresh.ts`
+6. Standardize `--quiet`/`--verbose` across all commands
+
+### Phase 3 — Future (Extensibility)
+1. Implement `.skillscheckrc.yml` global configuration
+2. Add progress indicators for long-running commands
+3. Export programmatic API from package
+4. Add composite `health` command
+5. Expand action.yml with per-command outputs
+6. Add SARIF reporters for all commands

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,25 @@ outputs:
   results:
     description: "JSON object with exit codes from each command that was run"
     value: ${{ steps.summary.outputs.results }}
+  # ── Per-command structured outputs ────────────────────────────────
+  audit-findings:
+    description: "Total number of audit findings"
+    value: ${{ steps.audit.outputs.finding_count }}
+  lint-findings:
+    description: "Total number of lint findings"
+    value: ${{ steps.lint.outputs.finding_count }}
+  budget-total-tokens:
+    description: "Total token count across all skills"
+    value: ${{ steps.budget.outputs.total_tokens }}
+  policy-findings:
+    description: "Total number of policy findings"
+    value: ${{ steps.policy.outputs.finding_count }}
+  verify-failed:
+    description: "Number of verify mismatches"
+    value: ${{ steps.verify.outputs.failed_count }}
+  test-failed:
+    description: "Number of failed test cases"
+    value: ${{ steps.test.outputs.failed_count }}
 
 runs:
   using: "composite"
@@ -205,14 +224,17 @@ runs:
         INPUT_AUDIT_FAIL_ON: ${{ inputs.audit-fail-on }}
       run: |
         set +e
-        npx --yes skills-check audit "$INPUT_SKILLS_DIR" \
+        AUDIT_OUTPUT=$(npx --yes skills-check audit "$INPUT_SKILLS_DIR" \
           --format json \
-          --fail-on "$INPUT_AUDIT_FAIL_ON" \
-          --quiet
+          --fail-on "$INPUT_AUDIT_FAIL_ON" 2>&1)
         EXIT_CODE=$?
         set -e
 
         echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+        # Extract finding count from JSON output
+        FINDING_COUNT=$(echo "$AUDIT_OUTPUT" | jq '.summary.total // 0' 2>/dev/null || echo "0")
+        echo "finding_count=${FINDING_COUNT}" >> "$GITHUB_OUTPUT"
 
         if [ "$EXIT_CODE" -eq 2 ]; then
           echo "::error::skills-check audit: configuration error"
@@ -233,14 +255,18 @@ runs:
         INPUT_LINT_FAIL_ON: ${{ inputs.lint-fail-on }}
       run: |
         set +e
-        npx --yes skills-check lint "$INPUT_SKILLS_DIR" \
+        LINT_OUTPUT=$(npx --yes skills-check lint "$INPUT_SKILLS_DIR" \
           --ci \
           --format json \
-          --fail-on "$INPUT_LINT_FAIL_ON"
+          --fail-on "$INPUT_LINT_FAIL_ON" 2>&1)
         EXIT_CODE=$?
         set -e
 
         echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+        # Extract finding count from JSON output
+        FINDING_COUNT=$(echo "$LINT_OUTPUT" | jq '.findings | length // 0' 2>/dev/null || echo "0")
+        echo "finding_count=${FINDING_COUNT}" >> "$GITHUB_OUTPUT"
 
         if [ "$EXIT_CODE" -eq 2 ]; then
           echo "::error::skills-check lint: configuration error"
@@ -266,11 +292,15 @@ runs:
         fi
 
         set +e
-        npx --yes skills-check budget "${BUDGET_ARGS[@]}"
+        BUDGET_OUTPUT=$(npx --yes skills-check budget "${BUDGET_ARGS[@]}" 2>&1)
         EXIT_CODE=$?
         set -e
 
         echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+        # Extract total tokens from JSON output
+        TOTAL_TOKENS=$(echo "$BUDGET_OUTPUT" | jq '.totalTokens // 0' 2>/dev/null || echo "0")
+        echo "total_tokens=${TOTAL_TOKENS}" >> "$GITHUB_OUTPUT"
 
         if [ "$EXIT_CODE" -eq 2 ]; then
           echo "::error::skills-check budget: configuration error"
@@ -298,11 +328,15 @@ runs:
         POLICY_ARGS+=(--fail-on "$INPUT_POLICY_FAIL_ON")
 
         set +e
-        npx --yes skills-check policy check "${POLICY_ARGS[@]}"
+        POLICY_OUTPUT=$(npx --yes skills-check policy check "${POLICY_ARGS[@]}" 2>&1)
         EXIT_CODE=$?
         set -e
 
         echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+        # Extract finding count from JSON output
+        FINDING_COUNT=$(echo "$POLICY_OUTPUT" | jq '.findings | length // 0' 2>/dev/null || echo "0")
+        echo "finding_count=${FINDING_COUNT}" >> "$GITHUB_OUTPUT"
 
         if [ "$EXIT_CODE" -eq 2 ]; then
           echo "::error::skills-check policy: configuration error"
@@ -320,11 +354,15 @@ runs:
       shell: bash
       run: |
         set +e
-        npx --yes skills-check verify --all --format json --skip-llm --quiet
+        VERIFY_OUTPUT=$(npx --yes skills-check verify --all --format json --skip-llm 2>&1)
         EXIT_CODE=$?
         set -e
 
         echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+        # Extract failed count from JSON output
+        FAILED_COUNT=$(echo "$VERIFY_OUTPUT" | jq '.summary.failed // 0' 2>/dev/null || echo "0")
+        echo "failed_count=${FAILED_COUNT}" >> "$GITHUB_OUTPUT"
 
         if [ "$EXIT_CODE" -eq 2 ]; then
           echo "::error::skills-check verify: configuration error"
@@ -344,11 +382,15 @@ runs:
         INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
       run: |
         set +e
-        npx --yes skills-check test "$INPUT_SKILLS_DIR" --ci --format json
+        TEST_OUTPUT=$(npx --yes skills-check test "$INPUT_SKILLS_DIR" --ci --format json 2>&1)
         EXIT_CODE=$?
         set -e
 
         echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+        # Extract failed count from JSON output (sum of failed across all suites)
+        FAILED_COUNT=$(echo "$TEST_OUTPUT" | jq '[.[].failed] | add // 0' 2>/dev/null || echo "0")
+        echo "failed_count=${FAILED_COUNT}" >> "$GITHUB_OUTPUT"
 
         if [ "$EXIT_CODE" -eq 2 ]; then
           echo "::error::skills-check test: configuration error"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "skills-check-monorepo",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skills-check-monorepo",
+      "version": "1.2.0",
       "workspaces": [
         "packages/*"
       ],
@@ -16,8 +18,7 @@
       },
       "engines": {
         "node": ">=22"
-      },
-      "version": "1.2.0"
+      }
     },
     "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.53",
@@ -3868,6 +3869,5 @@
         "typescript": "^5.8.0"
       }
     }
-  },
-  "version": "1.2.0"
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,13 @@
   "bin": {
     "skills-check": "./dist/index.js"
   },
+  "exports": {
+    ".": "./dist/index.js",
+    "./api": {
+      "types": "./dist/api.d.ts",
+      "import": "./dist/api.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,0 +1,36 @@
+/**
+ * Programmatic API for skills-check.
+ *
+ * Provides importable functions for IDE integrations,
+ * custom dashboards, and monorepo tooling.
+ *
+ * @example
+ * ```ts
+ * import { runAudit, runLint, runBudget } from "skills-check/api";
+ *
+ * const auditReport = await runAudit(["./skills"]);
+ * const lintReport = await runLint(["./skills"]);
+ * const budgetReport = await runBudget(["./skills"]);
+ * ```
+ */
+
+// biome-ignore lint/performance/noBarrelFile: intentional public API entry point
+export { runAudit } from "./audit/index.js";
+// Types
+export type { AuditFinding, AuditOptions, AuditReport } from "./audit/types.js";
+export { runBudget } from "./budget/index.js";
+export type { BudgetOptions, BudgetReport } from "./budget/types.js";
+export { runLint } from "./lint/index.js";
+export type { LintFinding, LintOptions, LintReport } from "./lint/types.js";
+export { runPolicyCheck } from "./policy/index.js";
+export type { PolicyReport, SkillPolicy } from "./policy/types.js";
+export type { SkillsCheckConfig } from "./shared/config.js";
+// Shared utilities
+export { loadConfig } from "./shared/config.js";
+export { discoverSkillFiles } from "./shared/discovery.js";
+export type { Progress } from "./shared/progress.js";
+export { createProgress } from "./shared/progress.js";
+export { runTests } from "./testing/index.js";
+export type { TestOptions, TestReport } from "./testing/types.js";
+export { runVerify } from "./verify/index.js";
+export type { VerifyOptions, VerifyReport, VerifyResult } from "./verify/types.js";

--- a/packages/cli/src/audit/checkers/urls.ts
+++ b/packages/cli/src/audit/checkers/urls.ts
@@ -86,17 +86,20 @@ async function checkUrlLiveness(url: string): Promise<{ ok: boolean; status?: nu
 		const controller = new AbortController();
 		const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
-		const response = await fetch(url, {
-			method: "HEAD",
-			signal: controller.signal,
-			redirect: "follow",
-			headers: {
-				"User-Agent": "skills-check-cli (https://skillscheck.ai)",
-			},
-		});
+		try {
+			const response = await fetch(url, {
+				method: "HEAD",
+				signal: controller.signal,
+				redirect: "follow",
+				headers: {
+					"User-Agent": "skills-check-cli (https://skillscheck.ai)",
+				},
+			});
 
-		clearTimeout(timer);
-		return { ok: response.ok, status: response.status };
+			return { ok: response.ok, status: response.status };
+		} finally {
+			clearTimeout(timer);
+		}
 	} catch {
 		// Network error, timeout, or DNS failure
 		return { ok: false };

--- a/packages/cli/src/budget/reporters/sarif.ts
+++ b/packages/cli/src/budget/reporters/sarif.ts
@@ -1,0 +1,74 @@
+import type { BudgetReport } from "../types.js";
+
+function buildRules(report: BudgetReport): object[] {
+	const rules: object[] = [];
+
+	if (report.redundancy.length > 0) {
+		rules.push({
+			id: "skills-check/budget/redundancy",
+			shortDescription: { text: "Skill content redundancy detected" },
+			defaultConfiguration: { level: "warning" },
+		});
+	}
+
+	return rules;
+}
+
+function buildResults(report: BudgetReport): object[] {
+	return report.redundancy.map((r) => ({
+		ruleId: "skills-check/budget/redundancy",
+		level: "warning" as const,
+		message: {
+			text: `${r.nameA} and ${r.nameB} share ${Math.round(r.similarity * 100)}% similarity (~${r.overlapTokens} tokens). ${r.suggestion}`,
+		},
+		locations: [
+			{
+				physicalLocation: {
+					artifactLocation: { uri: r.skillA },
+					region: { startLine: 1 },
+				},
+			},
+		],
+		relatedLocations: [
+			{
+				id: 1,
+				physicalLocation: {
+					artifactLocation: { uri: r.skillB },
+					region: { startLine: 1 },
+				},
+				message: { text: `Related skill: ${r.nameB}` },
+			},
+		],
+		properties: {
+			similarity: r.similarity,
+			overlapTokens: r.overlapTokens,
+		},
+	}));
+}
+
+export function formatBudgetSarif(report: BudgetReport): string {
+	const sarif = {
+		$schema: "https://json.schemastore.org/sarif-2.1.0.json",
+		version: "2.1.0",
+		runs: [
+			{
+				tool: {
+					driver: {
+						name: "skills-check/budget",
+						informationUri: "https://skillscheck.ai",
+						rules: buildRules(report),
+					},
+				},
+				results: buildResults(report),
+				invocations: [
+					{
+						executionSuccessful: true,
+						endTimeUtc: report.generatedAt,
+					},
+				],
+			},
+		],
+	};
+
+	return JSON.stringify(sarif, null, 2);
+}

--- a/packages/cli/src/budget/types.ts
+++ b/packages/cli/src/budget/types.ts
@@ -89,7 +89,7 @@ export interface BudgetOptions {
 	/** Show per-section breakdown. */
 	detailed?: boolean;
 	/** Output format. */
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	/** Maximum tokens threshold for CI. */
 	maxTokens?: number;
 	/** Model for cost estimation. */

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,4 +1,3 @@
-import { writeFile } from "node:fs/promises";
 import chalk from "chalk";
 import { runAudit } from "../audit/index.js";
 import { formatJson } from "../audit/reporters/json.js";
@@ -7,6 +6,7 @@ import { formatSarif } from "../audit/reporters/sarif.js";
 import { formatTerminal } from "../audit/reporters/terminal.js";
 import type { AuditOptions, AuditSeverity } from "../audit/types.js";
 import type { IsolationChoice } from "../isolation/types.js";
+import { auditThreshold, formatAndOutput } from "../shared/index.js";
 
 interface AuditCommandOptions {
 	failOn?: string;
@@ -22,19 +22,6 @@ interface AuditCommandOptions {
 	verbose?: boolean;
 }
 
-const SEVERITY_ORDER: Record<AuditSeverity, number> = {
-	critical: 0,
-	high: 1,
-	medium: 2,
-	low: 3,
-};
-
-const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
-
-function meetsThreshold(severity: AuditSeverity, threshold: AuditSeverity): boolean {
-	return SEVERITY_ORDER[severity] <= SEVERITY_ORDER[threshold];
-}
-
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 export async function auditCommand(dir: string, options: AuditCommandOptions): Promise<number> {
 	if (options.verbose && options.quiet) {
@@ -43,9 +30,11 @@ export async function auditCommand(dir: string, options: AuditCommandOptions): P
 	}
 
 	const failOn = (options.failOn ?? "high") as AuditSeverity;
-	if (!VALID_SEVERITIES.has(failOn)) {
+	if (!auditThreshold.validValues.has(failOn)) {
 		console.error(
-			chalk.red(`Invalid --fail-on value: "${options.failOn}". Use: critical, high, medium, low`)
+			chalk.red(
+				`Invalid --fail-on value: "${options.failOn}". Use: ${[...auditThreshold.validValues].join(", ")}`
+			)
 		);
 		return 2;
 	}
@@ -171,35 +160,21 @@ export async function auditCommand(dir: string, options: AuditCommandOptions): P
 		);
 	}
 
-	// Format output
-	const format = options.format ?? "terminal";
-	let output: string;
-	switch (format) {
-		case "json":
-			output = formatJson(report);
-			break;
-		case "markdown":
-			output = formatMarkdown(report);
-			break;
-		case "sarif":
-			output = formatSarif(report);
-			break;
-		default:
-			output = formatTerminal(report);
-			break;
-	}
-
-	// Write to file or stdout
-	if (options.output) {
-		await writeFile(options.output, output, "utf-8");
-		if (!options.quiet) {
-			console.error(chalk.green(`Report written to ${options.output}`));
+	// Format and write output
+	await formatAndOutput(
+		report,
+		{ format: options.format, output: options.output, quiet: options.quiet },
+		{
+			terminal: formatTerminal,
+			json: formatJson,
+			markdown: formatMarkdown,
+			sarif: formatSarif,
 		}
-	} else if (!options.quiet) {
-		console.log(output);
-	}
+	);
 
 	// Determine exit code based on threshold
-	const hasFailingFindings = report.findings.some((f) => meetsThreshold(f.severity, failOn));
+	const hasFailingFindings = report.findings.some((f) =>
+		auditThreshold.meetsThreshold(f.severity, failOn)
+	);
 	return hasFailingFindings ? 1 : 0;
 }

--- a/packages/cli/src/commands/budget.ts
+++ b/packages/cli/src/commands/budget.ts
@@ -5,13 +5,14 @@ import { getAvailableModels } from "../budget/cost.js";
 import { runBudget } from "../budget/index.js";
 import { formatComparisonJson, formatJson } from "../budget/reporters/json.js";
 import { formatComparisonMarkdown, formatMarkdown } from "../budget/reporters/markdown.js";
+import { formatBudgetSarif } from "../budget/reporters/sarif.js";
 import { formatComparisonTerminal, formatTerminal } from "../budget/reporters/terminal.js";
 import type { BudgetOptions } from "../budget/types.js";
 
 interface BudgetCommandOptions {
 	compare?: string;
 	detailed?: boolean;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	maxTokens?: string;
 	model?: string;
 	output?: string;
@@ -86,6 +87,9 @@ export async function budgetCommand(dir: string, options: BudgetCommandOptions):
 				break;
 			case "markdown":
 				output = formatMarkdown(report, options.detailed);
+				break;
+			case "sarif":
+				output = formatBudgetSarif(report);
 				break;
 			default:
 				output = formatTerminal(report, options.detailed);

--- a/packages/cli/src/commands/budget.ts
+++ b/packages/cli/src/commands/budget.ts
@@ -15,11 +15,19 @@ interface BudgetCommandOptions {
 	maxTokens?: string;
 	model?: string;
 	output?: string;
+	quiet?: boolean;
 	save?: string;
 	skill?: string;
+	verbose?: boolean;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 export async function budgetCommand(dir: string, options: BudgetCommandOptions): Promise<number> {
+	if (options.verbose && options.quiet) {
+		console.error(chalk.red("Cannot use --verbose and --quiet together."));
+		return 2;
+	}
+
 	// Validate model if provided
 	if (options.model) {
 		const available = getAvailableModels();
@@ -63,30 +71,34 @@ export async function budgetCommand(dir: string, options: BudgetCommandOptions):
 	// Save snapshot if requested
 	if (options.save) {
 		await saveSnapshot(report, options.save);
-		console.error(chalk.green(`Snapshot saved to ${options.save}`));
+		if (!options.quiet) {
+			console.error(chalk.green(`Snapshot saved to ${options.save}`));
+		}
 	}
 
 	// Format output
-	const format = options.format ?? "terminal";
-	let output: string;
-	switch (format) {
-		case "json":
-			output = formatJson(report);
-			break;
-		case "markdown":
-			output = formatMarkdown(report, options.detailed);
-			break;
-		default:
-			output = formatTerminal(report, options.detailed);
-			break;
-	}
+	if (!options.quiet) {
+		const format = options.format ?? "terminal";
+		let output: string;
+		switch (format) {
+			case "json":
+				output = formatJson(report);
+				break;
+			case "markdown":
+				output = formatMarkdown(report, options.detailed);
+				break;
+			default:
+				output = formatTerminal(report, options.detailed);
+				break;
+		}
 
-	// Write to file or stdout
-	if (options.output) {
-		await writeFile(options.output, output, "utf-8");
-		console.error(chalk.green(`Report written to ${options.output}`));
-	} else {
-		console.log(output);
+		// Write to file or stdout
+		if (options.output) {
+			await writeFile(options.output, output, "utf-8");
+			console.error(chalk.green(`Report written to ${options.output}`));
+		} else {
+			console.log(output);
+		}
 	}
 
 	// Check max-tokens threshold
@@ -127,27 +139,29 @@ async function handleComparison(dir: string, options: BudgetCommandOptions): Pro
 
 	const diffs = compareSnapshots(baseline, currentSnapshot);
 
-	// Format output
-	const format = options.format ?? "terminal";
-	let output: string;
-	switch (format) {
-		case "json":
-			output = formatComparisonJson(diffs);
-			break;
-		case "markdown":
-			output = formatComparisonMarkdown(diffs);
-			break;
-		default:
-			output = formatComparisonTerminal(diffs);
-			break;
-	}
+	if (!options.quiet) {
+		// Format output
+		const format = options.format ?? "terminal";
+		let output: string;
+		switch (format) {
+			case "json":
+				output = formatComparisonJson(diffs);
+				break;
+			case "markdown":
+				output = formatComparisonMarkdown(diffs);
+				break;
+			default:
+				output = formatComparisonTerminal(diffs);
+				break;
+		}
 
-	// Write to file or stdout
-	if (options.output) {
-		await writeFile(options.output, output, "utf-8");
-		console.error(chalk.green(`Comparison written to ${options.output}`));
-	} else {
-		console.log(output);
+		// Write to file or stdout
+		if (options.output) {
+			await writeFile(options.output, output, "utf-8");
+			console.error(chalk.green(`Comparison written to ${options.output}`));
+		} else {
+			console.log(output);
+		}
 	}
 
 	return 0;

--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -101,7 +101,9 @@ describe("checkCommand", () => {
 	});
 
 	it("handles fetch errors gracefully", async () => {
-		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", new Error("Network error")]]));
+		mockedFetchLatestVersions.mockResolvedValue(
+			new Map<string, string | Error>([["next", new Error("Network error")]])
+		);
 		const code = await checkCommand({});
 		expect(code).toBe(0);
 		expect(console.error).toHaveBeenCalled();

--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies to avoid filesystem/network
+vi.mock("../npm.js", () => ({
+	fetchLatestVersions: vi.fn(),
+}));
+
+vi.mock("../registry.js", () => ({
+	loadRegistry: vi.fn(),
+}));
+
+import { fetchLatestVersions } from "../npm.js";
+import { loadRegistry } from "../registry.js";
+import type { Registry } from "../types.js";
+import { checkCommand } from "./check.js";
+
+const mockedLoadRegistry = vi.mocked(loadRegistry);
+const mockedFetchLatestVersions = vi.mocked(fetchLatestVersions);
+
+function makeRegistry(overrides?: Partial<Registry>): Registry {
+	return {
+		$schema: "https://skillscheck.ai/schema.json",
+		version: 1,
+		lastCheck: "2026-01-01T00:00:00.000Z",
+		products: {
+			nextjs: {
+				displayName: "Next.js",
+				package: "next",
+				verifiedVersion: "14.0.0",
+				verifiedAt: "2026-01-01T00:00:00.000Z",
+				skills: ["nextjs-routing"],
+			},
+		},
+		...overrides,
+	};
+}
+
+describe("checkCommand", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedLoadRegistry.mockResolvedValue(makeRegistry());
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", "15.0.0"]]));
+		vi.spyOn(console, "log").mockImplementation(() => {
+			/* intentionally empty */
+		});
+		vi.spyOn(console, "error").mockImplementation(() => {
+			/* intentionally empty */
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns 0 when all products are current", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", "14.0.0"]]));
+		const code = await checkCommand({});
+		expect(code).toBe(0);
+	});
+
+	it("returns 0 for stale products without --ci", async () => {
+		const code = await checkCommand({});
+		expect(code).toBe(0);
+	});
+
+	it("returns 1 for stale products with --ci", async () => {
+		const code = await checkCommand({ ci: true });
+		expect(code).toBe(1);
+	});
+
+	it("outputs JSON when --json is set", async () => {
+		const logSpy = vi.mocked(console.log);
+		await checkCommand({ json: true });
+		expect(logSpy).toHaveBeenCalled();
+		const output = logSpy.mock.calls[0][0] as string;
+		const parsed = JSON.parse(output);
+		expect(parsed).toBeInstanceOf(Array);
+		expect(parsed[0].product).toBe("nextjs");
+		expect(parsed[0].stale).toBe(true);
+	});
+
+	it("returns 1 with --json and --ci when stale", async () => {
+		const code = await checkCommand({ json: true, ci: true });
+		expect(code).toBe(1);
+	});
+
+	it("returns 0 with --json and --ci when current", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", "14.0.0"]]));
+		const code = await checkCommand({ json: true, ci: true });
+		expect(code).toBe(0);
+	});
+
+	it("returns 2 when product not found", async () => {
+		const code = await checkCommand({ product: "nonexistent" });
+		expect(code).toBe(2);
+	});
+
+	it("filters to single product with --product", async () => {
+		const code = await checkCommand({ product: "nextjs" });
+		expect(code).toBe(0);
+	});
+
+	it("handles fetch errors gracefully", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", new Error("Network error")]]));
+		const code = await checkCommand({});
+		expect(code).toBe(0);
+		expect(console.error).toHaveBeenCalled();
+	});
+
+	it("handles missing version data gracefully", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(new Map());
+		const code = await checkCommand({});
+		expect(code).toBe(0);
+		expect(console.error).toHaveBeenCalled();
+	});
+
+	it("warns on coerced version", async () => {
+		mockedLoadRegistry.mockResolvedValue(
+			makeRegistry({
+				products: {
+					nextjs: {
+						displayName: "Next.js",
+						package: "next",
+						verifiedVersion: "v14-beta",
+						verifiedAt: "2026-01-01T00:00:00.000Z",
+						skills: ["nextjs-routing"],
+					},
+				},
+			})
+		);
+		await checkCommand({});
+		const errorCalls = vi.mocked(console.error).mock.calls.map((c) => String(c[0]));
+		expect(errorCalls.some((c) => c.includes("coerced"))).toBe(true);
+	});
+
+	it("shows current products with --verbose", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", "14.0.0"]]));
+		await checkCommand({ verbose: true });
+		const logCalls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+		expect(logCalls.some((c) => c.includes("CURRENT"))).toBe(true);
+	});
+
+	it("loads custom registry path", async () => {
+		await checkCommand({ registry: "custom.json" });
+		expect(mockedLoadRegistry).toHaveBeenCalledWith("custom.json");
+	});
+
+	it("classifies severity correctly", async () => {
+		const logSpy = vi.mocked(console.log);
+		await checkCommand({ json: true });
+		const output = logSpy.mock.calls[0][0] as string;
+		const parsed = JSON.parse(output);
+		expect(parsed[0].severity).toBe("major");
+	});
+});

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -8,6 +8,7 @@ interface CheckOptions {
 	ci?: boolean;
 	json?: boolean;
 	product?: string;
+	quiet?: boolean;
 	registry?: string;
 	verbose?: boolean;
 }
@@ -27,6 +28,11 @@ function getSeverityColor(severity: string) {
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 export async function checkCommand(options: CheckOptions): Promise<number> {
+	if (options.verbose && options.quiet) {
+		console.error(chalk.red("Cannot use --verbose and --quiet together."));
+		return 2;
+	}
+
 	const registry = await loadRegistry(options.registry);
 
 	// Filter to single product if requested
@@ -96,7 +102,9 @@ export async function checkCommand(options: CheckOptions): Promise<number> {
 
 	// JSON output
 	if (options.json) {
-		console.log(JSON.stringify(results, null, 2));
+		if (!options.quiet) {
+			console.log(JSON.stringify(results, null, 2));
+		}
 		const hasStale = results.some((r) => r.stale);
 		return options.ci && hasStale ? 1 : 0;
 	}
@@ -104,6 +112,13 @@ export async function checkCommand(options: CheckOptions): Promise<number> {
 	// Human-readable output
 	const stale = results.filter((r) => r.stale);
 	const current = results.filter((r) => !r.stale);
+
+	if (options.quiet) {
+		if (options.ci && stale.length > 0) {
+			return 1;
+		}
+		return 0;
+	}
 
 	console.log();
 	console.log(chalk.bold("skills-check"));

--- a/packages/cli/src/commands/health.test.ts
+++ b/packages/cli/src/commands/health.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../audit/index.js", () => ({
+	runAudit: vi.fn().mockResolvedValue({
+		findings: [],
+		summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0 },
+		files: 1,
+	}),
+}));
+
+vi.mock("../lint/index.js", () => ({
+	runLint: vi.fn().mockResolvedValue({
+		findings: [],
+		files: 1,
+	}),
+}));
+
+vi.mock("../budget/index.js", () => ({
+	runBudget: vi.fn().mockResolvedValue({
+		skills: [],
+		totalTokens: 5000,
+		cost: { model: "claude-sonnet", inputCostPer1k: 0.003, totalInputCost: 0.015 },
+		redundancy: [],
+		generatedAt: "2025-01-01T00:00:00.000Z",
+	}),
+}));
+
+vi.mock("../policy/parser.js", () => ({
+	discoverPolicyFile: vi.fn().mockResolvedValue(null),
+	loadPolicyFile: vi.fn(),
+}));
+
+import { healthCommand } from "./health.js";
+
+describe("healthCommand", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+	});
+
+	it("returns 0 when all checks pass", async () => {
+		const code = await healthCommand(".", {});
+		expect(code).toBe(0);
+	});
+
+	it("rejects --verbose and --quiet together", async () => {
+		const code = await healthCommand(".", { verbose: true, quiet: true });
+		expect(code).toBe(2);
+	});
+
+	it("outputs JSON format", async () => {
+		const code = await healthCommand(".", { format: "json" });
+		expect(code).toBe(0);
+		expect(logSpy).toHaveBeenCalled();
+		const output = JSON.parse(logSpy.mock.calls[0][0]);
+		expect(output.results).toBeDefined();
+		expect(output.results.length).toBeGreaterThan(0);
+	});
+
+	it("skips commands when skip flags provided", async () => {
+		const code = await healthCommand(".", {
+			skipAudit: true,
+			skipLint: true,
+			skipBudget: true,
+			skipPolicy: true,
+			format: "json",
+		});
+		expect(code).toBe(0);
+		const output = JSON.parse(logSpy.mock.calls[0][0]);
+		expect(output.results).toHaveLength(0);
+	});
+
+	it("suppresses output with --quiet", async () => {
+		const code = await healthCommand(".", { quiet: true });
+		expect(code).toBe(0);
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+
+	it("returns 1 when budget exceeds max-tokens", async () => {
+		const code = await healthCommand(".", { maxTokens: "100" });
+		expect(code).toBe(1);
+	});
+});

--- a/packages/cli/src/commands/health.ts
+++ b/packages/cli/src/commands/health.ts
@@ -1,0 +1,173 @@
+import chalk from "chalk";
+import { runAudit } from "../audit/index.js";
+import type { AuditOptions, AuditSeverity } from "../audit/types.js";
+import { runBudget } from "../budget/index.js";
+import type { BudgetOptions } from "../budget/types.js";
+import { runLint } from "../lint/index.js";
+import type { LintOptions } from "../lint/types.js";
+import { runPolicyCheck } from "../policy/index.js";
+import { discoverPolicyFile, loadPolicyFile } from "../policy/parser.js";
+import { auditThreshold, lintThreshold, policyThreshold } from "../shared/index.js";
+
+interface HealthCommandOptions {
+	format?: "terminal" | "json";
+	maxTokens?: string;
+	output?: string;
+	quiet?: boolean;
+	skipAudit?: boolean;
+	skipBudget?: boolean;
+	skipLint?: boolean;
+	skipPolicy?: boolean;
+	verbose?: boolean;
+}
+
+interface HealthResult {
+	command: string;
+	exitCode: number;
+	summary: string;
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
+export async function healthCommand(dir: string, options: HealthCommandOptions): Promise<number> {
+	if (options.verbose && options.quiet) {
+		console.error(chalk.red("Cannot use --verbose and --quiet together."));
+		return 2;
+	}
+
+	const results: HealthResult[] = [];
+
+	// 1. Lint
+	if (!options.skipLint) {
+		if (options.verbose) {
+			console.error(chalk.dim("Running lint..."));
+		}
+		try {
+			const lintOptions: LintOptions = { failOn: "error" };
+			const report = await runLint([dir], lintOptions);
+			const hasErrors = report.findings.some((f) =>
+				lintThreshold.meetsThreshold(f.level as "error" | "warning", "error")
+			);
+			results.push({
+				command: "lint",
+				exitCode: hasErrors ? 1 : 0,
+				summary: `${report.findings.length} finding(s)`,
+			});
+		} catch (err) {
+			results.push({
+				command: "lint",
+				exitCode: 2,
+				summary: `error: ${err instanceof Error ? err.message : String(err)}`,
+			});
+		}
+	}
+
+	// 2. Audit
+	if (!options.skipAudit) {
+		if (options.verbose) {
+			console.error(chalk.dim("Running audit..."));
+		}
+		try {
+			const auditOptions: AuditOptions = { failOn: "high" as AuditSeverity, skipUrls: true };
+			const report = await runAudit([dir], auditOptions);
+			const hasFindings = report.findings.some((f) =>
+				auditThreshold.meetsThreshold(f.severity, "high" as AuditSeverity)
+			);
+			results.push({
+				command: "audit",
+				exitCode: hasFindings ? 1 : 0,
+				summary: `${report.summary.total} finding(s)`,
+			});
+		} catch (err) {
+			results.push({
+				command: "audit",
+				exitCode: 2,
+				summary: `error: ${err instanceof Error ? err.message : String(err)}`,
+			});
+		}
+	}
+
+	// 3. Budget
+	if (!options.skipBudget) {
+		if (options.verbose) {
+			console.error(chalk.dim("Running budget..."));
+		}
+		try {
+			const maxTokens = options.maxTokens ? Number.parseInt(options.maxTokens, 10) : undefined;
+			const budgetOptions: BudgetOptions = { maxTokens };
+			const report = await runBudget([dir], budgetOptions);
+			const overBudget = maxTokens !== undefined && report.totalTokens > maxTokens;
+			results.push({
+				command: "budget",
+				exitCode: overBudget ? 1 : 0,
+				summary: `${report.totalTokens.toLocaleString()} tokens`,
+			});
+		} catch (err) {
+			results.push({
+				command: "budget",
+				exitCode: 2,
+				summary: `error: ${err instanceof Error ? err.message : String(err)}`,
+			});
+		}
+	}
+
+	// 4. Policy
+	if (!options.skipPolicy) {
+		if (options.verbose) {
+			console.error(chalk.dim("Running policy check..."));
+		}
+		try {
+			const policyPath = await discoverPolicyFile(dir);
+			if (policyPath) {
+				const policy = await loadPolicyFile(policyPath);
+				const report = await runPolicyCheck([dir], policy, policyPath);
+				const hasFindings = report.findings.some((f) =>
+					policyThreshold.meetsThreshold(f.severity, "blocked")
+				);
+				results.push({
+					command: "policy",
+					exitCode: hasFindings ? 1 : 0,
+					summary: `${report.findings.length} finding(s)`,
+				});
+			} else {
+				results.push({
+					command: "policy",
+					exitCode: 0,
+					summary: "no policy file found, skipped",
+				});
+			}
+		} catch (err) {
+			results.push({
+				command: "policy",
+				exitCode: 2,
+				summary: `error: ${err instanceof Error ? err.message : String(err)}`,
+			});
+		}
+	}
+
+	// Output results
+	if (options.format === "json") {
+		const output = JSON.stringify({ results }, null, 2);
+		if (!options.quiet) {
+			console.log(output);
+		}
+	} else if (!options.quiet) {
+		console.log(chalk.bold("\nHealth Check Results"));
+		console.log("=".repeat(40));
+		for (const r of results) {
+			let icon: string;
+			if (r.exitCode === 0) {
+				icon = chalk.green("✓");
+			} else if (r.exitCode === 1) {
+				icon = chalk.red("✗");
+			} else {
+				icon = chalk.yellow("!");
+			}
+			console.log(`  ${icon} ${chalk.bold(r.command)}: ${r.summary}`);
+		}
+		console.log("");
+	}
+
+	// Exit code: 1 if any command failed, 2 if any errored
+	const maxExit = Math.max(0, ...results.map((r) => r.exitCode));
+	return maxExit > 1 ? 2 : maxExit;
+}

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies to avoid filesystem/network
+vi.mock("../scanner.js", () => ({
+	scanSkills: vi.fn(),
+	groupSkills: vi.fn(),
+}));
+
+vi.mock("../registry.js", () => ({
+	saveRegistry: vi.fn(),
+}));
+
+import { saveRegistry } from "../registry.js";
+import { groupSkills, scanSkills } from "../scanner.js";
+import type { ScannedSkill } from "../types.js";
+import { initCommand } from "./init.js";
+
+const mockedScanSkills = vi.mocked(scanSkills);
+const mockedGroupSkills = vi.mocked(groupSkills);
+const mockedSaveRegistry = vi.mocked(saveRegistry);
+
+function makeSkill(overrides?: Partial<ScannedSkill>): ScannedSkill {
+	return {
+		name: "nextjs-routing",
+		path: "./skills/nextjs-routing/SKILL.md",
+		productVersion: "14.0.0",
+		...overrides,
+	};
+}
+
+describe("initCommand", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedSaveRegistry.mockResolvedValue("skills-check.json");
+		vi.spyOn(console, "log").mockImplementation(() => {
+			/* intentionally empty */
+		});
+		vi.spyOn(console, "error").mockImplementation(() => {
+			/* intentionally empty */
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns 2 when no SKILL.md files found", async () => {
+		mockedScanSkills.mockResolvedValue([]);
+		const code = await initCommand("./skills", { yes: true });
+		expect(code).toBe(2);
+	});
+
+	it("returns 2 when no products can be mapped", async () => {
+		// Skill with unknown name won't auto-detect
+		mockedScanSkills.mockResolvedValue([
+			makeSkill({ name: "unknown-thing", productVersion: "1.0.0" }),
+		]);
+		mockedGroupSkills.mockReturnValue(
+			new Map([["unknown-thing", [makeSkill({ name: "unknown-thing", productVersion: "1.0.0" })]]])
+		);
+		const code = await initCommand("./skills", { yes: true });
+		expect(code).toBe(2);
+	});
+
+	it("auto-detects known packages in non-interactive mode", async () => {
+		const skill = makeSkill({ name: "nextjs-routing", productVersion: "14.0.0" });
+		mockedScanSkills.mockResolvedValue([skill]);
+		mockedGroupSkills.mockReturnValue(new Map([["nextjs", [skill]]]));
+
+		const code = await initCommand("./skills", { yes: true });
+		expect(code).toBe(0);
+		expect(mockedSaveRegistry).toHaveBeenCalledWith(
+			expect.objectContaining({
+				products: expect.objectContaining({
+					nextjs: expect.objectContaining({
+						displayName: "Next.js",
+						package: "next",
+						verifiedVersion: "14.0.0",
+					}),
+				}),
+			}),
+			undefined
+		);
+	});
+
+	it("saves to custom output path", async () => {
+		const skill = makeSkill({ name: "nextjs-routing", productVersion: "14.0.0" });
+		mockedScanSkills.mockResolvedValue([skill]);
+		mockedGroupSkills.mockReturnValue(new Map([["nextjs", [skill]]]));
+
+		await initCommand("./skills", { yes: true, output: "custom.json" });
+		expect(mockedSaveRegistry).toHaveBeenCalledWith(expect.anything(), "custom.json");
+	});
+
+	it("skips skills without product-version", async () => {
+		const withVersion = makeSkill({ name: "nextjs-routing", productVersion: "14.0.0" });
+		const withoutVersion = makeSkill({ name: "general-tips", productVersion: undefined });
+		mockedScanSkills.mockResolvedValue([withVersion, withoutVersion]);
+		mockedGroupSkills.mockReturnValue(new Map([["nextjs", [withVersion]]]));
+
+		await initCommand("./skills", { yes: true });
+
+		const logCalls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+		expect(logCalls.some((c) => c.includes("Skipping 1 without"))).toBe(true);
+	});
+
+	it("merges skills that map to the same npm package", async () => {
+		const skill1 = makeSkill({ name: "nextjs-routing", productVersion: "14.0.0" });
+		const skill2 = makeSkill({ name: "nextjs-api", productVersion: "14.0.0" });
+		mockedScanSkills.mockResolvedValue([skill1, skill2]);
+		mockedGroupSkills.mockReturnValue(
+			new Map([
+				["nextjs", [skill1]],
+				["nextjs-api", [skill2]],
+			])
+		);
+
+		const code = await initCommand("./skills", { yes: true });
+		expect(code).toBe(0);
+
+		// Both skills should be merged under nextjs since they map to "next" package
+		const savedRegistry = mockedSaveRegistry.mock.calls[0][0];
+		const nextjsProduct = savedRegistry.products.nextjs;
+		expect(nextjsProduct).toBeDefined();
+		expect(nextjsProduct.skills).toContain("nextjs-routing");
+		expect(nextjsProduct.skills).toContain("nextjs-api");
+	});
+
+	it("creates registry with correct schema", async () => {
+		const skill = makeSkill({ name: "nextjs-routing", productVersion: "14.0.0" });
+		mockedScanSkills.mockResolvedValue([skill]);
+		mockedGroupSkills.mockReturnValue(new Map([["nextjs", [skill]]]));
+
+		await initCommand("./skills", { yes: true });
+
+		const savedRegistry = mockedSaveRegistry.mock.calls[0][0];
+		expect(savedRegistry.$schema).toBe("https://skillscheck.ai/schema.json");
+		expect(savedRegistry.version).toBe(1);
+		expect(savedRegistry.lastCheck).toBeDefined();
+	});
+
+	it("auto-detects ai-sdk package", async () => {
+		const skill = makeSkill({ name: "ai-sdk-basics", productVersion: "3.0.0" });
+		mockedScanSkills.mockResolvedValue([skill]);
+		mockedGroupSkills.mockReturnValue(new Map([["ai-sdk", [skill]]]));
+
+		await initCommand("./skills", { yes: true });
+
+		const savedRegistry = mockedSaveRegistry.mock.calls[0][0];
+		expect(savedRegistry.products["ai-sdk"]).toBeDefined();
+		expect(savedRegistry.products["ai-sdk"].package).toBe("ai");
+		expect(savedRegistry.products["ai-sdk"].displayName).toBe("Vercel AI SDK");
+	});
+
+	it("auto-detects turborepo package", async () => {
+		const skill = makeSkill({ name: "turborepo", productVersion: "2.0.0" });
+		mockedScanSkills.mockResolvedValue([skill]);
+		mockedGroupSkills.mockReturnValue(new Map([["turborepo", [skill]]]));
+
+		await initCommand("./skills", { yes: true });
+
+		const savedRegistry = mockedSaveRegistry.mock.calls[0][0];
+		expect(savedRegistry.products.turborepo.package).toBe("turbo");
+	});
+});

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import { runLint } from "../lint/index.js";
 import { formatLintJson } from "../lint/reporters/json.js";
 import { formatLintMarkdown } from "../lint/reporters/markdown.js";
+import { formatLintSarif } from "../lint/reporters/sarif.js";
 import { formatLintTerminal } from "../lint/reporters/terminal.js";
 import type { LintOptions } from "../lint/types.js";
 import { formatAndOutput, lintThreshold } from "../shared/index.js";
@@ -10,7 +11,7 @@ interface LintCommandOptions {
 	ci?: boolean;
 	failOn?: string;
 	fix?: boolean;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	output?: string;
 	quiet?: boolean;
 	verbose?: boolean;
@@ -50,6 +51,7 @@ export async function lintCommand(dir: string, options: LintCommandOptions): Pro
 			terminal: formatLintTerminal,
 			json: formatLintJson,
 			markdown: formatLintMarkdown,
+			sarif: formatLintSarif,
 		}
 	);
 

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,34 +1,27 @@
-import { writeFile } from "node:fs/promises";
 import chalk from "chalk";
 import { runLint } from "../lint/index.js";
 import { formatLintJson } from "../lint/reporters/json.js";
+import { formatLintMarkdown } from "../lint/reporters/markdown.js";
 import { formatLintTerminal } from "../lint/reporters/terminal.js";
 import type { LintOptions } from "../lint/types.js";
+import { formatAndOutput, lintThreshold } from "../shared/index.js";
 
 interface LintCommandOptions {
 	ci?: boolean;
 	failOn?: string;
 	fix?: boolean;
-	format?: "terminal" | "json";
+	format?: "terminal" | "json" | "markdown";
 	output?: string;
-}
-
-const LEVEL_ORDER: Record<string, number> = {
-	error: 0,
-	warning: 1,
-	info: 2,
-};
-
-const VALID_LEVELS = new Set(["error", "warning"]);
-
-function meetsThreshold(level: string, threshold: string): boolean {
-	return (LEVEL_ORDER[level] ?? 2) <= (LEVEL_ORDER[threshold] ?? 0);
 }
 
 export async function lintCommand(dir: string, options: LintCommandOptions): Promise<number> {
 	const failOn = options.failOn ?? "error";
-	if (!VALID_LEVELS.has(failOn)) {
-		console.error(chalk.red(`Invalid --fail-on value: "${options.failOn}". Use: error, warning`));
+	if (!lintThreshold.validValues.has(failOn as "error" | "warning")) {
+		console.error(
+			chalk.red(
+				`Invalid --fail-on value: "${options.failOn}". Use: ${[...lintThreshold.validValues].join(", ")}`
+			)
+		);
 		return 2;
 	}
 
@@ -42,27 +35,20 @@ export async function lintCommand(dir: string, options: LintCommandOptions): Pro
 
 	const report = await runLint([dir], lintOptions);
 
-	// Format output
-	const format = options.format ?? "terminal";
-	let output: string;
-	switch (format) {
-		case "json":
-			output = formatLintJson(report);
-			break;
-		default:
-			output = formatLintTerminal(report);
-			break;
-	}
-
-	// Write to file or stdout
-	if (options.output) {
-		await writeFile(options.output, output, "utf-8");
-		console.error(chalk.green(`Report written to ${options.output}`));
-	} else {
-		console.log(output);
-	}
+	// Format and write output
+	await formatAndOutput(
+		report,
+		{ format: options.format, output: options.output },
+		{
+			terminal: formatLintTerminal,
+			json: formatLintJson,
+			markdown: formatLintMarkdown,
+		}
+	);
 
 	// Determine exit code based on threshold
-	const hasFailingFindings = report.findings.some((f) => meetsThreshold(f.level, failOn));
+	const hasFailingFindings = report.findings.some((f) =>
+		lintThreshold.meetsThreshold(f.level as "error" | "warning", failOn as "error" | "warning")
+	);
 	return hasFailingFindings ? 1 : 0;
 }

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -12,9 +12,16 @@ interface LintCommandOptions {
 	fix?: boolean;
 	format?: "terminal" | "json" | "markdown";
 	output?: string;
+	quiet?: boolean;
+	verbose?: boolean;
 }
 
 export async function lintCommand(dir: string, options: LintCommandOptions): Promise<number> {
+	if (options.verbose && options.quiet) {
+		console.error(chalk.red("Cannot use --verbose and --quiet together."));
+		return 2;
+	}
+
 	const failOn = options.failOn ?? "error";
 	if (!lintThreshold.validValues.has(failOn as "error" | "warning")) {
 		console.error(
@@ -38,7 +45,7 @@ export async function lintCommand(dir: string, options: LintCommandOptions): Pro
 	// Format and write output
 	await formatAndOutput(
 		report,
-		{ format: options.format, output: options.output },
+		{ format: options.format, output: options.output, quiet: options.quiet },
 		{
 			terminal: formatLintTerminal,
 			json: formatLintJson,

--- a/packages/cli/src/commands/policy.ts
+++ b/packages/cli/src/commands/policy.ts
@@ -4,28 +4,18 @@ import { runPolicyCheck } from "../policy/index.js";
 import { generateStarterPolicy } from "../policy/init.js";
 import { discoverPolicyFile, loadPolicyFile, validatePolicy } from "../policy/parser.js";
 import { formatPolicyJson } from "../policy/reporters/json.js";
+import { formatPolicyMarkdown } from "../policy/reporters/markdown.js";
 import { formatPolicyTerminal } from "../policy/reporters/terminal.js";
 import type { PolicyOptions, PolicySeverity, SkillPolicy } from "../policy/types.js";
+import { formatAndOutput, policyThreshold } from "../shared/index.js";
 
 interface PolicyCheckCommandOptions {
 	ci?: boolean;
 	failOn?: string;
-	format?: "terminal" | "json";
+	format?: "terminal" | "json" | "markdown";
 	output?: string;
 	policy?: string;
 	skill?: string;
-}
-
-const SEVERITY_ORDER: Record<PolicySeverity, number> = {
-	blocked: 0,
-	violation: 1,
-	warning: 2,
-};
-
-const VALID_SEVERITIES = new Set(["blocked", "violation", "warning"]);
-
-function meetsThreshold(severity: PolicySeverity, threshold: PolicySeverity): boolean {
-	return SEVERITY_ORDER[severity] <= SEVERITY_ORDER[threshold];
 }
 
 /**
@@ -36,9 +26,11 @@ export async function policyCheckCommand(
 	options: PolicyCheckCommandOptions
 ): Promise<number> {
 	const failOn = (options.failOn ?? "blocked") as PolicySeverity;
-	if (!VALID_SEVERITIES.has(failOn)) {
+	if (!policyThreshold.validValues.has(failOn)) {
 		console.error(
-			chalk.red(`Invalid --fail-on value: "${options.failOn}". Use: blocked, violation, warning`)
+			chalk.red(
+				`Invalid --fail-on value: "${options.failOn}". Use: ${[...policyThreshold.validValues].join(", ")}`
+			)
 		);
 		return 2;
 	}
@@ -89,28 +81,21 @@ export async function policyCheckCommand(
 
 	const report = await runPolicyCheck([dir], policy, policyPath, policyOptions);
 
-	// Format output
-	const format = options.format ?? "terminal";
-	let output: string;
-	switch (format) {
-		case "json":
-			output = formatPolicyJson(report);
-			break;
-		default:
-			output = formatPolicyTerminal(report);
-			break;
-	}
-
-	// Write to file or stdout
-	if (options.output) {
-		await writeFile(options.output, output, "utf-8");
-		console.error(chalk.green(`Report written to ${options.output}`));
-	} else {
-		console.log(output);
-	}
+	// Format and write output
+	await formatAndOutput(
+		report,
+		{ format: options.format, output: options.output },
+		{
+			terminal: formatPolicyTerminal,
+			json: formatPolicyJson,
+			markdown: formatPolicyMarkdown,
+		}
+	);
 
 	// Determine exit code based on threshold
-	const hasFailingFindings = report.findings.some((f) => meetsThreshold(f.severity, failOn));
+	const hasFailingFindings = report.findings.some((f) =>
+		policyThreshold.meetsThreshold(f.severity, failOn)
+	);
 	const hasMissingRequired = report.required.some((r) => !r.satisfied);
 
 	if (options.ci && (hasFailingFindings || hasMissingRequired)) {

--- a/packages/cli/src/commands/policy.ts
+++ b/packages/cli/src/commands/policy.ts
@@ -5,6 +5,7 @@ import { generateStarterPolicy } from "../policy/init.js";
 import { discoverPolicyFile, loadPolicyFile, validatePolicy } from "../policy/parser.js";
 import { formatPolicyJson } from "../policy/reporters/json.js";
 import { formatPolicyMarkdown } from "../policy/reporters/markdown.js";
+import { formatPolicySarif } from "../policy/reporters/sarif.js";
 import { formatPolicyTerminal } from "../policy/reporters/terminal.js";
 import type { PolicyOptions, PolicySeverity, SkillPolicy } from "../policy/types.js";
 import { formatAndOutput, policyThreshold } from "../shared/index.js";
@@ -12,7 +13,7 @@ import { formatAndOutput, policyThreshold } from "../shared/index.js";
 interface PolicyCheckCommandOptions {
 	ci?: boolean;
 	failOn?: string;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	output?: string;
 	policy?: string;
 	quiet?: boolean;
@@ -96,6 +97,7 @@ export async function policyCheckCommand(
 			terminal: formatPolicyTerminal,
 			json: formatPolicyJson,
 			markdown: formatPolicyMarkdown,
+			sarif: formatPolicySarif,
 		}
 	);
 

--- a/packages/cli/src/commands/policy.ts
+++ b/packages/cli/src/commands/policy.ts
@@ -15,7 +15,9 @@ interface PolicyCheckCommandOptions {
 	format?: "terminal" | "json" | "markdown";
 	output?: string;
 	policy?: string;
+	quiet?: boolean;
 	skill?: string;
+	verbose?: boolean;
 }
 
 /**
@@ -25,6 +27,11 @@ export async function policyCheckCommand(
 	dir: string,
 	options: PolicyCheckCommandOptions
 ): Promise<number> {
+	if (options.verbose && options.quiet) {
+		console.error(chalk.red("Cannot use --verbose and --quiet together."));
+		return 2;
+	}
+
 	const failOn = (options.failOn ?? "blocked") as PolicySeverity;
 	if (!policyThreshold.validValues.has(failOn)) {
 		console.error(
@@ -84,7 +91,7 @@ export async function policyCheckCommand(
 	// Format and write output
 	await formatAndOutput(
 		report,
-		{ format: options.format, output: options.output },
+		{ format: options.format, output: options.output, quiet: options.quiet },
 		{
 			terminal: formatPolicyTerminal,
 			json: formatPolicyJson,

--- a/packages/cli/src/commands/refresh.test.ts
+++ b/packages/cli/src/commands/refresh.test.ts
@@ -70,12 +70,13 @@ describe("refreshCommand", () => {
 		mockedSaveRegistry.mockResolvedValue("skills-check.json");
 		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", "15.0.0"]]));
 		mockedFetchChangelog.mockResolvedValue("## v15.0.0\n- Breaking changes");
-		mockedResolveModel.mockResolvedValue({} as ReturnType<typeof mockedResolveModel>);
+		mockedResolveModel.mockResolvedValue({} as Awaited<ReturnType<typeof resolveModel>>);
 		mockedReadSkillFile.mockResolvedValue({
+			path: "skills/nextjs-routing/SKILL.md",
 			raw: "---\nname: nextjs-routing\nproduct-version: '14.0.0'\n---\n# Routing",
 			content: "# Routing",
 			frontmatter: { name: "nextjs-routing", "product-version": "14.0.0" },
-		} as Awaited<ReturnType<typeof readSkillFile>>);
+		});
 		mockedWriteSkillFile.mockResolvedValue(undefined);
 		mockedGenerateObject.mockResolvedValue({
 			object: {
@@ -114,7 +115,9 @@ describe("refreshCommand", () => {
 	});
 
 	it("skips products with fetch errors", async () => {
-		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", new Error("Network error")]]));
+		mockedFetchLatestVersions.mockResolvedValue(
+			new Map<string, string | Error>([["next", new Error("Network error")]])
+		);
 		const code = await refreshCommand(undefined, { yes: true });
 		expect(code).toBe(0);
 		expect(console.error).toHaveBeenCalled();
@@ -207,15 +210,17 @@ describe("refreshCommand", () => {
 		// First call: initial read. Second call: verification read after write (still old version)
 		mockedReadSkillFile
 			.mockResolvedValueOnce({
+				path: "skills/nextjs-routing/SKILL.md",
 				raw: originalRaw,
 				content: "# Routing\n\nOld content.\n",
 				frontmatter: { name: "nextjs-routing", "product-version": "14.0.0" },
-			} as Awaited<ReturnType<typeof readSkillFile>>)
+			})
 			.mockResolvedValueOnce({
+				path: "skills/nextjs-routing/SKILL.md",
 				raw: updatedRaw,
 				content: "# Routing\n\nNew content.\nExtra line.\n",
 				frontmatter: { name: "nextjs-routing", "product-version": "14.0.0" },
-			} as Awaited<ReturnType<typeof readSkillFile>>);
+			});
 
 		await refreshCommand("./skills", { yes: true });
 

--- a/packages/cli/src/commands/refresh.test.ts
+++ b/packages/cli/src/commands/refresh.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock all external dependencies
+vi.mock("../npm.js", () => ({
+	fetchLatestVersions: vi.fn(),
+}));
+
+vi.mock("../registry.js", () => ({
+	loadRegistry: vi.fn(),
+	saveRegistry: vi.fn(),
+}));
+
+vi.mock("../changelog.js", () => ({
+	fetchChangelog: vi.fn(),
+}));
+
+vi.mock("../skill-io.js", () => ({
+	readSkillFile: vi.fn(),
+	writeSkillFile: vi.fn(),
+}));
+
+vi.mock("../llm/providers.js", () => ({
+	resolveModel: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+	generateObject: vi.fn(),
+}));
+
+import { generateObject } from "ai";
+import { fetchChangelog } from "../changelog.js";
+import { resolveModel } from "../llm/providers.js";
+import { fetchLatestVersions } from "../npm.js";
+import { loadRegistry, saveRegistry } from "../registry.js";
+import { readSkillFile, writeSkillFile } from "../skill-io.js";
+import type { Registry } from "../types.js";
+import { refreshCommand } from "./refresh.js";
+
+const mockedLoadRegistry = vi.mocked(loadRegistry);
+const mockedSaveRegistry = vi.mocked(saveRegistry);
+const mockedFetchLatestVersions = vi.mocked(fetchLatestVersions);
+const mockedFetchChangelog = vi.mocked(fetchChangelog);
+const mockedReadSkillFile = vi.mocked(readSkillFile);
+const mockedWriteSkillFile = vi.mocked(writeSkillFile);
+const mockedResolveModel = vi.mocked(resolveModel);
+const mockedGenerateObject = vi.mocked(generateObject);
+
+function makeRegistry(overrides?: Partial<Registry>): Registry {
+	return {
+		$schema: "https://skillscheck.ai/schema.json",
+		version: 1,
+		lastCheck: "2026-01-01T00:00:00.000Z",
+		products: {
+			nextjs: {
+				displayName: "Next.js",
+				package: "next",
+				verifiedVersion: "14.0.0",
+				verifiedAt: "2026-01-01T00:00:00.000Z",
+				skills: ["nextjs-routing"],
+			},
+		},
+		...overrides,
+	};
+}
+
+describe("refreshCommand", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedLoadRegistry.mockResolvedValue(makeRegistry());
+		mockedSaveRegistry.mockResolvedValue("skills-check.json");
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", "15.0.0"]]));
+		mockedFetchChangelog.mockResolvedValue("## v15.0.0\n- Breaking changes");
+		mockedResolveModel.mockResolvedValue({} as ReturnType<typeof mockedResolveModel>);
+		mockedReadSkillFile.mockResolvedValue({
+			raw: "---\nname: nextjs-routing\nproduct-version: '14.0.0'\n---\n# Routing",
+			content: "# Routing",
+			frontmatter: { name: "nextjs-routing", "product-version": "14.0.0" },
+		} as Awaited<ReturnType<typeof readSkillFile>>);
+		mockedWriteSkillFile.mockResolvedValue(undefined);
+		mockedGenerateObject.mockResolvedValue({
+			object: {
+				summary: "Updated routing docs for Next.js 15",
+				confidence: "high",
+				breakingChanges: true,
+				changes: [{ section: "Routing", description: "Updated API" }],
+				updatedContent:
+					"---\nname: nextjs-routing\nproduct-version: '15.0.0'\n---\n# Routing (updated)",
+			},
+		} as Awaited<ReturnType<typeof generateObject>>);
+
+		vi.spyOn(console, "log").mockImplementation(() => {
+			/* intentionally empty */
+		});
+		vi.spyOn(console, "error").mockImplementation(() => {
+			/* intentionally empty */
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns 0 when all products are current", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", "14.0.0"]]));
+		const code = await refreshCommand(undefined, { yes: true });
+		expect(code).toBe(0);
+		const logCalls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+		expect(logCalls.some((c) => c.includes("current"))).toBe(true);
+	});
+
+	it("returns 2 when product not found", async () => {
+		const code = await refreshCommand(undefined, { product: "nonexistent", yes: true });
+		expect(code).toBe(2);
+	});
+
+	it("skips products with fetch errors", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", new Error("Network error")]]));
+		const code = await refreshCommand(undefined, { yes: true });
+		expect(code).toBe(0);
+		expect(console.error).toHaveBeenCalled();
+	});
+
+	it("applies changes with --yes", async () => {
+		await refreshCommand("./skills", { yes: true });
+		expect(mockedWriteSkillFile).toHaveBeenCalled();
+		expect(mockedSaveRegistry).toHaveBeenCalled();
+	});
+
+	it("does not write files with --dry-run", async () => {
+		await refreshCommand("./skills", { dryRun: true });
+		expect(mockedWriteSkillFile).not.toHaveBeenCalled();
+		expect(mockedSaveRegistry).not.toHaveBeenCalled();
+	});
+
+	it("calls LLM with correct parameters", async () => {
+		await refreshCommand("./skills", { yes: true });
+		expect(mockedGenerateObject).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.any(String),
+				prompt: expect.any(String),
+			})
+		);
+	});
+
+	it("resolves skills directory from CLI arg", async () => {
+		await refreshCommand("./my-skills", { yes: true });
+		expect(mockedReadSkillFile).toHaveBeenCalledWith(expect.stringContaining("my-skills"));
+	});
+
+	it("resolves skills directory from registry", async () => {
+		mockedLoadRegistry.mockResolvedValue(
+			makeRegistry({ skillsDir: "./custom-skills" } as Partial<Registry>)
+		);
+		await refreshCommand(undefined, { yes: true });
+		expect(mockedReadSkillFile).toHaveBeenCalledWith(expect.stringContaining("custom-skills"));
+	});
+
+	it("defaults skills directory to ./skills", async () => {
+		mockedLoadRegistry.mockResolvedValue(makeRegistry());
+		await refreshCommand(undefined, { yes: true });
+		expect(mockedReadSkillFile).toHaveBeenCalledWith(expect.stringContaining("skills"));
+	});
+
+	it("skips platform-versioned products", async () => {
+		mockedLoadRegistry.mockResolvedValue(
+			makeRegistry({
+				products: {
+					vercel: {
+						displayName: "Vercel",
+						package: "vercel",
+						verifiedVersion: "platform",
+						verifiedAt: "2026-01-01T00:00:00.000Z",
+						skills: ["vercel-deploy"],
+					},
+				},
+			})
+		);
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["vercel", "35.0.0"]]));
+		const code = await refreshCommand(undefined, { yes: true });
+		expect(code).toBe(0);
+		expect(mockedGenerateObject).not.toHaveBeenCalled();
+	});
+
+	it("handles skill file read errors gracefully", async () => {
+		mockedReadSkillFile.mockRejectedValue(new Error("ENOENT"));
+		await refreshCommand("./skills", { yes: true });
+		expect(console.error).toHaveBeenCalled();
+	});
+
+	it("patches product-version when LLM omits bump", async () => {
+		const originalRaw =
+			"---\nname: nextjs-routing\nproduct-version: '14.0.0'\n---\n# Routing\n\nOld content.\n";
+		const updatedRaw =
+			"---\nname: nextjs-routing\nproduct-version: '14.0.0'\n---\n# Routing\n\nNew content.\nExtra line.\n";
+
+		// LLM returns changed content but without bumped version
+		mockedGenerateObject.mockResolvedValue({
+			object: {
+				summary: "Updated",
+				confidence: "high",
+				breakingChanges: false,
+				changes: [{ section: "Routing", description: "Updated API" }],
+				updatedContent: updatedRaw,
+			},
+		} as Awaited<ReturnType<typeof generateObject>>);
+
+		// First call: initial read. Second call: verification read after write (still old version)
+		mockedReadSkillFile
+			.mockResolvedValueOnce({
+				raw: originalRaw,
+				content: "# Routing\n\nOld content.\n",
+				frontmatter: { name: "nextjs-routing", "product-version": "14.0.0" },
+			} as Awaited<ReturnType<typeof readSkillFile>>)
+			.mockResolvedValueOnce({
+				raw: updatedRaw,
+				content: "# Routing\n\nNew content.\nExtra line.\n",
+				frontmatter: { name: "nextjs-routing", "product-version": "14.0.0" },
+			} as Awaited<ReturnType<typeof readSkillFile>>);
+
+		await refreshCommand("./skills", { yes: true });
+
+		// Should write twice — once for LLM output, once for version patch
+		expect(mockedWriteSkillFile).toHaveBeenCalledTimes(2);
+	});
+
+	it("uses custom registry path", async () => {
+		await refreshCommand(undefined, { registry: "custom.json", yes: true });
+		expect(mockedLoadRegistry).toHaveBeenCalledWith("custom.json");
+	});
+
+	it("filters to single product with --product", async () => {
+		mockedLoadRegistry.mockResolvedValue(
+			makeRegistry({
+				products: {
+					nextjs: {
+						displayName: "Next.js",
+						package: "next",
+						verifiedVersion: "14.0.0",
+						verifiedAt: "2026-01-01T00:00:00.000Z",
+						skills: ["nextjs-routing"],
+					},
+					react: {
+						displayName: "React",
+						package: "react",
+						verifiedVersion: "18.0.0",
+						verifiedAt: "2026-01-01T00:00:00.000Z",
+						skills: ["react-basics"],
+					},
+				},
+			})
+		);
+		mockedFetchLatestVersions.mockResolvedValue(
+			new Map([
+				["next", "15.0.0"],
+				["react", "19.0.0"],
+			])
+		);
+
+		await refreshCommand("./skills", { product: "nextjs", yes: true });
+
+		// readSkillFile is called twice for the one skill: once to read, once to verify after write
+		expect(mockedReadSkillFile).toHaveBeenCalledTimes(2);
+		expect(mockedReadSkillFile).toHaveBeenCalledWith(expect.stringContaining("nextjs-routing"));
+		// Should NOT have been called with the react skill
+		for (const call of mockedReadSkillFile.mock.calls) {
+			expect(String(call[0])).not.toContain("react-basics");
+		}
+	});
+});

--- a/packages/cli/src/commands/refresh.ts
+++ b/packages/cli/src/commands/refresh.ts
@@ -311,10 +311,18 @@ function promptUser(question: string): Promise<string> {
 		output: process.stdout,
 	});
 
-	return new Promise((resolve) => {
+	return new Promise((resolve, reject) => {
 		rl.question(question, (answer) => {
 			rl.close();
 			resolve(answer.trim().toLowerCase() || "n");
+		});
+		rl.on("error", (err) => {
+			rl.close();
+			reject(err);
+		});
+		rl.on("close", () => {
+			// If closed without an answer (e.g. stdin EOF), resolve with default
+			resolve("n");
 		});
 	});
 }

--- a/packages/cli/src/commands/report.test.ts
+++ b/packages/cli/src/commands/report.test.ts
@@ -127,7 +127,7 @@ describe("reportCommand", () => {
 
 	it("skips products with fetch errors", async () => {
 		mockedFetchLatestVersions.mockResolvedValue(
-			new Map([
+			new Map<string, string | Error>([
 				["next", new Error("Network error")],
 				["react", "18.2.0"],
 			])

--- a/packages/cli/src/commands/report.test.ts
+++ b/packages/cli/src/commands/report.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies to avoid filesystem/network
+vi.mock("../npm.js", () => ({
+	fetchLatestVersions: vi.fn(),
+}));
+
+vi.mock("../registry.js", () => ({
+	loadRegistry: vi.fn(),
+}));
+
+import { fetchLatestVersions } from "../npm.js";
+import { loadRegistry } from "../registry.js";
+import type { Registry } from "../types.js";
+import { reportCommand } from "./report.js";
+
+const mockedLoadRegistry = vi.mocked(loadRegistry);
+const mockedFetchLatestVersions = vi.mocked(fetchLatestVersions);
+
+function makeRegistry(overrides?: Partial<Registry>): Registry {
+	return {
+		$schema: "https://skillscheck.ai/schema.json",
+		version: 1,
+		lastCheck: "2026-01-01T00:00:00.000Z",
+		products: {
+			nextjs: {
+				displayName: "Next.js",
+				package: "next",
+				verifiedVersion: "14.0.0",
+				verifiedAt: "2026-01-01T00:00:00.000Z",
+				skills: ["nextjs-routing"],
+			},
+			react: {
+				displayName: "React",
+				package: "react",
+				verifiedVersion: "18.2.0",
+				verifiedAt: "2026-01-01T00:00:00.000Z",
+				skills: ["react-basics"],
+			},
+		},
+		...overrides,
+	};
+}
+
+describe("reportCommand", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedLoadRegistry.mockResolvedValue(makeRegistry());
+		mockedFetchLatestVersions.mockResolvedValue(
+			new Map([
+				["next", "15.0.0"],
+				["react", "18.2.0"],
+			])
+		);
+		vi.spyOn(console, "log").mockImplementation(() => {
+			/* intentionally empty */
+		});
+		vi.spyOn(console, "error").mockImplementation(() => {
+			/* intentionally empty */
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns 0 always", async () => {
+		const code = await reportCommand({});
+		expect(code).toBe(0);
+	});
+
+	it("generates markdown by default", async () => {
+		const logSpy = vi.mocked(console.log);
+		await reportCommand({});
+		const output = logSpy.mock.calls[0][0] as string;
+		expect(output).toContain("# Skills Check Report");
+		expect(output).toContain("## Summary");
+	});
+
+	it("includes stale products in markdown", async () => {
+		const logSpy = vi.mocked(console.log);
+		await reportCommand({});
+		const output = logSpy.mock.calls[0][0] as string;
+		expect(output).toContain("## Stale Products");
+		expect(output).toContain("Next.js");
+		expect(output).toContain("14.0.0");
+		expect(output).toContain("15.0.0");
+	});
+
+	it("includes current products in markdown", async () => {
+		const logSpy = vi.mocked(console.log);
+		await reportCommand({});
+		const output = logSpy.mock.calls[0][0] as string;
+		expect(output).toContain("## Current Products");
+		expect(output).toContain("React");
+	});
+
+	it("outputs JSON format", async () => {
+		const logSpy = vi.mocked(console.log);
+		await reportCommand({ format: "json" });
+		const output = logSpy.mock.calls[0][0] as string;
+		const parsed = JSON.parse(output);
+		expect(parsed).toBeInstanceOf(Array);
+		expect(parsed.length).toBe(2);
+	});
+
+	it("includes changelog link in markdown", async () => {
+		mockedLoadRegistry.mockResolvedValue(
+			makeRegistry({
+				products: {
+					nextjs: {
+						displayName: "Next.js",
+						package: "next",
+						verifiedVersion: "14.0.0",
+						verifiedAt: "2026-01-01T00:00:00.000Z",
+						skills: ["nextjs-routing"],
+						changelog: "https://github.com/vercel/next.js/releases",
+					},
+				},
+			})
+		);
+		const logSpy = vi.mocked(console.log);
+		await reportCommand({});
+		const output = logSpy.mock.calls[0][0] as string;
+		expect(output).toContain("[Next.js](https://github.com/vercel/next.js/releases)");
+	});
+
+	it("skips products with fetch errors", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(
+			new Map([
+				["next", new Error("Network error")],
+				["react", "18.2.0"],
+			])
+		);
+		const logSpy = vi.mocked(console.log);
+		await reportCommand({ format: "json" });
+		const output = logSpy.mock.calls[0][0] as string;
+		const parsed = JSON.parse(output);
+		// Only react should be present
+		expect(parsed.length).toBe(1);
+		expect(parsed[0].product).toBe("react");
+	});
+
+	it("loads custom registry path", async () => {
+		await reportCommand({ registry: "custom.json" });
+		expect(mockedLoadRegistry).toHaveBeenCalledWith("custom.json");
+	});
+
+	it("shows all current when nothing is stale", async () => {
+		mockedFetchLatestVersions.mockResolvedValue(
+			new Map([
+				["next", "14.0.0"],
+				["react", "18.2.0"],
+			])
+		);
+		const logSpy = vi.mocked(console.log);
+		await reportCommand({});
+		const output = logSpy.mock.calls[0][0] as string;
+		expect(output).not.toContain("## Stale Products");
+		expect(output).toContain("## Current Products");
+	});
+
+	it("includes summary counts", async () => {
+		const logSpy = vi.mocked(console.log);
+		await reportCommand({});
+		const output = logSpy.mock.calls[0][0] as string;
+		expect(output).toContain("**Total products**: 2");
+		expect(output).toContain("**Stale**: 1");
+		expect(output).toContain("**Current**: 1");
+	});
+});

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -19,6 +19,7 @@ interface TestCommandOptions {
 	output?: string;
 	passThreshold?: string;
 	provider?: string;
+	quiet?: boolean;
 	skill?: string;
 	timeout?: string;
 	trials?: string;
@@ -29,6 +30,11 @@ interface TestCommandOptions {
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 export async function testCommand(dir: string, options: TestCommandOptions): Promise<number> {
+	if (options.verbose && options.quiet) {
+		console.error(chalk.red("Cannot use --verbose and --quiet together."));
+		return 2;
+	}
+
 	const testOptions: TestOptions = {
 		skill: options.skill,
 		type: options.type,
@@ -245,8 +251,10 @@ export async function testCommand(dir: string, options: TestCommandOptions): Pro
 	// Write to file or stdout
 	if (options.output) {
 		await writeFile(options.output, output, "utf-8");
-		console.error(chalk.green(`Report written to ${options.output}`));
-	} else {
+		if (!options.quiet) {
+			console.error(chalk.green(`Report written to ${options.output}`));
+		}
+	} else if (!options.quiet) {
 		console.log(output);
 	}
 

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -4,6 +4,7 @@ import type { IsolationChoice } from "../isolation/types.js";
 import { runTests } from "../testing/index.js";
 import { formatJson } from "../testing/reporters/json.js";
 import { formatMarkdown } from "../testing/reporters/markdown.js";
+import { formatTestSarif } from "../testing/reporters/sarif.js";
 import { formatTerminal } from "../testing/reporters/terminal.js";
 import type { TestOptions } from "../testing/types.js";
 
@@ -12,7 +13,7 @@ interface TestCommandOptions {
 	agentCmd?: string;
 	ci?: boolean;
 	dry?: boolean;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	isolation?: IsolationChoice | boolean;
 	maxCost?: string;
 	model?: string;
@@ -239,6 +240,9 @@ export async function testCommand(dir: string, options: TestCommandOptions): Pro
 			break;
 		case "markdown":
 			output = formatMarkdown(reports, baselineDiffs);
+			break;
+		case "sarif":
+			output = formatTestSarif(reports);
 			break;
 		default:
 			output = formatTerminal(reports, {

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,7 +1,8 @@
-import { writeFile } from "node:fs/promises";
 import chalk from "chalk";
+import { formatAndOutput } from "../shared/index.js";
 import { runVerify } from "../verify/index.js";
 import { formatVerifyJson } from "../verify/reporters/json.js";
+import { formatVerifyMarkdown } from "../verify/reporters/markdown.js";
 import { formatVerifyTerminal } from "../verify/reporters/terminal.js";
 import type { VerifyOptions } from "../verify/types.js";
 
@@ -9,7 +10,7 @@ interface VerifyCommandOptions {
 	after?: string;
 	all?: boolean;
 	before?: string;
-	format?: "terminal" | "json";
+	format?: "terminal" | "json" | "markdown";
 	model?: string;
 	output?: string;
 	provider?: string;
@@ -20,7 +21,6 @@ interface VerifyCommandOptions {
 	verbose?: boolean;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 export async function verifyCommand(options: VerifyCommandOptions): Promise<number> {
 	if (options.verbose && options.quiet) {
 		console.error(chalk.red("Cannot use --verbose and --quiet together"));
@@ -78,27 +78,16 @@ export async function verifyCommand(options: VerifyCommandOptions): Promise<numb
 		);
 	}
 
-	// Format output
-	const format = options.format ?? "terminal";
-	let output: string;
-	switch (format) {
-		case "json":
-			output = formatVerifyJson(report);
-			break;
-		default:
-			output = formatVerifyTerminal(report);
-			break;
-	}
-
-	// Write to file or stdout
-	if (options.output) {
-		await writeFile(options.output, output, "utf-8");
-		if (!options.quiet) {
-			console.error(chalk.green(`Report written to ${options.output}`));
+	// Format and write output
+	await formatAndOutput(
+		report,
+		{ format: options.format, output: options.output, quiet: options.quiet },
+		{
+			terminal: formatVerifyTerminal,
+			json: formatVerifyJson,
+			markdown: formatVerifyMarkdown,
 		}
-	} else if (!options.quiet) {
-		console.log(output);
-	}
+	);
 
 	// Exit code: 1 if any mismatches found
 	return report.summary.failed > 0 ? 1 : 0;

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -3,6 +3,7 @@ import { formatAndOutput } from "../shared/index.js";
 import { runVerify } from "../verify/index.js";
 import { formatVerifyJson } from "../verify/reporters/json.js";
 import { formatVerifyMarkdown } from "../verify/reporters/markdown.js";
+import { formatVerifySarif } from "../verify/reporters/sarif.js";
 import { formatVerifyTerminal } from "../verify/reporters/terminal.js";
 import type { VerifyOptions } from "../verify/types.js";
 
@@ -10,7 +11,7 @@ interface VerifyCommandOptions {
 	after?: string;
 	all?: boolean;
 	before?: string;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	model?: string;
 	output?: string;
 	provider?: string;
@@ -86,6 +87,7 @@ export async function verifyCommand(options: VerifyCommandOptions): Promise<numb
 			terminal: formatVerifyTerminal,
 			json: formatVerifyJson,
 			markdown: formatVerifyMarkdown,
+			sarif: formatVerifySarif,
 		}
 	);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -141,7 +141,7 @@ program
 	.option("--fix", "auto-fix missing fields from git context")
 	.option("--ci", "strict CI mode")
 	.option("--fail-on <level>", "exit code 1 threshold: error, warning", "error")
-	.option("-f, --format <type>", "output format: terminal or json", "terminal")
+	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.action(async (dir, options) => {
 		try {
@@ -176,7 +176,7 @@ program
 	.option("--before <path>", "path to previous version of skill")
 	.option("--after <path>", "path to current version of skill")
 	.option("--suggest", "suggest appropriate version bump")
-	.option("-f, --format <type>", "output format: terminal or json", "terminal")
+	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--provider <name>", "LLM provider: anthropic, openai, google")
 	.option("--model <id>", "specific model ID")
@@ -204,7 +204,7 @@ policyCmd
 	.option("--policy <path>", "path to .skill-policy.yml")
 	.option("-s, --skill <name>", "check a specific skill by name")
 	.option("--ci", "strict exit codes")
-	.option("-f, --format <type>", "output format: terminal or json", "terminal")
+	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--fail-on <severity>", "exit code 1 threshold: blocked, violation, warning", "blocked")
 	.action(async (dir, options) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,7 @@ program
 	.option("-p, --product <name>", "check a single product")
 	.option("--json", "output results as JSON")
 	.option("-v, --verbose", "show all products including current")
+	.option("--quiet", "suppress output, exit code only")
 	.option("--ci", "exit code 1 if any stale products found")
 	.action(async (options) => {
 		try {
@@ -124,6 +125,8 @@ program
 		"--model <name>",
 		"model for cost estimation: claude-opus, claude-sonnet, claude-haiku, gpt-4o"
 	)
+	.option("--verbose", "show progress and details")
+	.option("--quiet", "suppress output, exit code only")
 	.action(async (dir, options) => {
 		try {
 			const code = await budgetCommand(dir, options);
@@ -143,6 +146,8 @@ program
 	.option("--fail-on <level>", "exit code 1 threshold: error, warning", "error")
 	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
 	.option("-o, --output <path>", "write report to file")
+	.option("--verbose", "show progress and details")
+	.option("--quiet", "suppress output, exit code only")
 	.action(async (dir, options) => {
 		try {
 			const code = await lintCommand(dir, options);
@@ -207,6 +212,8 @@ policyCmd
 	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--fail-on <severity>", "exit code 1 threshold: blocked, violation, warning", "blocked")
+	.option("--verbose", "show progress and details")
+	.option("--quiet", "suppress output, exit code only")
 	.action(async (dir, options) => {
 		try {
 			const code = await policyCheckCommand(dir, options);
@@ -265,6 +272,7 @@ program
 	.option("--provider <name>", "LLM provider for rubric grading: anthropic, openai, google")
 	.option("--model <id>", "model for rubric grading")
 	.option("--verbose", "show per-grader results")
+	.option("--quiet", "suppress output, exit code only")
 	.option(
 		"--isolation <provider>",
 		"run in isolated environment: auto, oci, apple, docker, podman, orbstack, rancher, nerdctl, vercel, local"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { auditCommand } from "./commands/audit.js";
 import { budgetCommand } from "./commands/budget.js";
 import { checkCommand } from "./commands/check.js";
+import { healthCommand } from "./commands/health.js";
 import { initCommand } from "./commands/init.js";
 import { lintCommand } from "./commands/lint.js";
 import { policyCheckCommand, policyInitCommand, policyValidateCommand } from "./commands/policy.js";
@@ -116,7 +117,7 @@ program
 	.argument("[dir]", "directory to analyze", ".")
 	.option("-s, --skill <name>", "analyze a specific skill by name")
 	.option("-d, --detailed", "show per-section token breakdown")
-	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
+	.option("-f, --format <type>", "output format: terminal, json, markdown, or sarif", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--max-tokens <n>", "exit code 1 if total exceeds this threshold")
 	.option("--save <path>", "save a snapshot for later comparison")
@@ -144,7 +145,7 @@ program
 	.option("--fix", "auto-fix missing fields from git context")
 	.option("--ci", "strict CI mode")
 	.option("--fail-on <level>", "exit code 1 threshold: error, warning", "error")
-	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
+	.option("-f, --format <type>", "output format: terminal, json, markdown, or sarif", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--verbose", "show progress and details")
 	.option("--quiet", "suppress output, exit code only")
@@ -181,7 +182,7 @@ program
 	.option("--before <path>", "path to previous version of skill")
 	.option("--after <path>", "path to current version of skill")
 	.option("--suggest", "suggest appropriate version bump")
-	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
+	.option("-f, --format <type>", "output format: terminal, json, markdown, or sarif", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--provider <name>", "LLM provider: anthropic, openai, google")
 	.option("--model <id>", "specific model ID")
@@ -209,7 +210,7 @@ policyCmd
 	.option("--policy <path>", "path to .skill-policy.yml")
 	.option("-s, --skill <name>", "check a specific skill by name")
 	.option("--ci", "strict exit codes")
-	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
+	.option("-f, --format <type>", "output format: terminal, json, markdown, or sarif", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--fail-on <severity>", "exit code 1 threshold: blocked, violation, warning", "blocked")
 	.option("--verbose", "show progress and details")
@@ -260,7 +261,7 @@ program
 	.option("-t, --type <type>", "filter by test type: trigger, outcome, style, regression")
 	.option("--agent <name>", "agent harness: claude-code, generic", "generic")
 	.option("--agent-cmd <command>", "custom command template for generic harness")
-	.option("-f, --format <type>", "output format: terminal, json, or markdown", "terminal")
+	.option("-f, --format <type>", "output format: terminal, json, markdown, or sarif", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--trials <n>", "runs per test case")
 	.option("--pass-threshold <n>", "trials that must pass")
@@ -281,6 +282,29 @@ program
 	.action(async (dir, options) => {
 		try {
 			const code = await testCommand(dir, options);
+			process.exit(code);
+		} catch (error) {
+			console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+			process.exit(2);
+		}
+	});
+
+program
+	.command("health")
+	.description("Run audit + lint + budget + policy as a single CI gate")
+	.argument("[dir]", "directory to check", ".")
+	.option("-f, --format <type>", "output format: terminal or json", "terminal")
+	.option("-o, --output <path>", "write report to file")
+	.option("--max-tokens <n>", "budget threshold for token count")
+	.option("--skip-audit", "skip audit check")
+	.option("--skip-lint", "skip lint check")
+	.option("--skip-budget", "skip budget check")
+	.option("--skip-policy", "skip policy check")
+	.option("--verbose", "show progress and details")
+	.option("--quiet", "suppress output, exit code only")
+	.action(async (dir, options) => {
+		try {
+			const code = await healthCommand(dir, options);
 			process.exit(code);
 		} catch (error) {
 			console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/cli/src/isolation/providers/oci.ts
+++ b/packages/cli/src/isolation/providers/oci.ts
@@ -87,6 +87,14 @@ export async function detectOCIRuntime(
 }
 
 /**
+ * Shell-escape a string for safe inclusion in a sh -c command.
+ * Wraps the value in single quotes and escapes any embedded single quotes.
+ */
+function shellEscape(s: string): string {
+	return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
  * OCI container runtime provider.
  * Supports Docker, Podman, OrbStack, Rancher Desktop, nerdctl (containerd), and CRI-O.
  */
@@ -106,7 +114,7 @@ export class OCIProvider implements IsolationProvider {
 	}
 
 	async execute(options: IsolationExecuteOptions): Promise<IsolationResult> {
-		const fullCommand = `npx skills-check ${options.command}`;
+		const escapedCommand = shellEscape(options.command);
 		const args = ["run", "--rm"];
 
 		// Mount skills directory read-only
@@ -131,7 +139,11 @@ export class OCIProvider implements IsolationProvider {
 
 		// Use a slim Node 22 image
 		args.push("node:22-alpine");
-		args.push("sh", "-c", `cd /skills && npm install -g skills-check && ${fullCommand}`);
+		args.push(
+			"sh",
+			"-c",
+			`cd /skills && npm install -g skills-check && npx skills-check ${escapedCommand}`
+		);
 
 		const result = await new Promise<{ exitCode: number; stdout: string; stderr: string }>(
 			(resolve) => {

--- a/packages/cli/src/lint/reporters/markdown.ts
+++ b/packages/cli/src/lint/reporters/markdown.ts
@@ -1,0 +1,69 @@
+import type { LintFinding, LintReport } from "../types.js";
+
+function groupByFile(findings: LintFinding[]): Map<string, LintFinding[]> {
+	const groups = new Map<string, LintFinding[]>();
+	for (const f of findings) {
+		const existing = groups.get(f.file) ?? [];
+		existing.push(f);
+		groups.set(f.file, existing);
+	}
+	return groups;
+}
+
+export function formatLintMarkdown(report: LintReport): string {
+	const lines: string[] = [];
+	const now = report.generatedAt.split("T")[0];
+
+	lines.push("# Skills Check Lint Report");
+	lines.push("");
+	lines.push(`Generated: ${now}`);
+	lines.push("");
+
+	// Summary table
+	lines.push("## Summary");
+	lines.push("");
+	lines.push("| Level | Count |");
+	lines.push("|-------|-------|");
+	lines.push(`| Errors | ${report.errors} |`);
+	lines.push(`| Warnings | ${report.warnings} |`);
+	lines.push(`| Info | ${report.infos} |`);
+	if (report.fixed > 0) {
+		lines.push(`| Fixed | ${report.fixed} |`);
+	}
+	lines.push(`| **Total** | **${report.errors + report.warnings + report.infos}** |`);
+	lines.push("");
+	lines.push(`Files scanned: ${report.files}`);
+	lines.push("");
+
+	if (report.findings.length === 0) {
+		lines.push("No findings. All skill files have valid metadata.");
+		lines.push("");
+		return lines.join("\n");
+	}
+
+	// Findings by file
+	const grouped = groupByFile(report.findings);
+	const levelOrder: Record<string, number> = { error: 0, warning: 1, info: 2 };
+
+	for (const [file, findings] of grouped) {
+		lines.push(`## ${file}`);
+		lines.push("");
+		lines.push("| Level | Field | Message | Fixable |");
+		lines.push("|-------|-------|---------|---------|");
+
+		findings.sort(
+			(a, b) =>
+				(levelOrder[a.level] ?? 2) - (levelOrder[b.level] ?? 2) || a.field.localeCompare(b.field)
+		);
+
+		for (const f of findings) {
+			const escapedMessage = f.message.replace(/\|/g, "\\|");
+			const fixable = f.fixable ? "Yes" : "No";
+			lines.push(`| ${f.level} | ${f.field} | ${escapedMessage} | ${fixable} |`);
+		}
+
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}

--- a/packages/cli/src/lint/reporters/sarif.ts
+++ b/packages/cli/src/lint/reporters/sarif.ts
@@ -1,0 +1,80 @@
+import type { LintFinding, LintReport } from "../types.js";
+
+function toSarifLevel(level: LintFinding["level"]): "error" | "warning" | "note" {
+	switch (level) {
+		case "error":
+			return "error";
+		case "warning":
+			return "warning";
+		case "info":
+			return "note";
+		default:
+			return "note";
+	}
+}
+
+function buildRules(findings: LintFinding[]): object[] {
+	const seen = new Set<string>();
+	const rules: object[] = [];
+
+	for (const f of findings) {
+		const ruleId = `skills-check/lint/${f.field}`;
+		if (!seen.has(ruleId)) {
+			seen.add(ruleId);
+			rules.push({
+				id: ruleId,
+				shortDescription: { text: `Lint: ${f.field}` },
+				defaultConfiguration: { level: toSarifLevel(f.level) },
+			});
+		}
+	}
+
+	return rules;
+}
+
+function buildResults(findings: LintFinding[]): object[] {
+	return findings.map((f) => ({
+		ruleId: `skills-check/lint/${f.field}`,
+		level: toSarifLevel(f.level),
+		message: { text: f.message },
+		locations: [
+			{
+				physicalLocation: {
+					artifactLocation: { uri: f.file },
+					region: { startLine: 1 },
+				},
+			},
+		],
+		properties: {
+			field: f.field,
+			fixable: f.fixable,
+		},
+	}));
+}
+
+export function formatLintSarif(report: LintReport): string {
+	const sarif = {
+		$schema: "https://json.schemastore.org/sarif-2.1.0.json",
+		version: "2.1.0",
+		runs: [
+			{
+				tool: {
+					driver: {
+						name: "skills-check/lint",
+						informationUri: "https://skillscheck.ai",
+						rules: buildRules(report.findings),
+					},
+				},
+				results: buildResults(report.findings),
+				invocations: [
+					{
+						executionSuccessful: true,
+						endTimeUtc: report.generatedAt,
+					},
+				],
+			},
+		],
+	};
+
+	return JSON.stringify(sarif, null, 2);
+}

--- a/packages/cli/src/lint/types.ts
+++ b/packages/cli/src/lint/types.ts
@@ -20,6 +20,6 @@ export interface LintOptions {
 	ci?: boolean;
 	failOn?: "error" | "warning";
 	fix?: boolean;
-	format?: "terminal" | "json";
+	format?: "terminal" | "json" | "markdown";
 	output?: string;
 }

--- a/packages/cli/src/lint/types.ts
+++ b/packages/cli/src/lint/types.ts
@@ -20,6 +20,6 @@ export interface LintOptions {
 	ci?: boolean;
 	failOn?: "error" | "warning";
 	fix?: boolean;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	output?: string;
 }

--- a/packages/cli/src/npm.ts
+++ b/packages/cli/src/npm.ts
@@ -1,6 +1,7 @@
 import type { NpmDistTags } from "./types.js";
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
+const FETCH_TIMEOUT_MS = 15_000;
 
 export interface NpmPackageMetadata {
 	name: string;
@@ -17,11 +18,17 @@ export interface NpmPackageMetadata {
  */
 export async function fetchPackageMetadata(packageName: string): Promise<NpmPackageMetadata> {
 	const url = `${NPM_REGISTRY}/${encodeURIComponent(packageName)}`;
-	const response = await fetch(url, {
-		headers: {
-			Accept: "application/json",
-		},
-	});
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			headers: { Accept: "application/json" },
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timer);
+	}
 
 	if (!response.ok) {
 		throw new Error(`npm registry returned ${response.status} for "${packageName}"`);
@@ -37,11 +44,17 @@ export async function fetchPackageMetadata(packageName: string): Promise<NpmPack
  */
 export async function fetchLatestVersion(packageName: string): Promise<string> {
 	const url = `${NPM_REGISTRY}/${encodeURIComponent(packageName)}`;
-	const response = await fetch(url, {
-		headers: {
-			Accept: "application/vnd.npm.install-v1+json",
-		},
-	});
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			headers: { Accept: "application/vnd.npm.install-v1+json" },
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timer);
+	}
 
 	if (!response.ok) {
 		if (response.status === 404) {

--- a/packages/cli/src/policy/reporters/markdown.ts
+++ b/packages/cli/src/policy/reporters/markdown.ts
@@ -1,0 +1,73 @@
+import type { PolicyReport, PolicySeverity } from "../types.js";
+
+export function formatPolicyMarkdown(report: PolicyReport): string {
+	const lines: string[] = [];
+	const now = report.generatedAt.split("T")[0];
+
+	lines.push("# Skills Check Policy Report");
+	lines.push("");
+	lines.push(`Generated: ${now}`);
+	lines.push(`Policy: ${report.policyFile}`);
+	lines.push("");
+
+	// Summary table
+	lines.push("## Summary");
+	lines.push("");
+	lines.push("| Severity | Count |");
+	lines.push("|----------|-------|");
+	lines.push(`| Blocked | ${report.summary.blocked} |`);
+	lines.push(`| Violations | ${report.summary.violations} |`);
+	lines.push(`| Warnings | ${report.summary.warnings} |`);
+	const total = report.summary.blocked + report.summary.violations + report.summary.warnings;
+	lines.push(`| **Total** | **${total}** |`);
+	lines.push("");
+	lines.push(`Files checked: ${report.files}`);
+	lines.push("");
+
+	if (report.findings.length === 0 && report.required.every((r) => r.satisfied)) {
+		lines.push("All skills comply with policy.");
+		lines.push("");
+		return lines.join("\n");
+	}
+
+	// Findings by severity
+	const severityOrder: PolicySeverity[] = ["blocked", "violation", "warning"];
+
+	for (const severity of severityOrder) {
+		const findings = report.findings.filter((f) => f.severity === severity);
+		if (findings.length === 0) {
+			continue;
+		}
+
+		const label = severity.charAt(0).toUpperCase() + severity.slice(1);
+		lines.push(`## ${label} (${findings.length})`);
+		lines.push("");
+		lines.push("| File | Rule | Message |");
+		lines.push("|------|------|---------|");
+
+		for (const f of findings) {
+			const escapedMessage = f.message.replace(/\|/g, "\\|");
+			const lineRef = f.line ? ` (line ${f.line})` : "";
+			lines.push(`| ${f.file}${lineRef} | ${f.rule} | ${escapedMessage} |`);
+		}
+
+		lines.push("");
+	}
+
+	// Required skills section
+	if (report.required.length > 0) {
+		lines.push("## Required Skills");
+		lines.push("");
+		lines.push("| Skill | Status |");
+		lines.push("|-------|--------|");
+
+		for (const r of report.required) {
+			const status = r.satisfied ? "Installed" : "**MISSING**";
+			lines.push(`| ${r.skill} | ${status} |`);
+		}
+
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}

--- a/packages/cli/src/policy/reporters/sarif.ts
+++ b/packages/cli/src/policy/reporters/sarif.ts
@@ -1,0 +1,80 @@
+import type { PolicyFinding, PolicyReport, PolicySeverity } from "../types.js";
+
+function toSarifLevel(severity: PolicySeverity): "error" | "warning" | "note" {
+	switch (severity) {
+		case "blocked":
+			return "error";
+		case "violation":
+			return "warning";
+		case "warning":
+			return "note";
+		default:
+			return "note";
+	}
+}
+
+function buildRules(findings: PolicyFinding[]): object[] {
+	const seen = new Set<string>();
+	const rules: object[] = [];
+
+	for (const f of findings) {
+		const ruleId = `skills-check/policy/${f.rule}`;
+		if (!seen.has(ruleId)) {
+			seen.add(ruleId);
+			rules.push({
+				id: ruleId,
+				shortDescription: { text: f.rule.replace(/-/g, " ") },
+				defaultConfiguration: { level: toSarifLevel(f.severity) },
+			});
+		}
+	}
+
+	return rules;
+}
+
+function buildResults(findings: PolicyFinding[]): object[] {
+	return findings.map((f) => ({
+		ruleId: `skills-check/policy/${f.rule}`,
+		level: toSarifLevel(f.severity),
+		message: { text: f.message },
+		locations: [
+			{
+				physicalLocation: {
+					artifactLocation: { uri: f.file },
+					region: { startLine: f.line ?? 1 },
+				},
+			},
+		],
+		properties: {
+			severity: f.severity,
+			detail: f.detail,
+		},
+	}));
+}
+
+export function formatPolicySarif(report: PolicyReport): string {
+	const sarif = {
+		$schema: "https://json.schemastore.org/sarif-2.1.0.json",
+		version: "2.1.0",
+		runs: [
+			{
+				tool: {
+					driver: {
+						name: "skills-check/policy",
+						informationUri: "https://skillscheck.ai",
+						rules: buildRules(report.findings),
+					},
+				},
+				results: buildResults(report.findings),
+				invocations: [
+					{
+						executionSuccessful: true,
+						endTimeUtc: report.generatedAt,
+					},
+				],
+			},
+		],
+	};
+
+	return JSON.stringify(sarif, null, 2);
+}

--- a/packages/cli/src/policy/types.ts
+++ b/packages/cli/src/policy/types.ts
@@ -46,7 +46,7 @@ export interface PolicyReport {
 export interface PolicyOptions {
 	ci?: boolean;
 	failOn?: PolicySeverity;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	output?: string;
 	policy?: string;
 	skill?: string;

--- a/packages/cli/src/policy/types.ts
+++ b/packages/cli/src/policy/types.ts
@@ -46,7 +46,7 @@ export interface PolicyReport {
 export interface PolicyOptions {
 	ci?: boolean;
 	failOn?: PolicySeverity;
-	format?: "terminal" | "json";
+	format?: "terminal" | "json" | "markdown";
 	output?: string;
 	policy?: string;
 	skill?: string;

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { lstat, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import matter from "gray-matter";
 import type { ScannedSkill } from "./types.js";
@@ -21,7 +21,7 @@ export async function scanSkills(skillsDir: string): Promise<ScannedSkill[]> {
 			const skillPath = join(skillsDir, entry, "SKILL.md");
 
 			try {
-				const info = await stat(join(skillsDir, entry));
+				const info = await lstat(join(skillsDir, entry));
 				if (!info.isDirectory()) {
 					return null;
 				}

--- a/packages/cli/src/shared/config.test.ts
+++ b/packages/cli/src/shared/config.test.ts
@@ -1,0 +1,105 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock os.homedir to avoid touching real user config
+vi.mock("node:os", async () => {
+	const actual = await vi.importActual<typeof import("node:os")>("node:os");
+	return { ...actual, homedir: vi.fn(() => "/nonexistent-home-for-test") };
+});
+
+import { loadConfig } from "./config.js";
+
+describe("loadConfig", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skills-check-config-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns empty config when no config files exist", async () => {
+		const config = await loadConfig(tempDir);
+		expect(config).toEqual({});
+	});
+
+	it("loads project-level .skillscheckrc.yml", async () => {
+		await writeFile(
+			join(tempDir, ".skillscheckrc.yml"),
+			"format: json\naudit:\n  failOn: medium\n",
+			"utf-8"
+		);
+
+		const config = await loadConfig(tempDir);
+		expect(config.format).toBe("json");
+		expect(config.audit).toEqual({ failOn: "medium" });
+	});
+
+	it("walks up directories to find config", async () => {
+		await writeFile(join(tempDir, ".skillscheckrc.yml"), "format: markdown\n", "utf-8");
+		const subDir = join(tempDir, "sub", "deep");
+		await mkdir(subDir, { recursive: true });
+
+		const config = await loadConfig(subDir);
+		expect(config.format).toBe("markdown");
+	});
+
+	it("loads all command sections", async () => {
+		const yaml = `
+format: sarif
+audit:
+  failOn: low
+  skipUrls: true
+  uniqueOnly: true
+lint:
+  failOn: warning
+  fix: true
+policy:
+  failOn: warning
+  policyPath: ./my-policy.yml
+budget:
+  maxTokens: 50000
+  model: claude-sonnet
+  detailed: true
+verify:
+  skipLlm: true
+  provider: openai
+  model: gpt-4o
+test:
+  agent: claude-code
+  trials: 3
+  timeout: 120
+  provider: anthropic
+  model: claude-sonnet-4-20250514
+`;
+		await writeFile(join(tempDir, ".skillscheckrc.yml"), yaml, "utf-8");
+
+		const config = await loadConfig(tempDir);
+		expect(config.format).toBe("sarif");
+		expect(config.audit?.failOn).toBe("low");
+		expect(config.audit?.skipUrls).toBe(true);
+		expect(config.lint?.fix).toBe(true);
+		expect(config.policy?.policyPath).toBe("./my-policy.yml");
+		expect(config.budget?.maxTokens).toBe(50_000);
+		expect(config.verify?.skipLlm).toBe(true);
+		expect(config.test?.trials).toBe(3);
+	});
+
+	it("handles invalid YAML gracefully", async () => {
+		await writeFile(join(tempDir, ".skillscheckrc.yml"), "{{{invalid yaml", "utf-8");
+
+		const config = await loadConfig(tempDir);
+		expect(config).toEqual({});
+	});
+
+	it("handles empty file gracefully", async () => {
+		await writeFile(join(tempDir, ".skillscheckrc.yml"), "", "utf-8");
+
+		const config = await loadConfig(tempDir);
+		expect(config).toEqual({});
+	});
+});

--- a/packages/cli/src/shared/config.ts
+++ b/packages/cli/src/shared/config.ts
@@ -1,0 +1,132 @@
+import { readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+/**
+ * Configuration loaded from .skillscheckrc.yml files.
+ * CLI flags always override these values.
+ */
+export interface SkillsCheckConfig {
+	/** Default --fail-on severity for audit */
+	audit?: { failOn?: string; skipUrls?: boolean; uniqueOnly?: boolean };
+	/** Default budget settings */
+	budget?: { maxTokens?: number; model?: string; detailed?: boolean };
+	/** Default output format for all commands */
+	format?: string;
+	/** Default --fail-on level for lint */
+	lint?: { failOn?: string; fix?: boolean };
+	/** Default --fail-on severity for policy */
+	policy?: { failOn?: string; policyPath?: string };
+	/** Default test settings */
+	test?: {
+		agent?: string;
+		trials?: number;
+		timeout?: number;
+		provider?: string;
+		model?: string;
+	};
+	/** Default verify settings */
+	verify?: { skipLlm?: boolean; provider?: string; model?: string };
+}
+
+/**
+ * Dynamically import js-yaml (transitive dep via gray-matter).
+ */
+async function loadYaml(): Promise<{
+	load: (str: string, opts?: { schema: unknown }) => unknown;
+	JSON_SCHEMA: unknown;
+}> {
+	const mod = await import("js-yaml");
+	return (mod.default ?? mod) as {
+		load: (str: string, opts?: { schema: unknown }) => unknown;
+		JSON_SCHEMA: unknown;
+	};
+}
+
+const CONFIG_FILE_NAME = ".skillscheckrc.yml";
+
+/**
+ * Walk up the directory tree to find a project-level config file.
+ */
+async function findProjectConfig(startDir: string): Promise<string | null> {
+	let current = resolve(startDir);
+	const root = resolve("/");
+
+	while (current !== root) {
+		const candidate = join(current, CONFIG_FILE_NAME);
+		try {
+			await stat(candidate);
+			return candidate;
+		} catch {
+			// Not found, continue walking up
+		}
+		const parent = dirname(current);
+		if (parent === current) {
+			break;
+		}
+		current = parent;
+	}
+
+	return null;
+}
+
+/**
+ * Get the user-level config path (~/.config/skills-check/config.yml).
+ */
+function getUserConfigPath(): string {
+	return join(homedir(), ".config", "skills-check", "config.yml");
+}
+
+/**
+ * Parse a YAML config file into a SkillsCheckConfig.
+ * Returns an empty config on parse errors (graceful degradation).
+ */
+async function parseConfigFile(filePath: string): Promise<SkillsCheckConfig> {
+	try {
+		const content = await readFile(filePath, "utf-8");
+		const yaml = await loadYaml();
+		const raw = yaml.load(content, { schema: yaml.JSON_SCHEMA });
+
+		if (raw === null || raw === undefined || typeof raw !== "object") {
+			return {};
+		}
+
+		return raw as SkillsCheckConfig;
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Shallow merge two configs. Values in `override` take precedence.
+ */
+function mergeConfigs(base: SkillsCheckConfig, override: SkillsCheckConfig): SkillsCheckConfig {
+	return {
+		format: override.format ?? base.format,
+		audit: override.audit ?? base.audit,
+		lint: override.lint ?? base.lint,
+		policy: override.policy ?? base.policy,
+		budget: override.budget ?? base.budget,
+		verify: override.verify ?? base.verify,
+		test: override.test ?? base.test,
+	};
+}
+
+/**
+ * Load configuration with 3-level cascade: project config > user config.
+ * CLI flags are applied separately by each command (they always win).
+ *
+ * @param cwd - Directory to start searching for project config
+ */
+export async function loadConfig(cwd: string): Promise<SkillsCheckConfig> {
+	// Level 1: User-level config (~/.config/skills-check/config.yml)
+	const userConfigPath = getUserConfigPath();
+	const userConfig = await parseConfigFile(userConfigPath);
+
+	// Level 2: Project-level config (walk up from cwd)
+	const projectConfigPath = await findProjectConfig(cwd);
+	const projectConfig = projectConfigPath ? await parseConfigFile(projectConfigPath) : {};
+
+	// Project overrides user
+	return mergeConfigs(userConfig, projectConfig);
+}

--- a/packages/cli/src/shared/discovery.ts
+++ b/packages/cli/src/shared/discovery.ts
@@ -1,4 +1,4 @@
-import { readdir, stat } from "node:fs/promises";
+import { lstat, readdir } from "node:fs/promises";
 import { join } from "node:path";
 
 /**
@@ -21,11 +21,11 @@ export async function discoverSkillFiles(dir: string): Promise<string[]> {
 	for (const entry of entries) {
 		const fullPath = join(dir, entry);
 		try {
-			const info = await stat(fullPath);
+			const info = await lstat(fullPath);
 			if (info.isDirectory()) {
 				const skillPath = join(fullPath, "SKILL.md");
 				try {
-					await stat(skillPath);
+					await lstat(skillPath);
 					files.push(skillPath);
 				} catch {
 					// No SKILL.md here — recurse deeper

--- a/packages/cli/src/shared/index.ts
+++ b/packages/cli/src/shared/index.ts
@@ -1,5 +1,9 @@
+export type { SkillsCheckConfig } from "./config.js";
 // biome-ignore lint/performance/noBarrelFile: shared module barrel export by design
+export { loadConfig } from "./config.js";
 export { discoverSkillFiles } from "./discovery.js";
+export type { Progress } from "./progress.js";
+export { createProgress } from "./progress.js";
 export { formatAndOutput } from "./reporter.js";
 export type { SkillSection } from "./sections.js";
 export { parseSections } from "./sections.js";

--- a/packages/cli/src/shared/index.ts
+++ b/packages/cli/src/shared/index.ts
@@ -1,4 +1,11 @@
 // biome-ignore lint/performance/noBarrelFile: shared module barrel export by design
 export { discoverSkillFiles } from "./discovery.js";
+export { formatAndOutput } from "./reporter.js";
 export type { SkillSection } from "./sections.js";
 export { parseSections } from "./sections.js";
+export {
+	auditThreshold,
+	createThresholdChecker,
+	lintThreshold,
+	policyThreshold,
+} from "./threshold.js";

--- a/packages/cli/src/shared/progress.test.ts
+++ b/packages/cli/src/shared/progress.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProgress } from "./progress.js";
+
+describe("createProgress", () => {
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		stderrSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		stderrSpy.mockRestore();
+	});
+
+	it("returns no-op when verbose is false", () => {
+		const progress = createProgress(false);
+		progress.step("test");
+		progress.update(1, 10);
+		progress.done("done");
+		expect(stderrSpy).not.toHaveBeenCalled();
+	});
+
+	it("returns no-op when verbose is undefined", () => {
+		const progress = createProgress();
+		progress.step("test");
+		expect(stderrSpy).not.toHaveBeenCalled();
+	});
+
+	it("outputs step messages when verbose", () => {
+		const progress = createProgress(true);
+		progress.step("Scanning files...");
+		expect(stderrSpy).toHaveBeenCalledTimes(1);
+		expect(stderrSpy.mock.calls[0][0]).toContain("Scanning files...");
+	});
+
+	it("outputs update with progress percentage", () => {
+		const progress = createProgress(true);
+		progress.update(3, 10, "files checked");
+		expect(stderrSpy).toHaveBeenCalledTimes(1);
+		const output = stderrSpy.mock.calls[0][0] as string;
+		expect(output).toContain("3/10");
+		expect(output).toContain("30%");
+		expect(output).toContain("files checked");
+	});
+
+	it("outputs done message when provided", () => {
+		const progress = createProgress(true);
+		progress.done("Complete");
+		expect(stderrSpy).toHaveBeenCalledTimes(1);
+		expect(stderrSpy.mock.calls[0][0]).toContain("Complete");
+	});
+
+	it("does not output done when no message", () => {
+		const progress = createProgress(true);
+		progress.done();
+		expect(stderrSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/shared/progress.ts
+++ b/packages/cli/src/shared/progress.ts
@@ -1,0 +1,41 @@
+import chalk from "chalk";
+
+/**
+ * Lightweight progress indicator for long-running commands.
+ * Outputs to stderr so it doesn't interfere with report output on stdout.
+ * Only emits when verbose mode is enabled.
+ */
+export interface Progress {
+	/** Report step completion */
+	done(message?: string): void;
+	/** Report starting a step (e.g., "Scanning files...") */
+	step(message: string): void;
+	/** Report progress within a step (e.g., "3/10 files checked") */
+	update(current: number, total: number, label?: string): void;
+}
+
+/**
+ * Create a progress reporter. Returns a no-op if verbose is false.
+ */
+export function createProgress(verbose?: boolean): Progress {
+	if (!verbose) {
+		// biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-ops
+		return { step() {}, update() {}, done() {} };
+	}
+
+	return {
+		step(message: string) {
+			console.error(chalk.dim(`  → ${message}`));
+		},
+		update(current: number, total: number, label?: string) {
+			const pct = total > 0 ? Math.round((current / total) * 100) : 0;
+			const suffix = label ? ` ${label}` : "";
+			console.error(chalk.dim(`  ${current}/${total} (${pct}%)${suffix}`));
+		},
+		done(message?: string) {
+			if (message) {
+				console.error(chalk.dim(`  ✓ ${message}`));
+			}
+		},
+	};
+}

--- a/packages/cli/src/shared/reporter.ts
+++ b/packages/cli/src/shared/reporter.ts
@@ -1,0 +1,33 @@
+import { writeFile } from "node:fs/promises";
+import chalk from "chalk";
+
+/**
+ * Format a report using the given formatters and write to output or stdout.
+ *
+ * Centralises the format-switch + file-write-or-stdout pattern used by
+ * every command (audit, budget, lint, policy, verify).
+ */
+export async function formatAndOutput<T>(
+	report: T,
+	options: { format?: string; output?: string; quiet?: boolean },
+	formatters: Record<string, (report: T) => string>,
+	defaultFormat = "terminal"
+): Promise<void> {
+	const format = options.format ?? defaultFormat;
+	const formatter = formatters[format] ?? formatters[defaultFormat];
+
+	if (!formatter) {
+		throw new Error(`No formatter found for format "${format}"`);
+	}
+
+	const output = formatter(report);
+
+	if (options.output) {
+		await writeFile(options.output, output, "utf-8");
+		if (!options.quiet) {
+			console.error(chalk.green(`Report written to ${options.output}`));
+		}
+	} else if (!options.quiet) {
+		console.log(output);
+	}
+}

--- a/packages/cli/src/shared/threshold.test.ts
+++ b/packages/cli/src/shared/threshold.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+	auditThreshold,
+	createThresholdChecker,
+	lintThreshold,
+	policyThreshold,
+} from "./threshold.js";
+
+describe("createThresholdChecker", () => {
+	it("creates a checker with valid values", () => {
+		const checker = createThresholdChecker({ a: 0, b: 1, c: 2 });
+		expect(checker.validValues).toEqual(new Set(["a", "b", "c"]));
+	});
+
+	it("meetsThreshold returns true when severity is at threshold", () => {
+		const checker = createThresholdChecker({ high: 0, medium: 1, low: 2 });
+		expect(checker.meetsThreshold("medium", "medium")).toBe(true);
+	});
+
+	it("meetsThreshold returns true when severity is above threshold", () => {
+		const checker = createThresholdChecker({ high: 0, medium: 1, low: 2 });
+		expect(checker.meetsThreshold("high", "medium")).toBe(true);
+	});
+
+	it("meetsThreshold returns false when severity is below threshold", () => {
+		const checker = createThresholdChecker({ high: 0, medium: 1, low: 2 });
+		expect(checker.meetsThreshold("low", "medium")).toBe(false);
+	});
+});
+
+describe("auditThreshold", () => {
+	it("has correct valid values", () => {
+		expect(auditThreshold.validValues).toEqual(new Set(["critical", "high", "medium", "low"]));
+	});
+
+	it("critical meets any threshold", () => {
+		expect(auditThreshold.meetsThreshold("critical", "low")).toBe(true);
+	});
+
+	it("low only meets low threshold", () => {
+		expect(auditThreshold.meetsThreshold("low", "low")).toBe(true);
+		expect(auditThreshold.meetsThreshold("low", "medium")).toBe(false);
+	});
+});
+
+describe("policyThreshold", () => {
+	it("has correct valid values", () => {
+		expect(policyThreshold.validValues).toEqual(new Set(["blocked", "violation", "warning"]));
+	});
+
+	it("blocked meets any threshold", () => {
+		expect(policyThreshold.meetsThreshold("blocked", "warning")).toBe(true);
+	});
+
+	it("warning only meets warning threshold", () => {
+		expect(policyThreshold.meetsThreshold("warning", "warning")).toBe(true);
+		expect(policyThreshold.meetsThreshold("warning", "violation")).toBe(false);
+	});
+});
+
+describe("lintThreshold", () => {
+	it("has correct valid values", () => {
+		expect(lintThreshold.validValues).toEqual(new Set(["error", "warning"]));
+	});
+
+	it("error meets any threshold", () => {
+		expect(lintThreshold.meetsThreshold("error", "warning")).toBe(true);
+	});
+
+	it("warning does not meet error threshold", () => {
+		expect(lintThreshold.meetsThreshold("warning", "error")).toBe(false);
+	});
+});

--- a/packages/cli/src/shared/threshold.ts
+++ b/packages/cli/src/shared/threshold.ts
@@ -1,0 +1,46 @@
+/**
+ * Generic threshold comparison for severity/level-based filtering.
+ *
+ * Used by audit (critical/high/medium/low), policy (blocked/violation/warning),
+ * and lint (error/warning) commands to avoid duplicating threshold logic.
+ */
+
+/**
+ * Create a threshold checker for a given severity ordering.
+ *
+ * @param order - Map of severity labels to numeric priority (lower = more severe)
+ * @returns Object with `meetsThreshold` and `validValues`
+ */
+export function createThresholdChecker<T extends string>(order: Record<T, number>) {
+	const validValues = new Set(Object.keys(order) as T[]);
+
+	return {
+		/** Returns true if `severity` is at or above the `threshold` level. */
+		meetsThreshold(severity: T, threshold: T): boolean {
+			return (order[severity] ?? Number.MAX_SAFE_INTEGER) <= (order[threshold] ?? 0);
+		},
+		/** Set of valid severity/level values for input validation. */
+		validValues,
+	};
+}
+
+/** Audit severity threshold checker. */
+export const auditThreshold = createThresholdChecker({
+	critical: 0,
+	high: 1,
+	medium: 2,
+	low: 3,
+});
+
+/** Policy severity threshold checker. */
+export const policyThreshold = createThresholdChecker({
+	blocked: 0,
+	violation: 1,
+	warning: 2,
+});
+
+/** Lint level threshold checker. */
+export const lintThreshold = createThresholdChecker({
+	error: 0,
+	warning: 1,
+});

--- a/packages/cli/src/testing/discovery.ts
+++ b/packages/cli/src/testing/discovery.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises";
+import { lstat } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { discoverSkillFiles } from "../shared/discovery.js";
 import type { SkillFile } from "../skill-io.js";
@@ -38,7 +38,7 @@ export async function discoverTestableSkills(
 		for (const name of ["cases.yaml", "cases.yml"]) {
 			const candidate = join(testsDir, name);
 			try {
-				const info = await stat(candidate);
+				const info = await lstat(candidate);
 				if (info.isFile()) {
 					casesPath = candidate;
 					break;

--- a/packages/cli/src/testing/graders/file-exists.ts
+++ b/packages/cli/src/testing/graders/file-exists.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises";
+import { lstat } from "node:fs/promises";
 import { resolve } from "node:path";
 import { safePath } from "../safe-path.js";
 import type { GraderResult } from "../types.js";
@@ -14,7 +14,7 @@ export async function gradeFileExists(workDir: string, paths: string[]): Promise
 	for (const p of paths) {
 		const fullPath = safePath(resolvedWorkDir, p);
 		try {
-			const info = await stat(fullPath);
+			const info = await lstat(fullPath);
 			if (info.isFile() || info.isDirectory()) {
 				found.push(p);
 			} else {

--- a/packages/cli/src/testing/harness/claude-code.test.ts
+++ b/packages/cli/src/testing/harness/claude-code.test.ts
@@ -19,7 +19,7 @@ vi.mock("node:fs/promises", async () => {
 	return {
 		...actual,
 		readdir: vi.fn().mockResolvedValue([]),
-		stat: vi.fn().mockRejectedValue(new Error("not found")),
+		lstat: vi.fn().mockRejectedValue(new Error("not found")),
 	};
 });
 

--- a/packages/cli/src/testing/harness/claude-code.ts
+++ b/packages/cli/src/testing/harness/claude-code.ts
@@ -31,9 +31,9 @@ async function listFilesRecursive(dir: string): Promise<Set<string>> {
 		}
 		for (const entry of entries) {
 			const fullPath = join(d, entry);
-			const { stat } = await import("node:fs/promises");
+			const { lstat } = await import("node:fs/promises");
 			try {
-				const info = await stat(fullPath);
+				const info = await lstat(fullPath);
 				if (info.isDirectory()) {
 					await walk(fullPath);
 				} else {

--- a/packages/cli/src/testing/harness/generic.test.ts
+++ b/packages/cli/src/testing/harness/generic.test.ts
@@ -18,7 +18,7 @@ vi.mock("node:fs/promises", async () => {
 	return {
 		...actual,
 		readdir: vi.fn().mockResolvedValue([]),
-		stat: vi.fn().mockRejectedValue(new Error("not found")),
+		lstat: vi.fn().mockRejectedValue(new Error("not found")),
 	};
 });
 

--- a/packages/cli/src/testing/harness/generic.ts
+++ b/packages/cli/src/testing/harness/generic.ts
@@ -1,5 +1,5 @@
 import { exec } from "node:child_process";
-import { readdir, stat } from "node:fs/promises";
+import { lstat, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { AgentExecution } from "../types.js";
 import type { AgentHarness } from "./interface.js";
@@ -20,7 +20,7 @@ async function listFilesRecursive(dir: string): Promise<Set<string>> {
 		for (const entry of entries) {
 			const fullPath = join(d, entry);
 			try {
-				const info = await stat(fullPath);
+				const info = await lstat(fullPath);
 				if (info.isDirectory()) {
 					await walk(fullPath);
 				} else {

--- a/packages/cli/src/testing/reporters/sarif.ts
+++ b/packages/cli/src/testing/reporters/sarif.ts
@@ -1,0 +1,91 @@
+import type { TestReport } from "../types.js";
+
+function buildRules(reports: TestReport[]): object[] {
+	const seen = new Set<string>();
+	const rules: object[] = [];
+
+	for (const report of reports) {
+		for (const c of report.cases) {
+			if (!c.passed) {
+				const ruleId = `skills-check/test/${c.type}`;
+				if (!seen.has(ruleId)) {
+					seen.add(ruleId);
+					rules.push({
+						id: ruleId,
+						shortDescription: { text: `Test failure: ${c.type}` },
+						defaultConfiguration: { level: "error" },
+					});
+				}
+			}
+		}
+	}
+
+	return rules;
+}
+
+function buildResults(reports: TestReport[]): object[] {
+	const results: object[] = [];
+
+	for (const report of reports) {
+		for (const c of report.cases) {
+			if (!c.passed) {
+				const failedGraders = c.trials
+					.flatMap((t) => t.graderResults.filter((g) => !g.passed))
+					.map((g) => `${g.grader}: ${g.message}`)
+					.slice(0, 5);
+
+				results.push({
+					ruleId: `skills-check/test/${c.type}`,
+					level: "error" as const,
+					message: {
+						text: `Test "${c.caseId}" failed (pass rate: ${Math.round(c.passRate * 100)}%)${failedGraders.length > 0 ? `. ${failedGraders.join("; ")}` : ""}`,
+					},
+					locations: [
+						{
+							physicalLocation: {
+								artifactLocation: { uri: report.skillPath },
+								region: { startLine: 1 },
+							},
+						},
+					],
+					properties: {
+						suite: report.suite,
+						caseId: c.caseId,
+						passRate: c.passRate,
+						flaky: c.flaky,
+						type: c.type,
+					},
+				});
+			}
+		}
+	}
+
+	return results;
+}
+
+export function formatTestSarif(reports: TestReport[]): string {
+	const sarif = {
+		$schema: "https://json.schemastore.org/sarif-2.1.0.json",
+		version: "2.1.0",
+		runs: [
+			{
+				tool: {
+					driver: {
+						name: "skills-check/test",
+						informationUri: "https://skillscheck.ai",
+						rules: buildRules(reports),
+					},
+				},
+				results: buildResults(reports),
+				invocations: [
+					{
+						executionSuccessful: true,
+						endTimeUtc: new Date().toISOString(),
+					},
+				],
+			},
+		],
+	};
+
+	return JSON.stringify(sarif, null, 2);
+}

--- a/packages/cli/src/testing/types.ts
+++ b/packages/cli/src/testing/types.ts
@@ -75,7 +75,7 @@ export interface TestOptions {
 	agentCmd?: string;
 	ci?: boolean;
 	dry?: boolean;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	maxCost?: number;
 	model?: string;
 	output?: string;

--- a/packages/cli/src/verify/git.ts
+++ b/packages/cli/src/verify/git.ts
@@ -3,6 +3,7 @@ import { relative } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const GIT_TIMEOUT_MS = 30_000;
 
 /**
  * Get the git repository root directory for the given path.
@@ -10,7 +11,10 @@ const execFileAsync = promisify(execFile);
  */
 async function getRepoRoot(cwd: string): Promise<string | null> {
 	try {
-		const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], { cwd });
+		const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			timeout: GIT_TIMEOUT_MS,
+		});
 		return stdout.trim();
 	} catch {
 		return null;
@@ -41,7 +45,7 @@ export async function getPreviousVersion(filePath: string): Promise<string | nul
 		const { stdout: commitHash } = await execFileAsync(
 			"git",
 			["log", "--follow", "-1", "--skip=1", "--format=%H", "--", relativePath],
-			{ cwd: repoRoot }
+			{ cwd: repoRoot, timeout: GIT_TIMEOUT_MS }
 		);
 
 		const hash = commitHash.trim();
@@ -50,6 +54,7 @@ export async function getPreviousVersion(filePath: string): Promise<string | nul
 			try {
 				const { stdout: content } = await execFileAsync("git", ["show", `HEAD~1:${relativePath}`], {
 					cwd: repoRoot,
+					timeout: GIT_TIMEOUT_MS,
 				});
 				return content;
 			} catch {
@@ -59,6 +64,7 @@ export async function getPreviousVersion(filePath: string): Promise<string | nul
 
 		const { stdout: content } = await execFileAsync("git", ["show", `${hash}:${relativePath}`], {
 			cwd: repoRoot,
+			timeout: GIT_TIMEOUT_MS,
 		});
 		return content;
 	} catch {

--- a/packages/cli/src/verify/reporters/markdown.ts
+++ b/packages/cli/src/verify/reporters/markdown.ts
@@ -1,0 +1,95 @@
+import type { VerifyReport, VerifyResult } from "../types.js";
+
+function formatResult(result: VerifyResult): string[] {
+	const lines: string[] = [];
+	const icon = result.match ? "PASS" : "FAIL";
+
+	lines.push(`### ${result.skill} [${icon}]`);
+	lines.push("");
+
+	if (result.declaredBump) {
+		lines.push(
+			`**Declared change:** ${result.declaredBefore ?? "?"} -> ${result.declaredAfter ?? "?"} (${result.declaredBump})`
+		);
+	} else {
+		lines.push("*No previous version for comparison*");
+	}
+	lines.push("");
+
+	if (result.signals.length > 0) {
+		lines.push("**Content analysis:**");
+		lines.push("");
+		lines.push("| Signal | Confidence | Bump | Source |");
+		lines.push("|--------|------------|------|--------|");
+
+		for (const signal of result.signals) {
+			const conf = `${(signal.confidence * 100).toFixed(0)}%`;
+			const reason = signal.reason.replace(/\|/g, "\\|");
+			lines.push(`| ${reason} | ${conf} | ${signal.type} | ${signal.source} |`);
+		}
+		lines.push("");
+	}
+
+	if (result.declaredBump) {
+		if (result.match) {
+			lines.push(`**Assessment:** ${result.assessedBump.toUpperCase()} bump is appropriate`);
+		} else {
+			lines.push(
+				`**Assessment:** ${result.declaredBump.toUpperCase()} bump appears ${result.assessedBump > result.declaredBump ? "INSUFFICIENT" : "EXCESSIVE"}. Recommended: ${result.assessedBump}`
+			);
+		}
+	} else {
+		lines.push(`**Suggested bump:** ${result.assessedBump}`);
+	}
+
+	if (result.explanation) {
+		lines.push("");
+		lines.push(`> ${result.explanation}`);
+	}
+
+	if (result.llmUsed) {
+		lines.push("");
+		lines.push("*LLM-assisted analysis*");
+	}
+
+	lines.push("");
+	return lines;
+}
+
+export function formatVerifyMarkdown(report: VerifyReport): string {
+	const lines: string[] = [];
+	const now = report.generatedAt.split("T")[0];
+
+	lines.push("# Skills Check Verify Report");
+	lines.push("");
+	lines.push(`Generated: ${now}`);
+	lines.push("");
+
+	// Summary table
+	lines.push("## Summary");
+	lines.push("");
+	lines.push("| Status | Count |");
+	lines.push("|--------|-------|");
+	lines.push(`| Passed | ${report.summary.passed} |`);
+	lines.push(`| Failed | ${report.summary.failed} |`);
+	lines.push(`| Skipped | ${report.summary.skipped} |`);
+	const total = report.summary.passed + report.summary.failed + report.summary.skipped;
+	lines.push(`| **Total** | **${total}** |`);
+	lines.push("");
+
+	if (report.results.length === 0) {
+		lines.push("No skills found to verify.");
+		lines.push("");
+		return lines.join("\n");
+	}
+
+	// Results
+	lines.push("## Results");
+	lines.push("");
+
+	for (const result of report.results) {
+		lines.push(...formatResult(result));
+	}
+
+	return lines.join("\n");
+}

--- a/packages/cli/src/verify/reporters/sarif.ts
+++ b/packages/cli/src/verify/reporters/sarif.ts
@@ -1,0 +1,77 @@
+import type { VerifyReport, VerifyResult } from "../types.js";
+
+function toSarifLevel(result: VerifyResult): "error" | "warning" | "note" {
+	return result.match ? "note" : "error";
+}
+
+function buildRules(results: VerifyResult[]): object[] {
+	const seen = new Set<string>();
+	const rules: object[] = [];
+
+	for (const r of results) {
+		const ruleId = `skills-check/verify/${r.match ? "pass" : "mismatch"}`;
+		if (!seen.has(ruleId)) {
+			seen.add(ruleId);
+			rules.push({
+				id: ruleId,
+				shortDescription: {
+					text: r.match ? "Version bump matches content" : "Version bump mismatch",
+				},
+				defaultConfiguration: { level: toSarifLevel(r) },
+			});
+		}
+	}
+
+	return rules;
+}
+
+function buildResults(results: VerifyResult[]): object[] {
+	return results
+		.filter((r) => !r.match)
+		.map((r) => ({
+			ruleId: "skills-check/verify/mismatch",
+			level: "error" as const,
+			message: { text: r.explanation },
+			locations: [
+				{
+					physicalLocation: {
+						artifactLocation: { uri: r.file },
+						region: { startLine: 1 },
+					},
+				},
+			],
+			properties: {
+				skill: r.skill,
+				declaredBump: r.declaredBump,
+				assessedBump: r.assessedBump,
+				llmUsed: r.llmUsed,
+			},
+		}));
+}
+
+export function formatVerifySarif(report: VerifyReport): string {
+	const sarif = {
+		$schema: "https://json.schemastore.org/sarif-2.1.0.json",
+		version: "2.1.0",
+		runs: [
+			{
+				tool: {
+					driver: {
+						name: "skills-check/verify",
+						informationUri: "https://skillscheck.ai",
+						rules: buildRules(report.results),
+					},
+				},
+				results: buildResults(report.results),
+				invocations: [
+					{
+						executionSuccessful: true,
+						endTimeUtc: report.generatedAt,
+					},
+				],
+			},
+		],
+	};
+
+	return JSON.stringify(sarif, null, 2);
+}

--- a/packages/cli/src/verify/types.ts
+++ b/packages/cli/src/verify/types.ts
@@ -30,7 +30,7 @@ export interface VerifyOptions {
 	after?: string;
 	all?: boolean;
 	before?: string;
-	format?: "terminal" | "json";
+	format?: "terminal" | "json" | "markdown";
 	model?: string;
 	output?: string;
 	provider?: string;

--- a/packages/cli/src/verify/types.ts
+++ b/packages/cli/src/verify/types.ts
@@ -30,7 +30,7 @@ export interface VerifyOptions {
 	after?: string;
 	all?: boolean;
 	before?: string;
-	format?: "terminal" | "json" | "markdown";
+	format?: "terminal" | "json" | "markdown" | "sarif";
 	model?: string;
 	output?: string;
 	provider?: string;

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,13 +1,23 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-	entry: ["src/index.ts"],
-	format: ["esm"],
-	target: "node18",
-	clean: true,
-	dts: false,
-	sourcemap: true,
-	banner: {
-		js: "#!/usr/bin/env node",
+export default defineConfig([
+	{
+		entry: ["src/index.ts"],
+		format: ["esm"],
+		target: "node18",
+		clean: true,
+		dts: false,
+		sourcemap: true,
+		banner: {
+			js: "#!/usr/bin/env node",
+		},
 	},
-});
+	{
+		entry: ["src/api.ts"],
+		format: ["esm"],
+		target: "node18",
+		clean: false,
+		dts: true,
+		sourcemap: true,
+	},
+]);


### PR DESCRIPTION
## Summary

This PR adds markdown output format support to audit, lint, policy, and verify commands, and refactors shared threshold/severity comparison logic to eliminate duplication across commands.

## Key Changes

- **New markdown reporters**: Added `formatters/markdown.ts` for audit, lint, policy, and verify commands to generate structured markdown reports alongside existing terminal and JSON formats
- **Shared threshold logic**: Extracted severity/level comparison into `shared/threshold.ts` with `createThresholdChecker()` utility, replacing duplicated `SEVERITY_ORDER` and `meetsThreshold()` implementations in audit, lint, and policy commands
- **Centralized output handling**: Created `shared/reporter.ts` with `formatAndOutput()` function to consolidate the format-switch + file-write pattern used across all reporting commands
- **Updated command interfaces**: Modified `AuditCommandOptions`, `LintCommandOptions`, `PolicyCheckCommandOptions`, and `VerifyCommandOptions` to accept `"markdown"` as a format option
- **Comprehensive test coverage**: Added test suites for refresh, report, init, and check commands with full mock coverage of external dependencies

## Implementation Details

- The threshold checker is generic and reusable: `createThresholdChecker<T>()` accepts any severity ordering and returns a checker with `meetsThreshold()` and `validValues` properties
- Pre-configured instances (`auditThreshold`, `policyThreshold`, `lintThreshold`) provide type-safe severity validation
- Markdown formatters follow consistent structure: summary table, detailed findings grouped by severity/file, and optional supplementary sections (changelog links, LLM indicators, etc.)
- The `formatAndOutput()` helper accepts a formatters map, allowing commands to define their own format implementations while centralizing I/O logic
- All test files use Vitest with comprehensive mocking to avoid filesystem and network dependencies

https://claude.ai/code/session_01ByRTAoGS6Fwjs657efVnNQ