### PR TITLE
feat: migrate to spec-native compatibility field and align with Agent Skills spec

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig — matches biome.jsonc settings
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.{json,jsonc,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,3 @@
 {
-  "recommendations": [
-    "biomejs.biome",
-    "editorconfig.editorconfig"
-  ]
+  "recommendations": ["biomejs.biome", "editorconfig.editorconfig"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,27 @@
+{
+  "editor.insertSpaces": false,
+  "editor.tabSize": 4,
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "editor.rulers": [100],
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2
+  },
+  "[jsonc]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2
+  },
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true
+}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,25 @@
+{
+  "tab_size": 4,
+  "hard_tabs": true,
+  "format_on_save": "on",
+  "formatter": "language_server",
+  "preferred_line_length": 100,
+  "ensure_final_newline_on_save": true,
+  "remove_trailing_whitespace_on_save": true,
+  "languages": {
+    "TypeScript": {
+      "hard_tabs": true,
+      "tab_size": 4,
+      "formatter": "language_server"
+    },
+    "JavaScript": {
+      "hard_tabs": true,
+      "tab_size": 4,
+      "formatter": "language_server"
+    },
+    "JSON": {
+      "hard_tabs": false,
+      "tab_size": 2
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ When implementing features, always check the relevant PRD first. When a PRD is t
 
 | Command | Status | What It Does |
 |---------|--------|-------------|
-| `check` | ✅ Shipped | Detect version drift in skills by comparing `product-version` frontmatter against npm registry |
+| `check` | ✅ Shipped | Detect version drift in skills by comparing `compatibility` or `product-version` frontmatter against npm registry |
 | `report` | ✅ Shipped | Generate a formatted report of check results |
 | `refresh` | ✅ Shipped | AI-assisted update of stale skill files using LLMs (Anthropic, OpenAI, Google) |
 | `audit` | ✅ Shipped | Security scan: hallucinated packages, prompt injection, dangerous commands, dead URLs, metadata gaps |
@@ -126,10 +126,12 @@ cd packages/web && npm run dev
 
 ## Code Style (Biome)
 
-- Tab indentation, 100-char line width
+- **Tab indentation** (not spaces), 100-char line width
 - Double quotes, semicolons always
 - Auto-organized imports
-- Config is in root `biome.json` — no ESLint or Prettier
+- Config is in root `biome.jsonc` — no ESLint or Prettier
+- Editor configs: `.editorconfig`, `.vscode/settings.json`, `.zed/settings.json`
+- **CRITICAL:** All TypeScript/JavaScript files use tabs. The `Edit` tool must preserve exact indentation from `Read` output. When writing new files, use tab characters (`\t`), never spaces for indentation.
 
 ## Architecture Notes
 
@@ -158,7 +160,7 @@ audit/
     advisory.ts                    # Known hallucinated packages (Aikido Security, Socket.dev research)
     injection.ts                   # Prompt injection: override instructions, exfiltration, obfuscation
     commands.ts                    # Dangerous commands: destructive, pipe-to-shell, sensitive access
-    metadata.ts                    # Frontmatter completeness (required: name, description, product-version)
+    metadata.ts                    # Frontmatter completeness (required: name, description)
     urls.ts                        # URL liveness via HEAD requests (10s timeout)
   reporters/
     terminal.ts                    # Chalk-colored, grouped by file, severity icons
@@ -170,6 +172,10 @@ audit/
 Key design: extractors run once per file, checkers consume extracted data. Findings pass through `.skills-checkignore` + inline comment filtering. Registry lookups use layered caching (in-memory Map + disk with TTL).
 
 **This extractor/checker/reporter pattern is the template used by all commands.** Each command follows the same architecture: parse SKILL.md → extract relevant data → run checks → filter → report. Extractors and reporters are reused across commands where possible.
+
+### Compatibility (`packages/cli/src/compatibility/`)
+
+Parser for the spec-native `compatibility` frontmatter field. Splits `"next@^15.0.0, react@19.0.0, docker"` into structured `CompatibilityEntry[]` with package name, optional semver/range, and raw text. Used across all commands via a precedence chain: `compatibility` (preferred) → `product-version` (deprecated fallback). The `resolvedPackages` field on `ScannedSkill` provides a unified view regardless of which field the skill uses. `product-version` still works everywhere but `lint` emits an `info`-level migration notice encouraging adoption of `compatibility`.
 
 ### Shared Infrastructure (`packages/cli/src/shared/`)
 
@@ -189,7 +195,7 @@ Semver verification using a two-layer classifier: heuristic rules (section diffs
 
 ### Lint (`packages/cli/src/lint/`)
 
-Metadata validation with four rule sets: required fields (name, description), publish-ready fields (author, license, repository), conditional fields (product-version when products referenced, agents when agent-specific content), and format validation (semver, SPDX, URLs). Auto-fix populates missing fields from git context. SPDX validation covers 100+ identifiers with OR/AND expressions.
+Metadata validation with four rule sets: required fields (name, description), publish-ready fields (author, license, repository), conditional fields (`compatibility` or `product-version` when products referenced, agents when agent-specific content), and format validation (semver, semver ranges in compatibility, SPDX, URLs). Auto-fix populates missing fields from git context. SPDX validation covers 100+ identifiers with OR/AND expressions.
 
 ### Policy (`packages/cli/src/policy/`)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Quality & integrity layer for [Agent Skills](https://agentskills.io) — like `npm outdated` for skill knowledge.
 
-Skills that reference versioned products (via `product-version` in frontmatter) can drift as upstream packages ship new releases. `skills-check` detects this drift, audits security, lints metadata, analyzes token budgets, enforces policy, and more.
+Skills that reference versioned products (via `compatibility` or `product-version` in frontmatter) can drift as upstream packages ship new releases. `skills-check` detects this drift, audits security, lints metadata, analyzes token budgets, enforces policy, and more.
 
 ## Install
 
@@ -547,11 +547,11 @@ Skills declare their product version in YAML frontmatter:
 ---
 name: ai-sdk-core
 description: "Generate text with Vercel AI SDK..."
-product-version: "6.0.105"
+compatibility: "ai@^6.0.0"
 ---
 ```
 
-The `init` command reads this field and groups skills by shared version + name prefix.
+The spec-native `compatibility` field uses `package@semver` format (e.g., `"next@^15.0.0, react@19.0.0"`). The legacy `product-version` field is still supported as a fallback. The `init` command reads version information and groups skills by shared version + name prefix.
 
 ## CI Integration
 

--- a/packages/cli/src/audit/checkers/metadata.test.ts
+++ b/packages/cli/src/audit/checkers/metadata.test.ts
@@ -12,11 +12,10 @@ function makeContext(frontmatter: Record<string, unknown>): CheckContext {
 }
 
 describe("metadataChecker", () => {
-	it("passes with all required fields", async () => {
+	it("passes with all required and recommended fields", async () => {
 		const ctx = makeContext({
 			name: "my-skill",
 			description: "A useful skill",
-			"product-version": "1.0.0",
 			version: "1.0",
 			author: "test",
 		});
@@ -27,7 +26,6 @@ describe("metadataChecker", () => {
 	it("reports missing name as medium", async () => {
 		const ctx = makeContext({
 			description: "A skill",
-			"product-version": "1.0.0",
 		});
 		const findings = await metadataChecker.check(ctx);
 		const nameFinding = findings.find((f) => f.message.includes("name"));
@@ -38,7 +36,6 @@ describe("metadataChecker", () => {
 	it("reports missing description as medium", async () => {
 		const ctx = makeContext({
 			name: "my-skill",
-			"product-version": "1.0.0",
 		});
 		const findings = await metadataChecker.check(ctx);
 		const descFinding = findings.find((f) => f.message.includes("description"));
@@ -46,22 +43,20 @@ describe("metadataChecker", () => {
 		expect(descFinding?.severity).toBe("medium");
 	});
 
-	it("reports missing product-version as medium", async () => {
+	it("does not require product-version (now handled by lint conditional rule)", async () => {
 		const ctx = makeContext({
 			name: "my-skill",
 			description: "A skill",
 		});
 		const findings = await metadataChecker.check(ctx);
 		const versionFinding = findings.find((f) => f.message.includes("product-version"));
-		expect(versionFinding).toBeDefined();
-		expect(versionFinding?.severity).toBe("medium");
+		expect(versionFinding).toBeUndefined();
 	});
 
 	it("reports missing recommended fields as low", async () => {
 		const ctx = makeContext({
 			name: "my-skill",
 			description: "A skill",
-			"product-version": "1.0.0",
 		});
 		const findings = await metadataChecker.check(ctx);
 		expect(findings.every((f) => f.severity === "low")).toBe(true);
@@ -72,7 +67,6 @@ describe("metadataChecker", () => {
 		const ctx = makeContext({
 			name: "",
 			description: "A skill",
-			"product-version": "1.0.0",
 		});
 		const findings = await metadataChecker.check(ctx);
 		const nameFinding = findings.find((f) => f.message.includes("name"));
@@ -82,8 +76,8 @@ describe("metadataChecker", () => {
 	it("reports all missing fields for empty frontmatter", async () => {
 		const ctx = makeContext({});
 		const findings = await metadataChecker.check(ctx);
-		// 3 required (medium) + 2 recommended (low) = 5
-		expect(findings).toHaveLength(5);
+		// 2 required (medium) + 2 recommended (low) = 4
+		expect(findings).toHaveLength(4);
 	});
 
 	it("uses correct category", async () => {

--- a/packages/cli/src/audit/checkers/metadata.ts
+++ b/packages/cli/src/audit/checkers/metadata.ts
@@ -1,6 +1,6 @@
 import type { AuditChecker, AuditFinding, CheckContext } from "../types.js";
 
-const REQUIRED_FIELDS = ["name", "description", "product-version"] as const;
+const REQUIRED_FIELDS = ["name", "description"] as const;
 const RECOMMENDED_FIELDS = ["version", "author"] as const;
 
 export const metadataChecker: AuditChecker = {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -62,6 +62,14 @@ function autoDetect(productKey: string): { displayName: string; package: string 
 }
 
 /**
+ * Get the version string for a group of skills.
+ * Uses resolvedPackages (which handles the compatibility > product-version precedence).
+ */
+function getGroupVersion(groupSkillsList: Array<{ productVersion?: string }>): string {
+	return groupSkillsList[0]?.productVersion ?? "unknown";
+}
+
+/**
  * Initialize a skills-check.json registry by scanning a skills directory.
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
@@ -83,13 +91,13 @@ export async function initCommand(dir: string, options: InitOptions): Promise<nu
 	const withoutVersion = skills.filter((s) => !s.productVersion);
 
 	console.log(
-		`Found ${chalk.bold(String(skills.length))} skills, ${chalk.bold(String(withVersion.length))} with product-version.`
+		`Found ${chalk.bold(String(skills.length))} skills, ${chalk.bold(String(withVersion.length))} with version tracking.`
 	);
 
 	if (withoutVersion.length > 0) {
 		console.log(
 			chalk.dim(
-				`  Skipping ${withoutVersion.length} without product-version: ${withoutVersion.map((s) => s.name).join(", ")}`
+				`  Skipping ${withoutVersion.length} without version tracking: ${withoutVersion.map((s) => s.name).join(", ")}`
 			)
 		);
 	}
@@ -108,7 +116,7 @@ export async function initCommand(dir: string, options: InitOptions): Promise<nu
 		// Non-interactive: auto-detect mappings
 		for (const [productKey, groupSkillsList] of versionGroups) {
 			const detected = autoDetect(productKey);
-			const version = groupSkillsList[0]?.productVersion ?? "unknown";
+			const version = getGroupVersion(groupSkillsList);
 
 			if (!detected) {
 				console.log(
@@ -152,7 +160,7 @@ export async function initCommand(dir: string, options: InitOptions): Promise<nu
 		try {
 			for (const [productKey, groupSkillsList] of versionGroups) {
 				const detected = autoDetect(productKey);
-				const version = groupSkillsList[0]?.productVersion ?? "unknown";
+				const version = getGroupVersion(groupSkillsList);
 				const defaultPkg = detected?.package;
 				const defaultName = detected?.displayName ?? productKey;
 				const hint = defaultPkg ? ` [${defaultPkg}]` : "";

--- a/packages/cli/src/commands/refresh.ts
+++ b/packages/cli/src/commands/refresh.ts
@@ -4,6 +4,11 @@ import { generateObject } from "ai";
 import chalk from "chalk";
 import matter from "gray-matter";
 import { fetchChangelog } from "../changelog.js";
+import {
+	extractVersionedPackages,
+	formatCompatibility,
+	parseCompatibility,
+} from "../compatibility/index.js";
 import { diffStats, formatDiff } from "../diff.js";
 import { buildSystemPrompt, buildUserPrompt } from "../llm/prompts.js";
 import { resolveModel } from "../llm/providers.js";
@@ -25,6 +30,69 @@ interface RefreshOptions {
 	provider?: string;
 	registry?: string;
 	yes?: boolean;
+}
+
+/**
+ * Resolve the tracked version from a skill file's frontmatter.
+ * Checks compatibility (for a specific package) first, then product-version.
+ */
+function resolveSkillVersion(
+	fm: Record<string, unknown>,
+	targetPackage?: string
+): string | undefined {
+	if (typeof fm.compatibility === "string") {
+		const versioned = extractVersionedPackages(parseCompatibility(fm.compatibility));
+		if (targetPackage) {
+			const match = versioned.find((e) => e.package === targetPackage);
+			if (match?.version) {
+				return match.version;
+			}
+		}
+		if (versioned.length > 0 && versioned[0].version) {
+			return versioned[0].version;
+		}
+	}
+	if (typeof fm["product-version"] === "string") {
+		return fm["product-version"];
+	}
+	return undefined;
+}
+
+/**
+ * Patch the version in a skill file's frontmatter to the target version.
+ * Updates whichever field the skill uses (compatibility or product-version).
+ */
+function patchVersion(
+	written: Awaited<ReturnType<typeof readSkillFile>>,
+	targetVersion: string,
+	targetPackage?: string
+): string {
+	const fm = written.frontmatter;
+
+	if (typeof fm.compatibility === "string") {
+		const entries = parseCompatibility(fm.compatibility);
+		const versioned = extractVersionedPackages(entries);
+		if (versioned.length > 0) {
+			// Update the matching package or the first versioned entry
+			for (const entry of entries) {
+				if (entry.version && (!targetPackage || entry.package === targetPackage)) {
+					entry.version = targetVersion;
+					break;
+				}
+			}
+			fm.compatibility = formatCompatibility(entries);
+			return matter.stringify(written.content, fm);
+		}
+	}
+
+	if (fm["product-version"] !== undefined) {
+		fm["product-version"] = targetVersion;
+		return matter.stringify(written.content, fm);
+	}
+
+	// Neither field exists — add compatibility
+	fm.compatibility = `${targetPackage ?? "unknown"}@${targetVersion}`;
+	return matter.stringify(written.content, fm);
 }
 
 /**
@@ -240,18 +308,17 @@ export async function refreshCommand(
 			if (shouldApply) {
 				await writeSkillFile(skillPath, llmResult.updatedContent);
 
-				// Verify the LLM actually bumped the frontmatter product-version
+				// Verify the LLM actually bumped the version
 				const written = await readSkillFile(skillPath);
-				const writtenVersion = written.frontmatter["product-version"] as string | undefined;
+				const writtenVersion = resolveSkillVersion(written.frontmatter, result.package);
 
 				if (writtenVersion !== result.latestVersion) {
 					console.log(
 						chalk.yellow(
-							`  ⚠ LLM did not bump product-version (got "${writtenVersion ?? "missing"}", expected "${result.latestVersion}") — patching`
+							`  ⚠ LLM did not bump version (got "${writtenVersion ?? "missing"}", expected "${result.latestVersion}") — patching`
 						)
 					);
-					written.frontmatter["product-version"] = result.latestVersion;
-					const patched = matter.stringify(written.content, written.frontmatter);
+					const patched = patchVersion(written, result.latestVersion, result.package);
 					await writeSkillFile(skillPath, patched);
 				}
 

--- a/packages/cli/src/commands/usage.ts
+++ b/packages/cli/src/commands/usage.ts
@@ -2,14 +2,8 @@ import chalk from "chalk";
 import type { UsageOptions } from "../usage/index.js";
 import { runUsage } from "../usage/index.js";
 import { formatUsageJson, formatUsageJsonWithPolicy } from "../usage/reporters/json.js";
-import {
-	formatUsageMarkdown,
-	formatUsageMarkdownWithPolicy,
-} from "../usage/reporters/markdown.js";
-import {
-	formatUsageTerminal,
-	formatUsageTerminalWithPolicy,
-} from "../usage/reporters/terminal.js";
+import { formatUsageMarkdown, formatUsageMarkdownWithPolicy } from "../usage/reporters/markdown.js";
+import { formatUsageTerminal, formatUsageTerminalWithPolicy } from "../usage/reporters/terminal.js";
 
 interface UsageCommandOptions {
 	checkPolicy?: boolean;
@@ -28,6 +22,7 @@ interface UsageCommandOptions {
 	verbose?: boolean;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 export async function usageCommand(options: UsageCommandOptions): Promise<number> {
 	if (options.verbose && options.quiet) {
 		console.error(chalk.red("Cannot use --verbose and --quiet together."));
@@ -51,22 +46,32 @@ export async function usageCommand(options: UsageCommandOptions): Promise<number
 	const { report, violations } = await runUsage(usageOptions);
 
 	// Determine format
-	const format = options.json ? "json" : options.markdown ? "markdown" : (options.format ?? "terminal");
+	let format: string;
+	if (options.json) {
+		format = "json";
+	} else if (options.markdown) {
+		format = "markdown";
+	} else {
+		format = options.format ?? "terminal";
+	}
 
 	// Format output
 	let output: string;
 	if (format === "json") {
-		output = violations.length > 0
-			? formatUsageJsonWithPolicy(report, violations)
-			: formatUsageJson(report);
+		output =
+			violations.length > 0
+				? formatUsageJsonWithPolicy(report, violations)
+				: formatUsageJson(report);
 	} else if (format === "markdown") {
-		output = violations.length > 0
-			? formatUsageMarkdownWithPolicy(report, violations)
-			: formatUsageMarkdown(report);
+		output =
+			violations.length > 0
+				? formatUsageMarkdownWithPolicy(report, violations)
+				: formatUsageMarkdown(report);
 	} else {
-		output = violations.length > 0
-			? formatUsageTerminalWithPolicy(report, violations)
-			: formatUsageTerminal(report);
+		output =
+			violations.length > 0
+				? formatUsageTerminalWithPolicy(report, violations)
+				: formatUsageTerminal(report);
 	}
 
 	if (!options.quiet) {

--- a/packages/cli/src/compatibility/index.ts
+++ b/packages/cli/src/compatibility/index.ts
@@ -1,0 +1,2 @@
+// biome-ignore lint/performance/noBarrelFile: compatibility module barrel export
+export { extractVersionedPackages, formatCompatibility, parseCompatibility } from "./parser.js";

--- a/packages/cli/src/compatibility/parser.test.ts
+++ b/packages/cli/src/compatibility/parser.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { extractVersionedPackages, formatCompatibility, parseCompatibility } from "./parser.js";
+
+describe("parseCompatibility", () => {
+	it("parses simple package@version", () => {
+		const entries = parseCompatibility("next@15.0.0");
+		expect(entries).toEqual([{ package: "next", version: "15.0.0", raw: "next@15.0.0" }]);
+	});
+
+	it("parses multiple packages", () => {
+		const entries = parseCompatibility("next@^15.0.0, react@19.0.0");
+		expect(entries).toHaveLength(2);
+		expect(entries[0]).toEqual({ package: "next", version: "^15.0.0", raw: "next@^15.0.0" });
+		expect(entries[1]).toEqual({
+			package: "react",
+			version: "19.0.0",
+			raw: "react@19.0.0",
+		});
+	});
+
+	it("parses scoped packages", () => {
+		const entries = parseCompatibility("@vercel/blob@4.0.0");
+		expect(entries).toEqual([
+			{ package: "@vercel/blob", version: "4.0.0", raw: "@vercel/blob@4.0.0" },
+		]);
+	});
+
+	it("parses semver ranges", () => {
+		const entries = parseCompatibility("next@^15.0.0, react@>=18.0.0, vue@~3.4.0");
+		expect(entries[0].version).toBe("^15.0.0");
+		expect(entries[1].version).toBe(">=18.0.0");
+		expect(entries[2].version).toBe("~3.4.0");
+	});
+
+	it("handles non-versioned tokens (environment requirements)", () => {
+		const entries = parseCompatibility("docker, network, git");
+		expect(entries).toHaveLength(3);
+		for (const entry of entries) {
+			expect(entry.version).toBeUndefined();
+		}
+		expect(entries[0].package).toBe("docker");
+		expect(entries[1].package).toBe("network");
+		expect(entries[2].package).toBe("git");
+	});
+
+	it("handles mixed versioned and non-versioned", () => {
+		const entries = parseCompatibility("next@^15.0.0, docker, react@19.0.0");
+		expect(entries).toHaveLength(3);
+		expect(entries[0].version).toBe("^15.0.0");
+		expect(entries[1].version).toBeUndefined();
+		expect(entries[2].version).toBe("19.0.0");
+	});
+
+	it("returns empty array for empty string", () => {
+		expect(parseCompatibility("")).toEqual([]);
+	});
+
+	it("returns empty array for whitespace-only", () => {
+		expect(parseCompatibility("   ")).toEqual([]);
+	});
+
+	it("returns empty array for non-string input", () => {
+		expect(parseCompatibility(null as unknown as string)).toEqual([]);
+		expect(parseCompatibility(undefined as unknown as string)).toEqual([]);
+		expect(parseCompatibility(123 as unknown as string)).toEqual([]);
+	});
+
+	it("trims whitespace around tokens", () => {
+		const entries = parseCompatibility("  next@15.0.0 ,  react@19.0.0  ");
+		expect(entries[0].package).toBe("next");
+		expect(entries[1].package).toBe("react");
+	});
+
+	it("handles prerelease versions", () => {
+		const entries = parseCompatibility("next@15.0.0-canary.1");
+		expect(entries[0].version).toBe("15.0.0-canary.1");
+	});
+});
+
+describe("extractVersionedPackages", () => {
+	it("filters to only versioned entries", () => {
+		const entries = parseCompatibility("next@^15.0.0, docker, react@19.0.0");
+		const versioned = extractVersionedPackages(entries);
+		expect(versioned).toHaveLength(2);
+		expect(versioned[0].package).toBe("next");
+		expect(versioned[1].package).toBe("react");
+	});
+
+	it("returns empty array when no versioned entries", () => {
+		const entries = parseCompatibility("docker, network");
+		expect(extractVersionedPackages(entries)).toEqual([]);
+	});
+});
+
+describe("formatCompatibility", () => {
+	it("round-trips versioned packages", () => {
+		const entries = parseCompatibility("next@^15.0.0, react@19.0.0");
+		expect(formatCompatibility(entries)).toBe("next@^15.0.0, react@19.0.0");
+	});
+
+	it("round-trips mixed entries", () => {
+		const entries = parseCompatibility("next@^15.0.0, docker, react@19.0.0");
+		expect(formatCompatibility(entries)).toBe("next@^15.0.0, docker, react@19.0.0");
+	});
+
+	it("handles empty array", () => {
+		expect(formatCompatibility([])).toBe("");
+	});
+});

--- a/packages/cli/src/compatibility/parser.ts
+++ b/packages/cli/src/compatibility/parser.ts
@@ -1,0 +1,57 @@
+/**
+ * Parse the `compatibility` frontmatter field into structured entries.
+ *
+ * Supports formats like:
+ *   "next@^15.0.0, react@19.0.0, docker"
+ *   "@vercel/blob@4.0.0"
+ *   "next@>=14.0.0, network"
+ */
+
+import type { CompatibilityEntry } from "../types.js";
+
+const PACKAGE_VERSION_RE = /^(@?[\w][\w./-]*)@(.+)$/;
+
+/**
+ * Parse a compatibility string into structured entries.
+ * Never throws — unparseable input returns an empty array.
+ */
+export function parseCompatibility(value: string): CompatibilityEntry[] {
+	if (!value || typeof value !== "string") {
+		return [];
+	}
+
+	const tokens = value
+		.split(",")
+		.map((t) => t.trim())
+		.filter(Boolean);
+
+	return tokens.map((token) => {
+		const match = PACKAGE_VERSION_RE.exec(token);
+		if (match) {
+			return {
+				package: match[1],
+				version: match[2],
+				raw: token,
+			};
+		}
+		return {
+			package: token,
+			version: undefined,
+			raw: token,
+		};
+	});
+}
+
+/**
+ * Extract only entries that have a version (i.e., package@semver).
+ */
+export function extractVersionedPackages(entries: CompatibilityEntry[]): CompatibilityEntry[] {
+	return entries.filter((e) => e.version !== undefined);
+}
+
+/**
+ * Format entries back to a compatibility string (round-trip).
+ */
+export function formatCompatibility(entries: CompatibilityEntry[]): string {
+	return entries.map((e) => (e.version ? `${e.package}@${e.version}` : e.package)).join(", ");
+}

--- a/packages/cli/src/fingerprint/extractors/hashes.test.ts
+++ b/packages/cli/src/fingerprint/extractors/hashes.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const WHITESPACE_SPLIT_RE = /\s+/;
+const SHA256_HEX_RE = /^[a-f0-9]{64}$/;
+
 vi.mock("../../budget/tokenizer.js", () => ({
-	countTokens: vi.fn((text: string) => text.split(/\s+/).filter(Boolean).length),
+	countTokens: vi.fn((text: string) => text.split(WHITESPACE_SPLIT_RE).filter(Boolean).length),
 	resetTokenizer: vi.fn(),
 }));
 
@@ -71,7 +74,7 @@ describe("computeFrontmatterHash", () => {
 
 	it("returns a 64-char hex string for sha256", () => {
 		const hash = computeFrontmatterHash("test");
-		expect(hash).toMatch(/^[a-f0-9]{64}$/);
+		expect(hash).toMatch(SHA256_HEX_RE);
 	});
 });
 
@@ -114,7 +117,7 @@ describe("computePrefixHash", () => {
 
 	it("returns a valid hex hash", () => {
 		const hash = computePrefixHash("some test content");
-		expect(hash).toMatch(/^[a-f0-9]{64}$/);
+		expect(hash).toMatch(SHA256_HEX_RE);
 	});
 });
 

--- a/packages/cli/src/fingerprint/extractors/hashes.ts
+++ b/packages/cli/src/fingerprint/extractors/hashes.ts
@@ -6,6 +6,11 @@ import { countTokens } from "../../budget/tokenizer.js";
  * Source is optional.
  */
 const WATERMARK_RE = /<!--\s*skill:([^/\s]+)\/(\S+?)(?:\s+(\S+))?\s*-->/;
+const WHITESPACE_SPLIT_RE = /\s+/;
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+const WHITESPACE_COLLAPSE_RE = /\s+/g;
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+const FRONTMATTER_INJECT_RE = /^(---[\s\S]*?---\r?\n?)/;
 
 export interface WatermarkInfo {
 	name: string;
@@ -58,8 +63,8 @@ export function computeFrontmatterHash(frontmatterRaw: string): string {
  */
 export function normalizeContent(content: string): string {
 	return content
-		.replace(/<!--[\s\S]*?-->/g, "") // strip HTML comments
-		.replace(/\s+/g, " ") // collapse whitespace
+		.replace(HTML_COMMENT_RE, "") // strip HTML comments
+		.replace(WHITESPACE_COLLAPSE_RE, " ") // collapse whitespace
 		.trim();
 }
 
@@ -81,7 +86,7 @@ export function computePrefixHash(content: string): string {
 		return computeHash(normalized);
 	}
 	// Estimate ~1.3 tokens per word, start with ~385 words then adjust
-	const words = normalized.split(/\s+/);
+	const words = normalized.split(WHITESPACE_SPLIT_RE);
 	const estimate = Math.min(words.length, 385);
 	let prefix = words.slice(0, estimate).join(" ");
 	let tc = countTokens(prefix);
@@ -126,7 +131,7 @@ export function injectWatermarkIntoContent(
 	source?: string
 ): { content: string; injected: boolean } {
 	const wm = generateWatermark(name, version, source);
-	const result = raw.replace(/^(---[\s\S]*?---\r?\n?)/, `$1${wm}\n`);
+	const result = raw.replace(FRONTMATTER_INJECT_RE, `$1${wm}\n`);
 	return { content: result, injected: result !== raw };
 }
 
@@ -134,6 +139,6 @@ export function injectWatermarkIntoContent(
  * Extract raw frontmatter string from SKILL.md content.
  */
 export function extractRawFrontmatter(raw: string): string | null {
-	const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw);
+	const match = FRONTMATTER_RE.exec(raw);
 	return match ? match[1] : null;
 }

--- a/packages/cli/src/fingerprint/index.test.ts
+++ b/packages/cli/src/fingerprint/index.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const WHITESPACE_SPLIT_RE = /\s+/;
+const SHA256_HEX_RE = /^[a-f0-9]{64}$/;
+
 vi.mock("../budget/tokenizer.js", () => ({
-	countTokens: vi.fn((text: string) => text.split(/\s+/).filter(Boolean).length),
+	countTokens: vi.fn((text: string) => text.split(WHITESPACE_SPLIT_RE).filter(Boolean).length),
 	resetTokenizer: vi.fn(),
 }));
 
@@ -53,9 +56,9 @@ describe("runFingerprint", () => {
 		expect(result.skills).toHaveLength(1);
 		expect(result.skills[0].name).toBe("react");
 		expect(result.skills[0].version).toBe("19.1.0");
-		expect(result.skills[0].fingerprints.frontmatter_sha256).toMatch(/^[a-f0-9]{64}$/);
-		expect(result.skills[0].fingerprints.content_sha256).toMatch(/^[a-f0-9]{64}$/);
-		expect(result.skills[0].fingerprints.content_prefix_sha256).toMatch(/^[a-f0-9]{64}$/);
+		expect(result.skills[0].fingerprints.frontmatter_sha256).toMatch(SHA256_HEX_RE);
+		expect(result.skills[0].fingerprints.content_sha256).toMatch(SHA256_HEX_RE);
+		expect(result.skills[0].fingerprints.content_prefix_sha256).toMatch(SHA256_HEX_RE);
 		expect(result.skills[0].token_count).toBeGreaterThan(0);
 	});
 

--- a/packages/cli/src/fingerprint/index.ts
+++ b/packages/cli/src/fingerprint/index.ts
@@ -1,6 +1,7 @@
 import { stat } from "node:fs/promises";
 import type { FingerprintEntry, FingerprintRegistry } from "@skills-check/schema";
 import { countTokens } from "../budget/tokenizer.js";
+import { extractVersionedPackages, parseCompatibility } from "../compatibility/index.js";
 import { discoverSkillFiles } from "../shared/discovery.js";
 import { readSkillFile, writeSkillFile } from "../skill-io.js";
 import {
@@ -20,6 +21,26 @@ export interface FingerprintOptions {
 }
 
 /**
+ * Resolve the best version for fingerprinting from frontmatter fields.
+ * Precedence: version > first versioned compatibility entry > product-version > "0.0.0"
+ */
+function resolveFingerprintVersion(fm: Record<string, unknown>): string {
+	if (typeof fm.version === "string") {
+		return fm.version;
+	}
+	if (typeof fm.compatibility === "string") {
+		const versioned = extractVersionedPackages(parseCompatibility(fm.compatibility));
+		if (versioned.length > 0 && versioned[0].version) {
+			return versioned[0].version;
+		}
+	}
+	if (typeof fm["product-version"] === "string") {
+		return fm["product-version"];
+	}
+	return "0.0.0";
+}
+
+/**
  * Run the fingerprint pipeline on skill files.
  *
  * 1. Discover SKILL.md files
@@ -28,6 +49,7 @@ export interface FingerprintOptions {
  * 4. Optionally inject watermarks
  * 5. Return FingerprintRegistry
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 export async function runFingerprint(
 	paths: string[],
 	options: FingerprintOptions = {}
@@ -54,7 +76,7 @@ export async function runFingerprint(
 		const skillFile = await readSkillFile(filePath);
 		const fm = skillFile.frontmatter;
 		const name = (fm.name as string) ?? "unknown";
-		const version = (fm.version as string) ?? (fm["product-version"] as string) ?? "0.0.0";
+		const version = resolveFingerprintVersion(fm);
 		const source = fm.source as string | undefined;
 
 		// Extract raw frontmatter for hashing

--- a/packages/cli/src/lint/field-resolver.ts
+++ b/packages/cli/src/lint/field-resolver.ts
@@ -1,0 +1,54 @@
+/**
+ * Resolve a frontmatter field from both top-level and metadata locations.
+ *
+ * The Agent Skills spec defines exactly 6 top-level fields:
+ * name, description, license, compatibility, allowed-tools, metadata.
+ *
+ * All other fields (author, repository, version, keywords, etc.) belong
+ * in the metadata dict. This resolver accepts both locations for backward
+ * compatibility, preferring top-level when present.
+ */
+
+/**
+ * The 6 fields defined by the Agent Skills specification.
+ * Any other top-level field is non-spec and should live in metadata.
+ */
+export const SPEC_FIELDS = new Set([
+	"name",
+	"description",
+	"license",
+	"compatibility",
+	"allowed-tools",
+	"metadata",
+]);
+
+/**
+ * Resolve a field value from frontmatter, checking both top-level and metadata.
+ * Prefers top-level for backward compatibility.
+ */
+export function resolveField(fm: Record<string, unknown>, field: string): unknown {
+	if (fm[field] !== undefined) {
+		return fm[field];
+	}
+	if (fm.metadata && typeof fm.metadata === "object") {
+		const meta = fm.metadata as Record<string, unknown>;
+		return meta[field];
+	}
+	return undefined;
+}
+
+/**
+ * Resolve a string field from frontmatter, checking both top-level and metadata.
+ */
+export function resolveStringField(fm: Record<string, unknown>, field: string): string | undefined {
+	const value = resolveField(fm, field);
+	return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Check if a field is in a non-spec top-level position.
+ * Returns true if the field exists at top-level and is not one of the 6 spec fields.
+ */
+export function isNonSpecTopLevel(fm: Record<string, unknown>, field: string): boolean {
+	return fm[field] !== undefined && !SPEC_FIELDS.has(field);
+}

--- a/packages/cli/src/lint/index.ts
+++ b/packages/cli/src/lint/index.ts
@@ -1,4 +1,5 @@
 import { stat } from "node:fs/promises";
+import { extractVersionedPackages, parseCompatibility } from "../compatibility/index.js";
 import { extractWatermark, injectWatermarkIntoContent } from "../fingerprint/extractors/hashes.js";
 import { discoverSkillFiles } from "../shared/discovery.js";
 import { readSkillFile, writeSkillFile } from "../skill-io.js";
@@ -9,6 +10,26 @@ import { checkPublishReady } from "./rules/publish.js";
 import { checkRecommended } from "./rules/recommended.js";
 import { checkRequired } from "./rules/required.js";
 import type { LintFinding, LintOptions, LintReport } from "./types.js";
+
+/**
+ * Resolve the best version for watermarking from frontmatter fields.
+ * Precedence: version > first versioned compatibility entry > product-version > "0.0.0"
+ */
+function resolveWatermarkVersion(fm: Record<string, unknown>): string {
+	if (typeof fm.version === "string") {
+		return fm.version;
+	}
+	if (typeof fm.compatibility === "string") {
+		const versioned = extractVersionedPackages(parseCompatibility(fm.compatibility));
+		if (versioned.length > 0 && versioned[0].version) {
+			return versioned[0].version;
+		}
+	}
+	if (typeof fm["product-version"] === "string") {
+		return fm["product-version"];
+	}
+	return "0.0.0";
+}
 
 /**
  * Run the lint pipeline on skill files.
@@ -86,10 +107,7 @@ export async function runLint(paths: string[], options: LintOptions = {}): Promi
 				// Inject watermark if requested and missing
 				if (options.injectWatermarks && !extractWatermark(content)) {
 					const name = (skillFile.frontmatter.name as string) ?? "unknown";
-					const version =
-						(skillFile.frontmatter.version as string) ??
-						(skillFile.frontmatter["product-version"] as string) ??
-						"0.0.0";
+					const version = resolveWatermarkVersion(skillFile.frontmatter);
 					const source = skillFile.frontmatter.source as string | undefined;
 					const wmResult = injectWatermarkIntoContent(content, name, version, source);
 					if (wmResult.injected) {
@@ -113,10 +131,7 @@ export async function runLint(paths: string[], options: LintOptions = {}): Promi
 		// Inject watermark even without other fixes
 		if (options.fix && options.injectWatermarks && !extractWatermark(skillFile.raw)) {
 			const name = (skillFile.frontmatter.name as string) ?? "unknown";
-			const version =
-				(skillFile.frontmatter.version as string) ??
-				(skillFile.frontmatter["product-version"] as string) ??
-				"0.0.0";
+			const version = resolveWatermarkVersion(skillFile.frontmatter);
 			const source = skillFile.frontmatter.source as string | undefined;
 			const wmResult = injectWatermarkIntoContent(skillFile.raw, name, version, source);
 			if (wmResult.injected) {

--- a/packages/cli/src/lint/rules/conditional.test.ts
+++ b/packages/cli/src/lint/rules/conditional.test.ts
@@ -12,28 +12,72 @@ function makeFile(frontmatter: Record<string, unknown>, content: string): SkillF
 }
 
 describe("checkConditional", () => {
-	it("warns about missing product-version when product references exist", () => {
+	it("warns about missing version tracking when product references exist", () => {
 		const file = makeFile({}, "Run `npm install express` to get started.");
 		const findings = checkConditional(file);
-		const pvFinding = findings.find((f) => f.field === "product-version");
-		expect(pvFinding).toBeDefined();
-		expect(pvFinding?.level).toBe("warning");
+		const vFinding = findings.find((f) => f.field === "compatibility");
+		expect(vFinding).toBeDefined();
+		expect(vFinding?.level).toBe("warning");
+		expect(vFinding?.message).toContain("compatibility");
+		expect(vFinding?.message).toContain("product-version");
 	});
 
-	it("does not warn about product-version when it is present", () => {
+	it("does not warn when product-version is present", () => {
 		const file = makeFile(
 			{ "product-version": "4.18.0" },
 			"Run `npm install express` to get started."
 		);
 		const findings = checkConditional(file);
-		const pvFinding = findings.find((f) => f.field === "product-version");
-		expect(pvFinding).toBeUndefined();
+		const vFinding = findings.find((f) => f.field === "compatibility");
+		expect(vFinding).toBeUndefined();
 	});
 
-	it("does not warn about product-version for generic content", () => {
+	it("does not warn when compatibility with versioned entries is present", () => {
+		const file = makeFile(
+			{ compatibility: "express@4.18.0" },
+			"Run `npm install express` to get started."
+		);
+		const findings = checkConditional(file);
+		const vFinding = findings.find((f) => f.field === "compatibility");
+		expect(vFinding).toBeUndefined();
+	});
+
+	it("warns when compatibility has only non-versioned entries", () => {
+		const file = makeFile(
+			{ compatibility: "docker, network" },
+			"Run `npm install express` to get started."
+		);
+		const findings = checkConditional(file);
+		const vFinding = findings.find((f) => f.field === "compatibility");
+		expect(vFinding).toBeDefined();
+	});
+
+	it("does not warn about version tracking for generic content", () => {
 		const file = makeFile({}, "This skill provides general coding best practices.");
 		const findings = checkConditional(file);
-		expect(findings.filter((f) => f.field === "product-version")).toHaveLength(0);
+		expect(findings.filter((f) => f.field === "compatibility")).toHaveLength(0);
+	});
+
+	it("emits info-level deprecation notice when product-version present without compatibility", () => {
+		const file = makeFile(
+			{ "product-version": "4.18.0" },
+			"Run `npm install express` to get started."
+		);
+		const findings = checkConditional(file);
+		const deprecation = findings.find((f) => f.field === "product-version" && f.level === "info");
+		expect(deprecation).toBeDefined();
+		expect(deprecation?.message).toContain("migrating");
+		expect(deprecation?.message).toContain("compatibility");
+	});
+
+	it("does not emit deprecation notice when both compatibility and product-version present", () => {
+		const file = makeFile(
+			{ "product-version": "4.18.0", compatibility: "express@4.18.0" },
+			"Run `npm install express` to get started."
+		);
+		const findings = checkConditional(file);
+		const deprecation = findings.find((f) => f.field === "product-version" && f.level === "info");
+		expect(deprecation).toBeUndefined();
 	});
 
 	it("warns about missing agents when agent-specific content exists", () => {

--- a/packages/cli/src/lint/rules/conditional.ts
+++ b/packages/cli/src/lint/rules/conditional.ts
@@ -1,32 +1,55 @@
+import { extractVersionedPackages, parseCompatibility } from "../../compatibility/index.js";
 import type { SkillFile } from "../../skill-io.js";
 import { detectsAgentSpecific } from "../detection/agent-specific.js";
 import { detectsProduct } from "../detection/product-refs.js";
+import { resolveField } from "../field-resolver.js";
 import type { LintFinding } from "../types.js";
 
 /**
  * Check conditionally required frontmatter fields.
  *
  * These fields are required only when the skill content indicates they are relevant:
- * - product-version: required if the skill references a specific product
+ * - compatibility or product-version: required if the skill references a specific product
  * - agents: required if the skill contains agent-specific instructions
+ *
+ * Fields are resolved from both top-level and metadata locations.
  */
 export function checkConditional(file: SkillFile): LintFinding[] {
 	const findings: LintFinding[] = [];
 	const fm = file.frontmatter;
 
-	// product-version: required if content references a product
-	if (!fm["product-version"] && detectsProduct(file.content)) {
+	// Version tracking: accept compatibility (with versioned entries) OR product-version
+	const hasProductVersion = !!resolveField(fm, "product-version");
+	const hasVersionedCompatibility =
+		typeof fm.compatibility === "string" &&
+		extractVersionedPackages(parseCompatibility(fm.compatibility)).length > 0;
+
+	if (!(hasProductVersion || hasVersionedCompatibility) && detectsProduct(file.content)) {
 		findings.push({
 			file: file.path,
-			field: "product-version",
+			field: "compatibility",
 			level: "warning",
-			message: "Skill references a product but is missing 'product-version' in frontmatter",
+			message:
+				"Skill references a product but is missing 'compatibility' or 'product-version' in frontmatter",
 			fixable: false,
 		});
 	}
 
-	// agents: required if content has agent-specific instructions
-	if (!fm.agents && detectsAgentSpecific(file.content)) {
+	// Deprecation notice: product-version without compatibility
+	if (hasProductVersion && !hasVersionedCompatibility) {
+		findings.push({
+			file: file.path,
+			field: "product-version",
+			level: "info",
+			message:
+				"Consider migrating from 'product-version' to the spec-native 'compatibility' field (e.g., compatibility: \"package@version\")",
+			fixable: false,
+		});
+	}
+
+	// agents: required if content has agent-specific instructions — resolve from both locations
+	const agents = resolveField(fm, "agents");
+	if (!agents && detectsAgentSpecific(file.content)) {
 		findings.push({
 			file: file.path,
 			field: "agents",

--- a/packages/cli/src/lint/rules/format.test.ts
+++ b/packages/cli/src/lint/rules/format.test.ts
@@ -12,53 +12,177 @@ function makeFile(frontmatter: Record<string, unknown>): SkillFile {
 }
 
 describe("checkFormats", () => {
-	it("returns no findings for valid formats", () => {
-		const file = makeFile({
-			name: "my-skill",
-			"product-version": "4.18.0",
-			repository: "https://github.com/test/repo",
-			license: "MIT",
-		});
-		expect(checkFormats(file)).toEqual([]);
+	it("returns no findings for valid spec-compliant frontmatter", () => {
+		const file: SkillFile = {
+			path: "/skills/my-skill/SKILL.md",
+			frontmatter: {
+				name: "my-skill",
+				description: "A test skill",
+				license: "MIT",
+				compatibility: "next@^15.0.0",
+			},
+			content: "Some content here.",
+			raw: "---\n---\nSome content here.",
+		};
+		const findings = checkFormats(file);
+		expect(findings).toEqual([]);
 	});
+
+	// --- name validation (spec-compliant) ---
+
+	it("warns about uppercase in name", () => {
+		const file = makeFile({ name: "My-Skill" });
+		const findings = checkFormats(file);
+		const nameFinding = findings.find(
+			(f) => f.field === "name" && f.message.includes("does not conform")
+		);
+		expect(nameFinding).toBeDefined();
+		expect(nameFinding?.level).toBe("warning");
+	});
+
+	it("warns about underscores in name", () => {
+		const file = makeFile({ name: "my_skill" });
+		const findings = checkFormats(file);
+		const nameFinding = findings.find(
+			(f) => f.field === "name" && f.message.includes("does not conform")
+		);
+		expect(nameFinding).toBeDefined();
+	});
+
+	it("warns about dots in name", () => {
+		const file = makeFile({ name: "my-skill.v2" });
+		const findings = checkFormats(file);
+		const nameFinding = findings.find(
+			(f) => f.field === "name" && f.message.includes("does not conform")
+		);
+		expect(nameFinding).toBeDefined();
+	});
+
+	it("warns about scoped names (not spec-compliant)", () => {
+		const file = makeFile({ name: "@org/my-skill" });
+		const findings = checkFormats(file);
+		const nameFinding = findings.find(
+			(f) => f.field === "name" && f.message.includes("does not conform")
+		);
+		expect(nameFinding).toBeDefined();
+	});
+
+	it("warns about consecutive hyphens in name", () => {
+		const file = makeFile({ name: "my--skill" });
+		const findings = checkFormats(file);
+		const nameFinding = findings.find(
+			(f) => f.field === "name" && f.message.includes("does not conform")
+		);
+		expect(nameFinding).toBeDefined();
+	});
+
+	it("warns about leading hyphen in name", () => {
+		const file = makeFile({ name: "-my-skill" });
+		const findings = checkFormats(file);
+		const nameFinding = findings.find(
+			(f) => f.field === "name" && f.message.includes("does not conform")
+		);
+		expect(nameFinding).toBeDefined();
+	});
+
+	it("accepts valid spec-compliant name", () => {
+		const file = makeFile({ name: "my-skill" });
+		const findings = checkFormats(file);
+		const nameFindings = findings.filter(
+			(f) => f.field === "name" && f.message.includes("does not conform")
+		);
+		expect(nameFindings).toHaveLength(0);
+	});
+
+	it("accepts name with digits", () => {
+		const file = makeFile({ name: "skill2" });
+		const findings = checkFormats(file);
+		const nameFindings = findings.filter(
+			(f) => f.field === "name" && f.message.includes("does not conform")
+		);
+		expect(nameFindings).toHaveLength(0);
+	});
+
+	it("warns about directory name mismatch", () => {
+		const file: SkillFile = {
+			path: "/skills/wrong-dir/SKILL.md",
+			frontmatter: { name: "my-skill" },
+			content: "",
+			raw: "",
+		};
+		const findings = checkFormats(file);
+		const dirFinding = findings.find((f) => f.message.includes("does not match parent directory"));
+		expect(dirFinding).toBeDefined();
+	});
+
+	// --- product-version ---
 
 	it("reports invalid semver for product-version", () => {
 		const file = makeFile({ "product-version": "not-semver" });
 		const findings = checkFormats(file);
-		const pvFinding = findings.find((f) => f.field === "product-version");
+		const pvFinding = findings.find((f) => f.field === "product-version" && f.level === "error");
 		expect(pvFinding).toBeDefined();
-		expect(pvFinding?.level).toBe("error");
 		expect(pvFinding?.message).toContain("Invalid semver");
 	});
 
-	it("accepts valid semver for product-version", () => {
-		const file = makeFile({ "product-version": "1.2.3" });
+	// --- compatibility ---
+
+	it("accepts valid compatibility with semver ranges", () => {
+		const file = makeFile({ compatibility: "next@^15.0.0, react@19.0.0" });
 		const findings = checkFormats(file);
-		expect(findings.filter((f) => f.field === "product-version")).toHaveLength(0);
+		expect(findings.filter((f) => f.field === "compatibility")).toHaveLength(0);
 	});
 
-	it("accepts semver with prerelease", () => {
-		const file = makeFile({ "product-version": "1.2.3-beta.1" });
+	it("accepts compatibility with non-versioned entries", () => {
+		const file = makeFile({ compatibility: "docker, network" });
 		const findings = checkFormats(file);
-		expect(findings.filter((f) => f.field === "product-version")).toHaveLength(0);
+		expect(findings.filter((f) => f.field === "compatibility")).toHaveLength(0);
 	});
+
+	it("reports invalid semver range in compatibility", () => {
+		const file = makeFile({ compatibility: "next@not-a-version" });
+		const findings = checkFormats(file);
+		const cFinding = findings.find((f) => f.field === "compatibility");
+		expect(cFinding).toBeDefined();
+		expect(cFinding?.level).toBe("error");
+	});
+
+	it("reports compatibility exceeding 500 chars", () => {
+		const file = makeFile({ compatibility: `pkg@${"1".repeat(500)}` });
+		const findings = checkFormats(file);
+		const cFinding = findings.find((f) => f.field === "compatibility" && f.message.includes("500"));
+		expect(cFinding).toBeDefined();
+		expect(cFinding?.level).toBe("error");
+	});
+
+	it("accepts scoped packages in compatibility", () => {
+		const file = makeFile({ compatibility: "@vercel/blob@^4.0.0" });
+		const findings = checkFormats(file);
+		expect(findings.filter((f) => f.field === "compatibility" && f.level === "error")).toHaveLength(
+			0
+		);
+	});
+
+	// --- repository ---
 
 	it("reports invalid URL for repository", () => {
 		const file = makeFile({ repository: "not-a-url" });
 		const findings = checkFormats(file);
-		const repoFinding = findings.find((f) => f.field === "repository");
+		const repoFinding = findings.find(
+			(f) => f.field === "repository" && f.message.includes("Invalid URL")
+		);
 		expect(repoFinding).toBeDefined();
 		expect(repoFinding?.level).toBe("error");
-		expect(repoFinding?.message).toContain("Invalid URL");
 	});
 
-	it("reports invalid SPDX license", () => {
+	// --- license (downgraded to info per spec) ---
+
+	it("reports non-SPDX license as info (spec allows any string)", () => {
 		const file = makeFile({ license: "INVALID-LICENSE" });
 		const findings = checkFormats(file);
 		const licenseFinding = findings.find((f) => f.field === "license");
 		expect(licenseFinding).toBeDefined();
-		expect(licenseFinding?.level).toBe("error");
-		expect(licenseFinding?.message).toContain("Invalid SPDX");
+		expect(licenseFinding?.level).toBe("info");
 	});
 
 	it("accepts valid SPDX license expression", () => {
@@ -67,24 +191,55 @@ describe("checkFormats", () => {
 		expect(findings.filter((f) => f.field === "license")).toHaveLength(0);
 	});
 
-	it("reports name with special characters", () => {
-		const file = makeFile({ name: "my skill!!" });
+	// --- metadata value types ---
+
+	it("warns about non-string metadata values", () => {
+		const file = makeFile({
+			metadata: { version: "1.0", count: 42 },
+		});
 		const findings = checkFormats(file);
-		const nameFinding = findings.find((f) => f.field === "name");
-		expect(nameFinding).toBeDefined();
-		expect(nameFinding?.message).toContain("invalid characters");
+		const metaFinding = findings.find((f) => f.field === "metadata.count");
+		expect(metaFinding).toBeDefined();
+		expect(metaFinding?.level).toBe("info");
 	});
 
-	it("accepts name with hyphens and dots", () => {
-		const file = makeFile({ name: "my-skill.v2" });
+	it("accepts all-string metadata values", () => {
+		const file = makeFile({
+			metadata: { version: "1.0", author: "test" },
+		});
 		const findings = checkFormats(file);
-		expect(findings.filter((f) => f.field === "name")).toHaveLength(0);
+		const metaFindings = findings.filter((f) => f.field.startsWith("metadata."));
+		expect(metaFindings).toHaveLength(0);
 	});
 
-	it("accepts scoped name with @", () => {
-		const file = makeFile({ name: "@org/my-skill" });
+	// --- unknown top-level fields ---
+
+	it("warns about non-spec top-level fields", () => {
+		const file = makeFile({ author: "test", version: "1.0" });
 		const findings = checkFormats(file);
-		expect(findings.filter((f) => f.field === "name")).toHaveLength(0);
+		const authorWarning = findings.find(
+			(f) => f.field === "author" && f.message.includes("not defined in the Agent Skills spec")
+		);
+		const versionWarning = findings.find(
+			(f) => f.field === "version" && f.message.includes("not defined in the Agent Skills spec")
+		);
+		expect(authorWarning).toBeDefined();
+		expect(versionWarning).toBeDefined();
+		expect(authorWarning?.level).toBe("info");
+	});
+
+	it("does not warn about spec-defined top-level fields", () => {
+		const file = makeFile({
+			name: "my-skill",
+			description: "Test",
+			license: "MIT",
+			compatibility: "next@15.0.0",
+		});
+		const findings = checkFormats(file);
+		const specFieldWarnings = findings.filter((f) =>
+			f.message.includes("not defined in the Agent Skills spec")
+		);
+		expect(specFieldWarnings).toHaveLength(0);
 	});
 
 	it("skips validation for missing fields", () => {
@@ -92,13 +247,16 @@ describe("checkFormats", () => {
 		expect(checkFormats(file)).toEqual([]);
 	});
 
-	it("skips validation for non-string fields", () => {
+	it("skips validation for non-string typed fields", () => {
 		const file = makeFile({
 			"product-version": 123,
 			repository: 456,
 			license: true,
 			name: 789,
 		});
-		expect(checkFormats(file)).toEqual([]);
+		// Non-string fields skip format checks but still get unknown-field warnings
+		const findings = checkFormats(file);
+		const formatErrors = findings.filter((f) => f.level === "error");
+		expect(formatErrors).toHaveLength(0);
 	});
 });

--- a/packages/cli/src/lint/rules/format.ts
+++ b/packages/cli/src/lint/rules/format.ts
@@ -1,9 +1,18 @@
-import { valid as semverValid } from "semver";
+import { valid as semverValid, validRange as semverValidRange } from "semver";
+import { parseCompatibility } from "../../compatibility/index.js";
 import type { SkillFile } from "../../skill-io.js";
+import { SPEC_FIELDS } from "../field-resolver.js";
 import { isValidSpdx } from "../spdx.js";
 import type { LintFinding } from "../types.js";
 
-const NAME_PATTERN_RE = /^[@a-zA-Z0-9][\w./-]*$/;
+/**
+ * Spec-compliant name pattern:
+ * - Unicode lowercase letters (\p{Ll}), digits, hyphens only
+ * - No leading/trailing hyphens
+ * - No consecutive hyphens
+ * - Must start with a letter or digit
+ */
+const SPEC_NAME_RE = /^[\p{Ll}0-9](?:[\p{Ll}0-9]|-(?=[\p{Ll}0-9]))*$/u;
 
 /**
  * Check the format/validity of frontmatter field values.
@@ -12,14 +21,45 @@ const NAME_PATTERN_RE = /^[@a-zA-Z0-9][\w./-]*$/;
  * the required/publish/conditional/recommended rules.
  *
  * Validations:
+ * - name: spec-compliant (lowercase, hyphens, digits, max 64 chars, NFKC)
  * - product-version: must be valid semver
+ * - compatibility: each @semver portion must be a valid semver range, max 500 chars
  * - repository: must be a valid URL
- * - license: must be a valid SPDX expression
- * - name: must not contain special characters beyond hyphens and dots
+ * - license: SPDX check (info-level, not error — spec allows any string)
+ * - allowed-tools: accepted as string (experimental spec field)
+ * - metadata: values should be strings
+ * - unknown top-level fields: info-level warning for non-spec fields
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: validates many fields
 export function checkFormats(file: SkillFile): LintFinding[] {
 	const findings: LintFinding[] = [];
 	const fm = file.frontmatter;
+
+	// name: spec-compliant validation
+	if (fm.name && typeof fm.name === "string") {
+		const normalized = fm.name.normalize("NFKC");
+		if (!SPEC_NAME_RE.test(normalized)) {
+			findings.push({
+				file: file.path,
+				field: "name",
+				level: "warning",
+				message: `Field 'name' does not conform to the Agent Skills spec: "${fm.name}" (must be lowercase letters, digits, and non-consecutive hyphens only)`,
+				fixable: false,
+			});
+		}
+
+		// Directory name match check
+		const dirName = file.path.split("/").filter(Boolean).at(-2);
+		if (dirName && dirName !== normalized) {
+			findings.push({
+				file: file.path,
+				field: "name",
+				level: "warning",
+				message: `Field 'name' ("${fm.name}") does not match parent directory name ("${dirName}")`,
+				fixable: false,
+			});
+		}
+	}
 
 	// product-version: valid semver
 	if (
@@ -34,6 +74,32 @@ export function checkFormats(file: SkillFile): LintFinding[] {
 			message: `Invalid semver for 'product-version': "${fm["product-version"]}"`,
 			fixable: false,
 		});
+	}
+
+	// compatibility: each @version portion must be a valid semver range, max 500 chars
+	if (fm.compatibility && typeof fm.compatibility === "string") {
+		if (fm.compatibility.length > 500) {
+			findings.push({
+				file: file.path,
+				field: "compatibility",
+				level: "error",
+				message: `Field 'compatibility' exceeds maximum length of 500 characters (${fm.compatibility.length})`,
+				fixable: false,
+			});
+		}
+
+		const entries = parseCompatibility(fm.compatibility);
+		for (const entry of entries) {
+			if (entry.version && !semverValidRange(entry.version)) {
+				findings.push({
+					file: file.path,
+					field: "compatibility",
+					level: "error",
+					message: `Invalid semver range in 'compatibility': "${entry.raw}"`,
+					fixable: false,
+				});
+			}
+		}
 	}
 
 	// repository: valid URL
@@ -51,26 +117,44 @@ export function checkFormats(file: SkillFile): LintFinding[] {
 		}
 	}
 
-	// license: valid SPDX
+	// license: SPDX check at info level (spec allows any string)
 	if (fm.license && typeof fm.license === "string" && !isValidSpdx(fm.license)) {
 		findings.push({
 			file: file.path,
 			field: "license",
-			level: "error",
-			message: `Invalid SPDX license identifier: "${fm.license}"`,
+			level: "info",
+			message: `License "${fm.license}" is not a recognized SPDX identifier. Valid SPDX expressions are recommended for publishing.`,
 			fixable: false,
 		});
 	}
 
-	// name: no special characters beyond hyphens, dots, slashes, and @
-	if (fm.name && typeof fm.name === "string" && !NAME_PATTERN_RE.test(fm.name)) {
-		findings.push({
-			file: file.path,
-			field: "name",
-			level: "error",
-			message: `Field 'name' contains invalid characters: "${fm.name}" (use only letters, numbers, hyphens, dots)`,
-			fixable: false,
-		});
+	// metadata: values should be strings per spec
+	if (fm.metadata && typeof fm.metadata === "object" && !Array.isArray(fm.metadata)) {
+		const meta = fm.metadata as Record<string, unknown>;
+		for (const [key, value] of Object.entries(meta)) {
+			if (value !== undefined && value !== null && typeof value !== "string") {
+				findings.push({
+					file: file.path,
+					field: `metadata.${key}`,
+					level: "info",
+					message: `Metadata value for '${key}' should be a string per the Agent Skills spec, got ${typeof value}`,
+					fixable: false,
+				});
+			}
+		}
+	}
+
+	// Unknown top-level fields: warn about non-spec fields
+	for (const key of Object.keys(fm)) {
+		if (!SPEC_FIELDS.has(key)) {
+			findings.push({
+				file: file.path,
+				field: key,
+				level: "info",
+				message: `Field '${key}' is not defined in the Agent Skills spec. Consider moving it to metadata.${key}`,
+				fixable: false,
+			});
+		}
 	}
 
 	return findings;

--- a/packages/cli/src/lint/rules/publish.test.ts
+++ b/packages/cli/src/lint/rules/publish.test.ts
@@ -21,6 +21,17 @@ describe("checkPublishReady", () => {
 		expect(checkPublishReady(file)).toEqual([]);
 	});
 
+	it("resolves fields from metadata location", () => {
+		const file = makeFile({
+			metadata: {
+				author: "test-author",
+				repository: "https://github.com/test/repo",
+			},
+			license: "MIT",
+		});
+		expect(checkPublishReady(file)).toEqual([]);
+	});
+
 	it("reports missing author as fixable", () => {
 		const file = makeFile({
 			license: "MIT",
@@ -55,7 +66,7 @@ describe("checkPublishReady", () => {
 		expect(repoFinding?.fixable).toBe(true);
 	});
 
-	it("reports invalid SPDX license as not fixable", () => {
+	it("reports invalid SPDX license as warning (spec allows any string)", () => {
 		const file = makeFile({
 			author: "test-author",
 			license: "INVALID",
@@ -64,7 +75,8 @@ describe("checkPublishReady", () => {
 		const findings = checkPublishReady(file);
 		const licenseFinding = findings.find((f) => f.field === "license");
 		expect(licenseFinding).toBeDefined();
-		expect(licenseFinding?.message).toContain("Invalid SPDX");
+		expect(licenseFinding?.level).toBe("warning");
+		expect(licenseFinding?.message).toContain("not a recognized SPDX");
 		expect(licenseFinding?.fixable).toBe(false);
 	});
 

--- a/packages/cli/src/lint/rules/publish.ts
+++ b/packages/cli/src/lint/rules/publish.ts
@@ -1,4 +1,5 @@
 import type { SkillFile } from "../../skill-io.js";
+import { resolveField } from "../field-resolver.js";
 import { isValidSpdx } from "../spdx.js";
 import type { LintFinding } from "../types.js";
 
@@ -9,13 +10,16 @@ import type { LintFinding } from "../types.js";
  * - author: non-empty string (fixable via git config)
  * - license: valid SPDX identifier (fixable with MIT default)
  * - repository: valid URL (fixable via git remote)
+ *
+ * Fields are resolved from both top-level and metadata locations.
  */
 export function checkPublishReady(file: SkillFile): LintFinding[] {
 	const findings: LintFinding[] = [];
 	const fm = file.frontmatter;
 
-	// author
-	if (!fm.author || (typeof fm.author === "string" && fm.author.trim() === "")) {
+	// author — resolve from top-level or metadata
+	const author = resolveField(fm, "author");
+	if (!author || (typeof author === "string" && author.trim() === "")) {
 		findings.push({
 			file: file.path,
 			field: "author",
@@ -23,18 +27,19 @@ export function checkPublishReady(file: SkillFile): LintFinding[] {
 			message: "Missing required field for publish: author",
 			fixable: true,
 		});
-	} else if (typeof fm.author !== "string") {
+	} else if (typeof author !== "string") {
 		findings.push({
 			file: file.path,
 			field: "author",
 			level: "error",
-			message: `Field 'author' must be a string, got ${typeof fm.author}`,
+			message: `Field 'author' must be a string, got ${typeof author}`,
 			fixable: false,
 		});
 	}
 
-	// license
-	if (!fm.license || (typeof fm.license === "string" && fm.license.trim() === "")) {
+	// license — spec allows any string, but SPDX is required for npm publishing
+	const license = resolveField(fm, "license");
+	if (!license || (typeof license === "string" && license.trim() === "")) {
 		findings.push({
 			file: file.path,
 			field: "license",
@@ -42,18 +47,19 @@ export function checkPublishReady(file: SkillFile): LintFinding[] {
 			message: "Missing required field for publish: license",
 			fixable: true,
 		});
-	} else if (typeof fm.license === "string" && !isValidSpdx(fm.license)) {
+	} else if (typeof license === "string" && !isValidSpdx(license)) {
 		findings.push({
 			file: file.path,
 			field: "license",
-			level: "error",
-			message: `Invalid SPDX license identifier: "${fm.license}"`,
+			level: "warning",
+			message: `License "${license}" is not a recognized SPDX identifier. Valid SPDX is recommended for npm publishing.`,
 			fixable: false,
 		});
 	}
 
-	// repository
-	if (!fm.repository || (typeof fm.repository === "string" && fm.repository.trim() === "")) {
+	// repository — resolve from top-level or metadata
+	const repository = resolveField(fm, "repository");
+	if (!repository || (typeof repository === "string" && repository.trim() === "")) {
 		findings.push({
 			file: file.path,
 			field: "repository",
@@ -61,15 +67,15 @@ export function checkPublishReady(file: SkillFile): LintFinding[] {
 			message: "Missing required field for publish: repository",
 			fixable: true,
 		});
-	} else if (typeof fm.repository === "string") {
+	} else if (typeof repository === "string") {
 		try {
-			new URL(fm.repository);
+			new URL(repository);
 		} catch {
 			findings.push({
 				file: file.path,
 				field: "repository",
 				level: "error",
-				message: `Field 'repository' is not a valid URL: "${fm.repository}"`,
+				message: `Field 'repository' is not a valid URL: "${repository}"`,
 				fixable: false,
 			});
 		}

--- a/packages/cli/src/lint/rules/recommended.ts
+++ b/packages/cli/src/lint/rules/recommended.ts
@@ -1,4 +1,5 @@
 import type { SkillFile } from "../../skill-io.js";
+import { resolveField } from "../field-resolver.js";
 import type { LintFinding } from "../types.js";
 
 /**
@@ -7,13 +8,16 @@ import type { LintFinding } from "../types.js";
  * These fields are not required but improve discoverability and tooling:
  * - spec-version: which version of the Agent Skills spec the skill conforms to
  * - keywords: discovery tags (array with at least 1 item)
+ *
+ * Fields are resolved from both top-level and metadata locations.
  */
 export function checkRecommended(file: SkillFile): LintFinding[] {
 	const findings: LintFinding[] = [];
 	const fm = file.frontmatter;
 
-	// spec-version
-	if (!fm["spec-version"]) {
+	// spec-version — resolve from top-level or metadata
+	const specVersion = resolveField(fm, "spec-version");
+	if (!specVersion) {
 		findings.push({
 			file: file.path,
 			field: "spec-version",
@@ -21,18 +25,19 @@ export function checkRecommended(file: SkillFile): LintFinding[] {
 			message: "Missing recommended field: spec-version",
 			fixable: false,
 		});
-	} else if (typeof fm["spec-version"] !== "string") {
+	} else if (typeof specVersion !== "string") {
 		findings.push({
 			file: file.path,
 			field: "spec-version",
 			level: "info",
-			message: `Field 'spec-version' should be a string, got ${typeof fm["spec-version"]}`,
+			message: `Field 'spec-version' should be a string, got ${typeof specVersion}`,
 			fixable: false,
 		});
 	}
 
-	// keywords
-	if (!fm.keywords) {
+	// keywords — resolve from top-level or metadata
+	const keywords = resolveField(fm, "keywords");
+	if (!keywords) {
 		findings.push({
 			file: file.path,
 			field: "keywords",
@@ -40,15 +45,15 @@ export function checkRecommended(file: SkillFile): LintFinding[] {
 			message: "Missing recommended field: keywords",
 			fixable: false,
 		});
-	} else if (!Array.isArray(fm.keywords)) {
+	} else if (!Array.isArray(keywords)) {
 		findings.push({
 			file: file.path,
 			field: "keywords",
 			level: "info",
-			message: `Field 'keywords' should be an array, got ${typeof fm.keywords}`,
+			message: `Field 'keywords' should be an array, got ${typeof keywords}`,
 			fixable: false,
 		});
-	} else if (fm.keywords.length === 0) {
+	} else if (keywords.length === 0) {
 		findings.push({
 			file: file.path,
 			field: "keywords",

--- a/packages/cli/src/lint/rules/required.test.ts
+++ b/packages/cli/src/lint/rules/required.test.ts
@@ -38,15 +38,25 @@ describe("checkRequired", () => {
 		expect(findings[0].field).toBe("name");
 	});
 
-	it("reports name exceeding max length", () => {
+	it("reports name exceeding max length of 64 chars", () => {
 		const file = makeFile({
-			name: "a".repeat(101),
-			description: "A useful skill for testing purposes and more.",
+			name: "a".repeat(65),
+			description: "A useful skill.",
 		});
 		const findings = checkRequired(file);
 		expect(findings).toHaveLength(1);
 		expect(findings[0].field).toBe("name");
 		expect(findings[0].message).toContain("exceeds maximum length");
+		expect(findings[0].message).toContain("64");
+	});
+
+	it("accepts name at exactly 64 chars", () => {
+		const file = makeFile({
+			name: "a".repeat(64),
+			description: "A useful skill.",
+		});
+		const findings = checkRequired(file);
+		expect(findings.filter((f) => f.field === "name")).toHaveLength(0);
 	});
 
 	it("reports non-string name", () => {
@@ -67,20 +77,25 @@ describe("checkRequired", () => {
 		expect(findings[0].level).toBe("error");
 	});
 
-	it("reports description too short", () => {
+	it("accepts short descriptions (spec allows 1+ chars)", () => {
 		const file = makeFile({ name: "my-skill", description: "Short" });
 		const findings = checkRequired(file);
-		expect(findings).toHaveLength(1);
-		expect(findings[0].field).toBe("description");
-		expect(findings[0].message).toContain("too short");
+		expect(findings.filter((f) => f.field === "description")).toHaveLength(0);
 	});
 
-	it("reports description too long", () => {
-		const file = makeFile({ name: "my-skill", description: "x".repeat(501) });
+	it("reports description exceeding 1024 chars", () => {
+		const file = makeFile({ name: "my-skill", description: "x".repeat(1025) });
 		const findings = checkRequired(file);
 		expect(findings).toHaveLength(1);
 		expect(findings[0].field).toBe("description");
 		expect(findings[0].message).toContain("exceeds maximum length");
+		expect(findings[0].message).toContain("1024");
+	});
+
+	it("accepts description at exactly 1024 chars", () => {
+		const file = makeFile({ name: "my-skill", description: "x".repeat(1024) });
+		const findings = checkRequired(file);
+		expect(findings.filter((f) => f.field === "description")).toHaveLength(0);
 	});
 
 	it("reports both missing name and description", () => {

--- a/packages/cli/src/lint/rules/required.ts
+++ b/packages/cli/src/lint/rules/required.ts
@@ -5,8 +5,8 @@ import type { LintFinding } from "../types.js";
  * Check always-required frontmatter fields.
  *
  * These fields are required by the Agent Skills spec for any SKILL.md file:
- * - name: must be a non-empty string, max 100 characters
- * - description: must be a non-empty string, 20-500 characters
+ * - name: must be a non-empty string, max 64 characters (spec limit)
+ * - description: must be a non-empty string, 1-1024 characters (spec limit)
  */
 export function checkRequired(file: SkillFile): LintFinding[] {
 	const findings: LintFinding[] = [];
@@ -29,12 +29,12 @@ export function checkRequired(file: SkillFile): LintFinding[] {
 			message: `Field 'name' must be a string, got ${typeof fm.name}`,
 			fixable: false,
 		});
-	} else if (fm.name.length > 100) {
+	} else if (fm.name.length > 64) {
 		findings.push({
 			file: file.path,
 			field: "name",
 			level: "error",
-			message: `Field 'name' exceeds maximum length of 100 characters (${fm.name.length})`,
+			message: `Field 'name' exceeds maximum length of 64 characters (${fm.name.length})`,
 			fixable: false,
 		});
 	}
@@ -58,20 +58,12 @@ export function checkRequired(file: SkillFile): LintFinding[] {
 		});
 	} else {
 		const descLen = fm.description.trim().length;
-		if (descLen < 20) {
+		if (descLen > 1024) {
 			findings.push({
 				file: file.path,
 				field: "description",
 				level: "error",
-				message: `Field 'description' is too short (${descLen} chars, minimum 20)`,
-				fixable: false,
-			});
-		} else if (descLen > 500) {
-			findings.push({
-				file: file.path,
-				field: "description",
-				level: "error",
-				message: `Field 'description' exceeds maximum length of 500 characters (${descLen})`,
+				message: `Field 'description' exceeds maximum length of 1024 characters (${descLen})`,
 				fixable: false,
 			});
 		}

--- a/packages/cli/src/llm/prompts.ts
+++ b/packages/cli/src/llm/prompts.ts
@@ -11,7 +11,7 @@ Given a SKILL.md file and information about a version update, produce an updated
 1. **Preserve structure and style**: Keep the same markdown formatting, heading hierarchy, frontmatter layout, and writing tone as the original.
 2. **Update code examples**: Modify code snippets to use new APIs, function signatures, or patterns introduced in the version update.
 3. **Update API references**: Fix any deprecated methods, renamed functions, or changed parameters.
-4. **Bump the frontmatter version**: Update the \`product-version\` field in the frontmatter to match the new version.
+4. **Update version references**: If the skill uses \`compatibility\`, update the relevant \`package@version\` entry. If it uses \`product-version\`, update that field. Prefer the \`compatibility\` field format: \`package@version\`.
 5. **Don't add speculative information**: Only include changes you can verify from the changelog. If the changelog is unavailable, make minimal updates (version bump + any commonly-known changes).
 6. **Don't remove content**: Don't delete sections unless the changelog explicitly indicates a feature was removed.
 7. **Mark confidence based on changelog quality**:

--- a/packages/cli/src/policy/init.ts
+++ b/packages/cli/src/policy/init.ts
@@ -56,7 +56,7 @@ content:
 freshness:
   max_age_days: 90
   # max_version_drift: minor
-  require_product_version: false
+  require_version_tracking: false
 
 # Audit integration
 audit:

--- a/packages/cli/src/policy/types.ts
+++ b/packages/cli/src/policy/types.ts
@@ -11,7 +11,9 @@ export interface SkillPolicy {
 	freshness?: {
 		max_age_days?: number;
 		max_version_drift?: "major" | "minor" | "patch";
+		/** @deprecated Use require_version_tracking instead */
 		require_product_version?: boolean;
+		require_version_tracking?: boolean;
 	};
 	metadata?: {
 		required_fields?: string[];

--- a/packages/cli/src/policy/validators/freshness.test.ts
+++ b/packages/cli/src/policy/validators/freshness.test.ts
@@ -3,6 +3,8 @@ import type { SkillFile } from "../../skill-io.js";
 import type { SkillPolicy } from "../types.js";
 import { checkFreshness } from "./freshness.js";
 
+const DAYS_AGO_RE = /\d+ days ago/;
+
 function makeSkillFile(frontmatter: Record<string, unknown>, content?: string): SkillFile {
 	const c = content ?? "# Test\n";
 	return {
@@ -32,7 +34,7 @@ describe("checkFreshness", () => {
 		const findings = checkFreshness(file, policy);
 		expect(findings).toHaveLength(1);
 		expect(findings[0].severity).toBe("warning");
-		expect(findings[0].message).toContain("100");
+		expect(findings[0].message).toMatch(DAYS_AGO_RE);
 		expect(findings[0].message).toContain("max: 90");
 	});
 
@@ -61,7 +63,7 @@ describe("checkFreshness", () => {
 		expect(findings[0].message).toContain("No last-verified date");
 	});
 
-	it("flags product-referencing skill without product-version", () => {
+	it("flags product-referencing skill without version tracking", () => {
 		const content = "# AI SDK\n\nUse `npm install ai` to install AI SDK 4.0.\n";
 		const file = makeSkillFile({}, content);
 		const policy: SkillPolicy = {
@@ -82,6 +84,40 @@ describe("checkFreshness", () => {
 		};
 		const findings = checkFreshness(file, policy);
 		expect(findings).toEqual([]);
+	});
+
+	it("does not flag skill with versioned compatibility set", () => {
+		const content = "# AI SDK\n\nUse `npm install ai` to install AI SDK 4.0.\n";
+		const file = makeSkillFile({ compatibility: "ai@4.0.0" }, content);
+		const policy: SkillPolicy = {
+			version: 1,
+			freshness: { require_product_version: true },
+		};
+		const findings = checkFreshness(file, policy);
+		expect(findings).toEqual([]);
+	});
+
+	it("flags skill with only non-versioned compatibility", () => {
+		const content = "# AI SDK\n\nUse `npm install ai` to install AI SDK 4.0.\n";
+		const file = makeSkillFile({ compatibility: "docker, network" }, content);
+		const policy: SkillPolicy = {
+			version: 1,
+			freshness: { require_product_version: true },
+		};
+		const findings = checkFreshness(file, policy);
+		expect(findings).toHaveLength(1);
+	});
+
+	it("supports require_version_tracking as alias for require_product_version", () => {
+		const content = "# AI SDK\n\nUse `npm install ai` to install AI SDK 4.0.\n";
+		const file = makeSkillFile({}, content);
+		const policy: SkillPolicy = {
+			version: 1,
+			freshness: { require_version_tracking: true },
+		};
+		const findings = checkFreshness(file, policy);
+		expect(findings).toHaveLength(1);
+		expect(findings[0].rule).toBe("freshness.require_product_version");
 	});
 
 	it("does not flag non-product skill without product-version", () => {

--- a/packages/cli/src/policy/validators/freshness.ts
+++ b/packages/cli/src/policy/validators/freshness.ts
@@ -1,3 +1,4 @@
+import { extractVersionedPackages, parseCompatibility } from "../../compatibility/index.js";
 import { detectsProduct } from "../../lint/detection/product-refs.js";
 import type { SkillFile } from "../../skill-io.js";
 import type { PolicyFinding, SkillPolicy } from "../types.js";
@@ -41,14 +42,21 @@ export function checkFreshness(file: SkillFile, policy: SkillPolicy): PolicyFind
 		}
 	}
 
-	// Check require_product_version
-	if (policy.freshness.require_product_version) {
+	// Check require_product_version or require_version_tracking
+	const requireVersionTracking =
+		policy.freshness.require_version_tracking ?? policy.freshness.require_product_version;
+
+	if (requireVersionTracking) {
 		const hasProductVersion =
 			fm["product-version"] !== undefined &&
 			fm["product-version"] !== null &&
 			fm["product-version"] !== "";
 
-		if (!hasProductVersion) {
+		const hasVersionedCompatibility =
+			typeof fm.compatibility === "string" &&
+			extractVersionedPackages(parseCompatibility(fm.compatibility)).length > 0;
+
+		if (!(hasProductVersion || hasVersionedCompatibility)) {
 			// Only flag if the skill references a product
 			const refsProduct = detectsProduct(file.content);
 			if (refsProduct) {
@@ -56,7 +64,8 @@ export function checkFreshness(file: SkillFile, policy: SkillPolicy): PolicyFind
 					file: file.path,
 					severity: "violation",
 					rule: "freshness.require_product_version",
-					message: "Skill references a product but does not declare product-version",
+					message:
+						"Skill references a product but does not declare version tracking (compatibility or product-version)",
 				});
 			}
 		}

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1,10 +1,34 @@
 import { lstat, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import matter from "gray-matter";
+import { extractVersionedPackages, parseCompatibility } from "./compatibility/index.js";
 import type { ScannedSkill } from "./types.js";
 
 /**
- * Scan a directory of skills for SKILL.md files and extract frontmatter.
+ * Try to read a skill file from a directory, preferring SKILL.md over skill.md.
+ */
+async function readSkillContent(
+	dirPath: string
+): Promise<{ content: string; path: string } | null> {
+	const uppercase = join(dirPath, "SKILL.md");
+	try {
+		const content = await readFile(uppercase, "utf-8");
+		return { content, path: uppercase };
+	} catch {
+		// Try lowercase fallback
+	}
+
+	const lowercase = join(dirPath, "skill.md");
+	try {
+		const content = await readFile(lowercase, "utf-8");
+		return { content, path: lowercase };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Scan a directory of skills for SKILL.md (or skill.md) files and extract frontmatter.
  * Expects directory structure: skills/{skill-name}/SKILL.md
  */
 export async function scanSkills(skillsDir: string): Promise<ScannedSkill[]> {
@@ -18,8 +42,6 @@ export async function scanSkills(skillsDir: string): Promise<ScannedSkill[]> {
 	const results = await Promise.all(
 		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 		entries.map(async (entry): Promise<ScannedSkill | null> => {
-			const skillPath = join(skillsDir, entry, "SKILL.md");
-
 			try {
 				const info = await lstat(join(skillsDir, entry));
 				if (!info.isDirectory()) {
@@ -29,13 +51,12 @@ export async function scanSkills(skillsDir: string): Promise<ScannedSkill[]> {
 				return null;
 			}
 
-			let content: string;
-			try {
-				content = await readFile(skillPath, "utf-8");
-			} catch {
-				// No SKILL.md in this directory, skip
+			const result = await readSkillContent(join(skillsDir, entry));
+			if (!result) {
 				return null;
 			}
+
+			const { content, path: skillPath } = result;
 
 			try {
 				const { data } = matter(content);
@@ -66,6 +87,34 @@ export async function scanSkills(skillsDir: string): Promise<ScannedSkill[]> {
 				}
 				if (!skill.product && typeof data.product === "string") {
 					skill.product = data.product;
+				}
+
+				// Parse compatibility field
+				if (typeof data.compatibility === "string") {
+					skill.compatibility = data.compatibility;
+					skill.compatibilityEntries = parseCompatibility(data.compatibility);
+				}
+
+				// Extract allowed-tools (experimental spec field)
+				if (typeof data["allowed-tools"] === "string") {
+					skill.allowedTools = data["allowed-tools"];
+				}
+
+				// Build resolvedPackages via precedence chain
+				const versionedCompat = skill.compatibilityEntries
+					? extractVersionedPackages(skill.compatibilityEntries)
+					: [];
+
+				if (versionedCompat.length > 0) {
+					skill.resolvedPackages = versionedCompat;
+				} else if (skill.productVersion) {
+					skill.resolvedPackages = [
+						{
+							package: skill.product ?? skill.name,
+							version: skill.productVersion,
+							raw: skill.productVersion,
+						},
+					];
 				}
 
 				return skill;

--- a/packages/cli/src/shared/discovery.ts
+++ b/packages/cli/src/shared/discovery.ts
@@ -2,11 +2,36 @@ import { lstat, readdir } from "node:fs/promises";
 import { join } from "node:path";
 
 /**
- * Recursively discover SKILL.md files in a directory.
+ * Try to find a skill file in a directory.
+ * Prefers SKILL.md (spec convention), falls back to skill.md.
+ * Returns the full path if found, null otherwise.
+ */
+async function findSkillFile(dirPath: string): Promise<string | null> {
+	// Prefer SKILL.md (spec convention)
+	const uppercase = join(dirPath, "SKILL.md");
+	try {
+		await lstat(uppercase);
+		return uppercase;
+	} catch {
+		// Try lowercase fallback
+	}
+
+	const lowercase = join(dirPath, "skill.md");
+	try {
+		await lstat(lowercase);
+		return lowercase;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Recursively discover SKILL.md (or skill.md) files in a directory.
  *
- * Walks the directory tree looking for SKILL.md files. When a directory
- * contains a SKILL.md, that file is collected and the directory is not
- * recursed further. Results are returned sorted alphabetically.
+ * Walks the directory tree looking for skill files. When a directory
+ * contains a SKILL.md or skill.md, that file is collected and the
+ * directory is not recursed further. Results are returned sorted
+ * alphabetically. Prefers SKILL.md over skill.md per the spec.
  */
 export async function discoverSkillFiles(dir: string): Promise<string[]> {
 	const files: string[] = [];
@@ -23,16 +48,15 @@ export async function discoverSkillFiles(dir: string): Promise<string[]> {
 		try {
 			const info = await lstat(fullPath);
 			if (info.isDirectory()) {
-				const skillPath = join(fullPath, "SKILL.md");
-				try {
-					await lstat(skillPath);
-					files.push(skillPath);
-				} catch {
-					// No SKILL.md here — recurse deeper
+				const skillFile = await findSkillFile(fullPath);
+				if (skillFile) {
+					files.push(skillFile);
+				} else {
+					// No skill file here — recurse deeper
 					const nested = await discoverSkillFiles(fullPath);
 					files.push(...nested);
 				}
-			} else if (entry === "SKILL.md") {
+			} else if (entry === "SKILL.md" || entry === "skill.md") {
 				files.push(fullPath);
 			}
 		} catch {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -16,13 +16,27 @@ export interface CheckResult {
 }
 
 /**
+ * A parsed entry from the `compatibility` frontmatter field.
+ */
+export interface CompatibilityEntry {
+	package: string;
+	raw: string; // original text fragment
+	version?: string; // semver or range
+}
+
+/**
  * Scanned skill from SKILL.md frontmatter
  */
 export interface ScannedSkill {
+	allowedTools?: string;
+	compatibility?: string;
+	compatibilityEntries?: CompatibilityEntry[];
 	name: string;
 	path: string;
 	product?: string;
+	/** @deprecated Use `resolvedPackages` from compatibility field instead */
 	productVersion?: string;
+	resolvedPackages?: CompatibilityEntry[];
 }
 
 /**

--- a/packages/cli/src/usage/analyzer.test.ts
+++ b/packages/cli/src/usage/analyzer.test.ts
@@ -1,10 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillTelemetryEvent } from "@skills-check/schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../budget/cost.js", () => ({
 	estimateCost: vi.fn((tokens: number) => ({
 		model: "claude-sonnet",
-		costPer1KLoads: tokens * 0.000003,
+		costPer1KLoads: tokens * 0.000_003,
 		tokens,
 	})),
 	getAvailableModels: vi.fn(() => ["claude-sonnet", "claude-opus", "gpt-4o"]),

--- a/packages/cli/src/usage/analyzer.ts
+++ b/packages/cli/src/usage/analyzer.ts
@@ -2,23 +2,23 @@ import type { SkillTelemetryEvent } from "@skills-check/schema";
 import { estimateCost } from "../budget/cost.js";
 
 export interface SkillUsageStats {
-	name: string;
-	versions: string[];
-	totalCalls: number;
-	totalTokens: number;
 	avgTokensPerCall: number;
 	estimatedCost: number;
-	models: Record<string, number>;
 	hasVersionDrift: boolean;
+	models: Record<string, number>;
+	name: string;
+	totalCalls: number;
+	totalTokens: number;
+	versions: string[];
 }
 
 export interface UsageReport {
-	period: { since?: string; until?: string };
-	totalCalls: number;
-	totalTokens: number;
-	totalEstimatedCost: number;
-	skills: SkillUsageStats[];
 	generatedAt: string;
+	period: { since?: string; until?: string };
+	skills: SkillUsageStats[];
+	totalCalls: number;
+	totalEstimatedCost: number;
+	totalTokens: number;
 }
 
 /**
@@ -44,7 +44,7 @@ function deduplicateEvents(events: SkillTelemetryEvent[]): SkillTelemetryEvent[]
  */
 export function analyzeUsage(
 	events: SkillTelemetryEvent[],
-	options?: { since?: string; until?: string },
+	options?: { since?: string; until?: string }
 ): UsageReport {
 	const deduplicated = deduplicateEvents(events);
 

--- a/packages/cli/src/usage/index.test.ts
+++ b/packages/cli/src/usage/index.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillTelemetryEvent } from "@skills-check/schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./readers/index.js", () => ({
 	createReader: vi.fn(),
@@ -80,7 +80,7 @@ describe("runUsage", () => {
 			expect.objectContaining({
 				since: expect.any(Date),
 				until: expect.any(Date),
-			}),
+			})
 		);
 	});
 

--- a/packages/cli/src/usage/index.ts
+++ b/packages/cli/src/usage/index.ts
@@ -1,7 +1,7 @@
-import { analyzeUsage } from "./analyzer.js";
 import type { UsageReport } from "./analyzer.js";
-import { checkUsagePolicy } from "./policy-check.js";
+import { analyzeUsage } from "./analyzer.js";
 import type { UsagePolicyViolation } from "./policy-check.js";
+import { checkUsagePolicy } from "./policy-check.js";
 import { createReader } from "./readers/index.js";
 
 export type { UsageReport } from "./analyzer.js";
@@ -41,8 +41,12 @@ export async function runUsage(options: UsageOptions = {}): Promise<UsageResult>
 
 	try {
 		const readerOptions: { since?: Date; until?: Date } = {};
-		if (options.since) readerOptions.since = new Date(options.since);
-		if (options.until) readerOptions.until = new Date(options.until);
+		if (options.since) {
+			readerOptions.since = new Date(options.since);
+		}
+		if (options.until) {
+			readerOptions.until = new Date(options.until);
+		}
 
 		const events = await reader.read(readerOptions);
 		const report = analyzeUsage(events, {

--- a/packages/cli/src/usage/policy-check.ts
+++ b/packages/cli/src/usage/policy-check.ts
@@ -2,27 +2,30 @@ import { discoverPolicyFile, loadPolicyFile } from "../policy/parser.js";
 import type { UsageReport } from "./analyzer.js";
 
 export interface UsagePolicyViolation {
-	skill: string;
-	version: string;
+	callCount: number;
+	message: string;
 	rule: string;
 	severity: "critical" | "high" | "medium";
-	message: string;
-	callCount: number;
+	skill: string;
+	version: string;
 }
 
 /**
  * Cross-reference usage data against .skill-policy.yml.
  * Returns violations found in runtime telemetry.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
 export async function checkUsagePolicy(
 	report: UsageReport,
-	policyPath?: string,
+	policyPath?: string
 ): Promise<UsagePolicyViolation[]> {
 	// Find policy file
 	const resolvedPath = policyPath ?? (await discoverPolicyFile(process.cwd()));
-	if (!resolvedPath) return [];
+	if (!resolvedPath) {
+		return [];
+	}
 
-	let policy;
+	let policy: Awaited<ReturnType<typeof loadPolicyFile>>;
 	try {
 		policy = await loadPolicyFile(resolvedPath);
 	} catch {
@@ -69,7 +72,7 @@ export async function checkUsagePolicy(
 	// Sort by severity (critical first) then call count
 	const severityOrder = { critical: 0, high: 1, medium: 2 };
 	violations.sort(
-		(a, b) => severityOrder[a.severity] - severityOrder[b.severity] || b.callCount - a.callCount,
+		(a, b) => severityOrder[a.severity] - severityOrder[b.severity] || b.callCount - a.callCount
 	);
 
 	return violations;

--- a/packages/cli/src/usage/readers/index.test.ts
+++ b/packages/cli/src/usage/readers/index.test.ts
@@ -31,7 +31,7 @@ describe("createReader", () => {
 
 	it("throws for unsupported URI scheme", async () => {
 		await expect(createReader("ftp://server/events")).rejects.toThrow(
-			"Unsupported telemetry store URI scheme",
+			"Unsupported telemetry store URI scheme"
 		);
 	});
 });

--- a/packages/cli/src/usage/readers/index.ts
+++ b/packages/cli/src/usage/readers/index.ts
@@ -1,6 +1,6 @@
 import type { TelemetryReader } from "./types.js";
 
-export type { TelemetryReader, TelemetryReaderOptions, SkillTelemetryEvent } from "./types.js";
+export type { SkillTelemetryEvent, TelemetryReader, TelemetryReaderOptions } from "./types.js";
 
 /**
  * Create a telemetry reader from a store URI.
@@ -24,6 +24,6 @@ export async function createReader(storeUri: string): Promise<TelemetryReader> {
 
 	throw new Error(
 		`Unsupported telemetry store URI scheme: "${storeUri}". ` +
-			"Supported: file://path/to/events.jsonl, sqlite:///path/to/db",
+			"Supported: file://path/to/events.jsonl, sqlite:///path/to/db"
 	);
 }

--- a/packages/cli/src/usage/readers/jsonl.test.ts
+++ b/packages/cli/src/usage/readers/jsonl.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillTelemetryEvent } from "@skills-check/schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:fs/promises", () => ({
 	readFile: vi.fn(),

--- a/packages/cli/src/usage/readers/jsonl.ts
+++ b/packages/cli/src/usage/readers/jsonl.ts
@@ -5,7 +5,11 @@ import type { SkillTelemetryEvent, TelemetryReader, TelemetryReaderOptions } fro
  * Read telemetry events from a newline-delimited JSON file.
  */
 export class JSONLReader implements TelemetryReader {
-	constructor(private filePath: string) {}
+	private readonly filePath: string;
+
+	constructor(filePath: string) {
+		this.filePath = filePath;
+	}
 
 	async read(options?: TelemetryReaderOptions): Promise<SkillTelemetryEvent[]> {
 		const content = await readFile(this.filePath, "utf-8");
@@ -15,14 +19,22 @@ export class JSONLReader implements TelemetryReader {
 		for (const line of lines) {
 			try {
 				const event = JSON.parse(line) as SkillTelemetryEvent;
-				if (event.schema_version !== 1) continue;
-				if (!event.timestamp || !event.skill || !event.request) continue;
+				if (event.schema_version !== 1) {
+					continue;
+				}
+				if (!(event.timestamp && event.skill && event.request)) {
+					continue;
+				}
 
 				// Date filtering
 				if (options?.since || options?.until) {
 					const ts = new Date(event.timestamp);
-					if (options.since && ts < options.since) continue;
-					if (options.until && ts > options.until) continue;
+					if (options.since && ts < options.since) {
+						continue;
+					}
+					if (options.until && ts > options.until) {
+						continue;
+					}
 				}
 
 				events.push(event);

--- a/packages/cli/src/usage/readers/sqlite.ts
+++ b/packages/cli/src/usage/readers/sqlite.ts
@@ -6,11 +6,18 @@ import type { SkillTelemetryEvent, TelemetryReader, TelemetryReaderOptions } fro
  */
 export class SQLiteReader implements TelemetryReader {
 	private db: unknown = null;
+	private readonly dbPath: string;
 
-	constructor(private dbPath: string) {}
+	constructor(dbPath: string) {
+		this.dbPath = dbPath;
+	}
 
-	private async getDb(): Promise<{ prepare: (sql: string) => { all: (...args: unknown[]) => unknown[] } }> {
-		if (this.db) return this.db as never;
+	private async getDb(): Promise<{
+		prepare: (sql: string) => { all: (...args: unknown[]) => unknown[] };
+	}> {
+		if (this.db) {
+			return this.db as never;
+		}
 		try {
 			const { DatabaseSync } = await import("node:sqlite");
 			this.db = new DatabaseSync(this.dbPath, { readOnly: true });
@@ -18,7 +25,7 @@ export class SQLiteReader implements TelemetryReader {
 		} catch {
 			throw new Error(
 				"SQLite reader requires Node.js 22+ with built-in sqlite module. " +
-					"Use a JSONL telemetry store instead, or upgrade Node.js.",
+					"Use a JSONL telemetry store instead, or upgrade Node.js."
 			);
 		}
 	}
@@ -41,7 +48,7 @@ export class SQLiteReader implements TelemetryReader {
 		sql += " ORDER BY timestamp DESC";
 
 		const stmt = db.prepare(sql);
-		const rows = stmt.all(...params) as Array<Record<string, unknown>>;
+		const rows = stmt.all(...params) as Record<string, unknown>[];
 
 		return rows.map((row) => ({
 			schema_version: 1 as const,
@@ -59,16 +66,18 @@ export class SQLiteReader implements TelemetryReader {
 				skill_tokens: row.skill_tokens as number,
 				total_prompt_tokens: (row.total_prompt_tokens as number) || undefined,
 			},
-			org: row.org_user || row.org_team || row.org_project
-				? {
-						user: (row.org_user as string) || undefined,
-						team: (row.org_team as string) || undefined,
-						project: (row.org_project as string) || undefined,
-					}
-				: undefined,
+			org:
+				row.org_user || row.org_team || row.org_project
+					? {
+							user: (row.org_user as string) || undefined,
+							team: (row.org_team as string) || undefined,
+							project: (row.org_project as string) || undefined,
+						}
+					: undefined,
 		}));
 	}
 
+	// biome-ignore lint/suspicious/useAwait: interface contract requires async
 	async close(): Promise<void> {
 		if (this.db) {
 			(this.db as { close: () => void }).close();

--- a/packages/cli/src/usage/readers/types.ts
+++ b/packages/cli/src/usage/readers/types.ts
@@ -1,6 +1,6 @@
-import type { SkillTelemetryEvent } from "@skills-check/schema";
+import type { SkillTelemetryEvent as _SkillTelemetryEvent } from "@skills-check/schema";
 
-export type { SkillTelemetryEvent };
+export type SkillTelemetryEvent = _SkillTelemetryEvent;
 
 export interface TelemetryReaderOptions {
 	since?: Date;
@@ -8,6 +8,6 @@ export interface TelemetryReaderOptions {
 }
 
 export interface TelemetryReader {
-	read(options?: TelemetryReaderOptions): Promise<SkillTelemetryEvent[]>;
 	close(): Promise<void>;
+	read(options?: TelemetryReaderOptions): Promise<SkillTelemetryEvent[]>;
 }

--- a/packages/cli/src/usage/reporters/json.ts
+++ b/packages/cli/src/usage/reporters/json.ts
@@ -7,7 +7,7 @@ export function formatUsageJson(report: UsageReport): string {
 
 export function formatUsageJsonWithPolicy(
 	report: UsageReport,
-	violations: UsagePolicyViolation[],
+	violations: UsagePolicyViolation[]
 ): string {
 	return JSON.stringify({ report, policyViolations: violations }, null, 2);
 }

--- a/packages/cli/src/usage/reporters/markdown.ts
+++ b/packages/cli/src/usage/reporters/markdown.ts
@@ -23,13 +23,13 @@ export function formatUsageMarkdown(report: UsageReport): string {
 		const versionStr = skill.versions.join(", ");
 		const drift = skill.hasVersionDrift ? " ⚠" : "";
 		lines.push(
-			`| ${skill.name} | ${skill.totalCalls.toLocaleString()} | ${skill.avgTokensPerCall.toLocaleString()} | $${skill.estimatedCost.toFixed(2)} | ${versionStr}${drift} |`,
+			`| ${skill.name} | ${skill.totalCalls.toLocaleString()} | ${skill.avgTokensPerCall.toLocaleString()} | $${skill.estimatedCost.toFixed(2)} | ${versionStr}${drift} |`
 		);
 	}
 
 	lines.push("");
 	lines.push(
-		`**Total:** ${report.totalCalls.toLocaleString()} calls, ~$${report.totalEstimatedCost.toFixed(2)} estimated cost`,
+		`**Total:** ${report.totalCalls.toLocaleString()} calls, ~$${report.totalEstimatedCost.toFixed(2)} estimated cost`
 	);
 
 	return lines.join("\n");
@@ -37,7 +37,7 @@ export function formatUsageMarkdown(report: UsageReport): string {
 
 export function formatUsageMarkdownWithPolicy(
 	report: UsageReport,
-	violations: UsagePolicyViolation[],
+	violations: UsagePolicyViolation[]
 ): string {
 	let output = formatUsageMarkdown(report);
 

--- a/packages/cli/src/usage/reporters/terminal.ts
+++ b/packages/cli/src/usage/reporters/terminal.ts
@@ -4,9 +4,10 @@ import type { UsagePolicyViolation } from "../policy-check.js";
 
 export function formatUsageTerminal(report: UsageReport): string {
 	const lines: string[] = [];
-	const periodStr = report.period.since || report.period.until
-		? `${report.period.since ?? "..."} to ${report.period.until ?? "now"}`
-		: "all time";
+	const periodStr =
+		report.period.since || report.period.until
+			? `${report.period.since ?? "..."} to ${report.period.until ?? "now"}`
+			: "all time";
 
 	lines.push(chalk.bold(`Skills Usage Report (${periodStr})`));
 	lines.push("═".repeat(70));
@@ -18,9 +19,11 @@ export function formatUsageTerminal(report: UsageReport): string {
 	}
 
 	lines.push(
-		`  ${chalk.dim("Skill".padEnd(25))}${chalk.dim("Calls".padEnd(10))}${chalk.dim("Tokens/call".padEnd(14))}${chalk.dim("Est. Cost".padEnd(12))}${chalk.dim("Version(s)")}`,
+		`  ${chalk.dim("Skill".padEnd(25))}${chalk.dim("Calls".padEnd(10))}${chalk.dim("Tokens/call".padEnd(14))}${chalk.dim("Est. Cost".padEnd(12))}${chalk.dim("Version(s)")}`
 	);
-	lines.push(`  ${"─".repeat(25)}${"─".repeat(10)}${"─".repeat(14)}${"─".repeat(12)}${"─".repeat(15)}`);
+	lines.push(
+		`  ${"─".repeat(25)}${"─".repeat(10)}${"─".repeat(14)}${"─".repeat(12)}${"─".repeat(15)}`
+	);
 
 	for (const skill of report.skills) {
 		const versionStr = skill.versions.join(", ");
@@ -34,11 +37,9 @@ export function formatUsageTerminal(report: UsageReport): string {
 	}
 
 	lines.push("");
+	lines.push(`  ${chalk.yellow("⚠")} = multiple versions in use or version drift detected`);
 	lines.push(
-		`  ${chalk.yellow("⚠")} = multiple versions in use or version drift detected`,
-	);
-	lines.push(
-		`  ${chalk.bold("Total:")} ${report.totalCalls.toLocaleString()} calls, ~$${report.totalEstimatedCost.toFixed(2)} estimated cost`,
+		`  ${chalk.bold("Total:")} ${report.totalCalls.toLocaleString()} calls, ~$${report.totalEstimatedCost.toFixed(2)} estimated cost`
 	);
 
 	return lines.join("\n");
@@ -46,7 +47,7 @@ export function formatUsageTerminal(report: UsageReport): string {
 
 export function formatUsageTerminalWithPolicy(
 	report: UsageReport,
-	violations: UsagePolicyViolation[],
+	violations: UsagePolicyViolation[]
 ): string {
 	let output = formatUsageTerminal(report);
 

--- a/packages/cli/src/verify/index.ts
+++ b/packages/cli/src/verify/index.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import matter from "gray-matter";
 import { major, minor, patch } from "semver";
+import { extractVersionedPackages, parseCompatibility } from "../compatibility/index.js";
 import { normalizeVersion } from "../severity.js";
 import { discoverSkillFiles } from "../shared/discovery.js";
 import { readSkillFile } from "../skill-io.js";
@@ -54,6 +55,23 @@ function buildExplanation(result: Omit<VerifyResult, "explanation">): string {
 	return `The declared ${result.declaredBump} bump appears excessive. Changes suggest only a ${result.assessedBump} bump.`;
 }
 
+/**
+ * Resolve the tracked version from parsed frontmatter.
+ * Precedence: compatibility (first versioned entry) > product-version
+ */
+function resolveVersion(parsed: matter.GrayMatterFile<string>): string | null {
+	if (typeof parsed.data.compatibility === "string") {
+		const versioned = extractVersionedPackages(parseCompatibility(parsed.data.compatibility));
+		if (versioned.length > 0 && versioned[0].version) {
+			return versioned[0].version;
+		}
+	}
+	if (parsed.data["product-version"] != null) {
+		return String(parsed.data["product-version"]);
+	}
+	return null;
+}
+
 async function verifyPair(
 	beforeContent: string,
 	afterContent: string,
@@ -71,8 +89,8 @@ async function verifyPair(
 			.pop() ||
 		"unknown";
 
-	const declaredBefore = (beforeParsed.data["product-version"] as string) ?? null;
-	const declaredAfter = (afterParsed.data["product-version"] as string) ?? null;
+	const declaredBefore = resolveVersion(beforeParsed);
+	const declaredAfter = resolveVersion(afterParsed);
 
 	const declaredBump =
 		declaredBefore && declaredAfter
@@ -160,6 +178,7 @@ export async function runVerify(options: VerifyOptions): Promise<VerifyReport> {
 
 			if (!previousContent) {
 				// New file, no previous version — skip with a note
+				const parsed = matter(skillFile.raw);
 				results.push({
 					skill:
 						(skillFile.frontmatter.name as string) ||
@@ -170,7 +189,7 @@ export async function runVerify(options: VerifyOptions): Promise<VerifyReport> {
 						"unknown",
 					file: filePath,
 					declaredBefore: null,
-					declaredAfter: (skillFile.frontmatter["product-version"] as string) ?? null,
+					declaredAfter: resolveVersion(parsed),
 					declaredBump: null,
 					assessedBump: "patch",
 					match: false,

--- a/packages/schema/src/generate.ts
+++ b/packages/schema/src/generate.ts
@@ -12,6 +12,7 @@ const generator = createGenerator(config);
 const schema = generator.createSchema(config.type);
 
 // Preserve the root $ref so skills-check.json $schema validation works
+// biome-ignore lint/complexity/useLiteralKeys: dynamic property assignment needed for JSON Schema
 schema["$ref"] = "#/definitions/Registry";
 
 const outDir = resolve(import.meta.dirname, "../dist");

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -23,14 +23,12 @@ export interface RegistryProduct {
  * Telemetry event emitted when a skill is detected in an LLM request.
  */
 export interface SkillTelemetryEvent {
-	schema_version: 1;
-	timestamp: string;
-	detection: "watermark" | "frontmatter_hash" | "content_hash" | "prefix_hash";
 	confidence: number;
-	skill: {
-		name: string;
-		version: string;
-		source?: string;
+	detection: "watermark" | "frontmatter_hash" | "content_hash" | "prefix_hash";
+	org?: {
+		user?: string;
+		team?: string;
+		project?: string;
 	};
 	request: {
 		id: string;
@@ -38,32 +36,34 @@ export interface SkillTelemetryEvent {
 		skill_tokens: number;
 		total_prompt_tokens?: number;
 	};
-	org?: {
-		user?: string;
-		team?: string;
-		project?: string;
+	schema_version: 1;
+	skill: {
+		name: string;
+		version: string;
+		source?: string;
 	};
+	timestamp: string;
 }
 
 /**
  * A registry of fingerprints for installed skills.
  */
 export interface FingerprintRegistry {
-	version: 1;
 	generated: string;
 	skills: FingerprintEntry[];
+	version: 1;
 }
 
 export interface FingerprintEntry {
-	name: string;
-	version: string;
-	source?: string;
 	fingerprints: {
 		watermark?: string;
 		frontmatter_sha256: string;
 		content_sha256: string;
 		content_prefix_sha256: string;
 	};
-	token_count: number;
+	name: string;
 	path: string;
+	source?: string;
+	token_count: number;
+	version: string;
 }

--- a/packages/web/app/concepts/page.tsx
+++ b/packages/web/app/concepts/page.tsx
@@ -7,7 +7,7 @@ import styles from "./concepts.module.css";
 export const metadata: Metadata = {
 	title: "Concepts & Glossary",
 	description:
-		"Key terms and concepts in the Agent Skills ecosystem: SKILL.md format, product-version drift, hallucinated packages, token budgets, semver verification, policy enforcement, and more.",
+		"Key terms and concepts in the Agent Skills ecosystem: SKILL.md format, compatibility and version drift, hallucinated packages, token budgets, semver verification, policy enforcement, and more.",
 	alternates: {
 		canonical: "https://skillscheck.ai/concepts",
 	},
@@ -29,13 +29,13 @@ const jsonLd = {
 			"@type": "DefinedTerm",
 			name: "SKILL.md",
 			description:
-				"The standard file format for agent skills. Contains YAML frontmatter (name, description, version, product-version) followed by a markdown body with instructions, code examples, and patterns.",
+				"The standard file format for agent skills. Contains YAML frontmatter (name, description, version, compatibility) followed by a markdown body with instructions, code examples, and patterns.",
 		},
 		{
 			"@type": "DefinedTerm",
-			name: "Product-version drift",
+			name: "Version drift",
 			description:
-				"When a skill's product-version frontmatter references an outdated version of the product it covers. For example, a React skill referencing v18 when v19 is current.",
+				'When a skill\'s compatibility (or product-version) frontmatter references an outdated version of the product it covers. For example, a React skill with compatibility: "react@^18.0.0" when v19 is current.',
 		},
 		{
 			"@type": "DefinedTerm",
@@ -149,19 +149,21 @@ export default function ConceptsPage() {
 							<p className={styles.termDef}>
 								The standard file format for agent skills. Contains YAML frontmatter (
 								<code>name</code>, <code>description</code>, <code>version</code>,{" "}
-								<code>product-version</code>) followed by a markdown body with instructions, code
+								<code>compatibility</code>) followed by a markdown body with instructions, code
 								examples, and patterns. Validated by the <Link href="/commands/lint">lint</Link>{" "}
 								command.
 							</p>
 						</div>
 
-						<div className={styles.term} id="product-version-drift">
-							<h3 className={styles.termName}>Product-version drift</h3>
+						<div className={styles.term} id="version-drift">
+							<h3 className={styles.termName}>Version drift</h3>
 							<p className={styles.termDef}>
-								When a skill&apos;s <code>product-version</code> frontmatter references an outdated
-								version of the product it covers. For example, a React skill referencing v18 when
-								v19 is current. Detected by the <Link href="/commands/check">check</Link> command
-								and resolvable via <Link href="/commands/refresh">refresh</Link>.
+								When a skill&apos;s <code>compatibility</code> (or legacy{" "}
+								<code>product-version</code>) frontmatter references an outdated version of the
+								product it covers. For example, a React skill with{" "}
+								<code>compatibility: &quot;react@^18.0.0&quot;</code> when v19 is current. Detected
+								by the <Link href="/commands/check">check</Link> command and resolvable via{" "}
+								<Link href="/commands/refresh">refresh</Link>.
 							</p>
 						</div>
 

--- a/packages/web/app/docs/page.tsx
+++ b/packages/web/app/docs/page.tsx
@@ -730,14 +730,15 @@ npx skills-check usage --store ./telemetry.jsonl --ci --fail-on high`}
 					<section>
 						<h2 id="frontmatter">SKILL.md Frontmatter</h2>
 						<p>
-							Each SKILL.md file should include a <code>product-version</code> field in its YAML
-							frontmatter:
+							Each SKILL.md file should include a <code>compatibility</code> field in its YAML
+							frontmatter. This is the spec-native format that combines package name and version
+							constraint in a single self-describing string:
 						</p>
 						<pre>
 							<code>
 								{`---
 name: ai-sdk-core
-product-version: "4.2.0"
+compatibility: "ai@^4.2.0"
 ---
 
 # AI SDK Core
@@ -745,6 +746,21 @@ product-version: "4.2.0"
 Your skill content here...`}
 							</code>
 						</pre>
+						<p>
+							The legacy <code>product-version</code> field is still supported as a deprecated
+							fallback:
+						</p>
+						<pre>
+							<code>
+								{`---
+name: ai-sdk-core
+product-version: "4.2.0"
+---`}
+							</code>
+						</pre>
+						<p>
+							When both fields are present, <code>compatibility</code> takes precedence.
+						</p>
 					</section>
 
 					<section>

--- a/packages/web/app/faq/page.tsx
+++ b/packages/web/app/faq/page.tsx
@@ -23,7 +23,7 @@ const faqItems = [
 			},
 			{
 				q: "What is a SKILL.md file?",
-				a: "A SKILL.md file is the standard format for Agent Skills, defined by the Agent Skills spec. It contains YAML frontmatter with metadata (name, description, product-version) followed by markdown content that teaches an AI agent how to use a particular technology correctly and safely.",
+				a: 'A SKILL.md file is the standard format for Agent Skills, defined by the Agent Skills spec. It contains YAML frontmatter with metadata (name, description, compatibility) followed by markdown content that teaches an AI agent how to use a particular technology correctly and safely. The compatibility field uses the format "package@version" (e.g., "react@^19.0.0"). The legacy product-version field is still supported as a fallback.',
 			},
 			{
 				q: "What is skills-check?",
@@ -51,10 +51,11 @@ const faqItems = [
 				q: "How do I check if my AI agent skills are up to date?",
 				a: (
 					<>
-						Run <code>npx skills-check check</code> to compare the <code>product-version</code> in
-						each skill&apos;s frontmatter against the latest version on npm. The{" "}
-						<Link href="/commands/check">check command</Link> reports which skills have drifted and
-						by how many versions, with <code>--ci</code> mode for pipeline integration.
+						Run <code>npx skills-check check</code> to compare the <code>compatibility</code> (or
+						legacy <code>product-version</code>) in each skill&apos;s frontmatter against the latest
+						version on npm. The <Link href="/commands/check">check command</Link> reports which
+						skills have drifted and by how many versions, with <code>--ci</code> mode for pipeline
+						integration.
 					</>
 				),
 			},
@@ -70,12 +71,13 @@ const faqItems = [
 				),
 			},
 			{
-				q: "What is product-version drift in agent skills?",
+				q: "What is version drift in agent skills?",
 				a: (
 					<>
-						Product-version drift occurs when the <code>product-version</code> field in a
-						skill&apos;s frontmatter falls behind the latest release on npm. This means the skill
-						may contain outdated instructions, deprecated APIs, or missing features. The{" "}
+						Version drift occurs when the <code>compatibility</code> (or legacy{" "}
+						<code>product-version</code>) field in a skill&apos;s frontmatter falls behind the
+						latest release on npm. This means the skill may contain outdated instructions,
+						deprecated APIs, or missing features. The{" "}
 						<Link href="/commands/check">check command</Link> detects this automatically.
 					</>
 				),
@@ -208,17 +210,17 @@ const jsonLdAnswers: Record<string, string> = {
 	"What is an Agent Skill?":
 		"An Agent Skill is a markdown document (SKILL.md) with YAML frontmatter that instructs AI coding agents — such as Claude Code, Cursor, and Codex — how to work with specific products, frameworks, and patterns. Skills look like documentation but are treated as executable instructions by agents with file system and shell access.",
 	"What is a SKILL.md file?":
-		"A SKILL.md file is the standard format for Agent Skills, defined by the Agent Skills spec. It contains YAML frontmatter with metadata (name, description, product-version) followed by markdown content that teaches an AI agent how to use a particular technology correctly and safely.",
+		'A SKILL.md file is the standard format for Agent Skills, defined by the Agent Skills spec. It contains YAML frontmatter with metadata (name, description, compatibility) followed by markdown content that teaches an AI agent how to use a particular technology correctly and safely. The compatibility field uses the format "package@version" (e.g., "react@^19.0.0"). The legacy product-version field is still supported as a fallback.',
 	"What is skills-check?":
 		"skills-check is the quality and integrity layer for Agent Skills. It answers whether your skills are correct, safe, current, and efficient by providing commands for freshness detection, security auditing, metadata linting, token budget analysis, semver verification, policy enforcement, and eval testing.",
 	"How is skills-check different from linters or security scanners?":
 		"Traditional linters check code syntax and style, while security scanners look for vulnerabilities in dependencies. skills-check is purpose-built for SKILL.md files — it detects hallucinated packages, prompt injection patterns, version drift against live registries, and measures the token cost of loading skills into an agent's context window.",
 	"How do I check if my AI agent skills are up to date?":
-		"Run npx skills-check check to compare the product-version in each skill's frontmatter against the latest version on npm. The check command reports which skills have drifted and by how many versions, with --ci mode for pipeline integration.",
+		"Run npx skills-check check to compare the compatibility (or legacy product-version) in each skill's frontmatter against the latest version on npm. The check command reports which skills have drifted and by how many versions, with --ci mode for pipeline integration.",
 	"How do I automatically update stale agent skills?":
 		"The refresh command uses an LLM to propose targeted updates to stale skill files. Run npx skills-check refresh to fetch changelogs, generate diffs, and optionally apply changes. It supports Anthropic, OpenAI, and Google providers.",
-	"What is product-version drift in agent skills?":
-		"Product-version drift occurs when the product-version field in a skill's frontmatter falls behind the latest release on npm. This means the skill may contain outdated instructions, deprecated APIs, or missing features. The check command detects this automatically.",
+	"What is version drift in agent skills?":
+		"Version drift occurs when the compatibility (or legacy product-version) field in a skill's frontmatter falls behind the latest release on npm. This means the skill may contain outdated instructions, deprecated APIs, or missing features. The check command detects this automatically.",
 	"How do I audit SKILL.md files for security issues?":
 		"Run npx skills-check audit to scan your skill files. The audit command checks for hallucinated packages that don't exist on registries, prompt injection patterns, dangerous shell commands, dead URLs, and metadata gaps. Output formats include terminal, JSON, Markdown, and SARIF for GitHub Security integration.",
 	"How do I detect hallucinated packages in agent skills?":

--- a/packages/web/app/llms-full.txt/route.ts
+++ b/packages/web/app/llms-full.txt/route.ts
@@ -155,10 +155,13 @@ Each SKILL.md file should include YAML frontmatter with the following fields:
 
 ### Recommended Fields
 
-- \`product-version\` — Semver version of the product this skill targets (e.g., "4.2.0"). Required for version drift detection via \`check\`.
+- \`compatibility\` — Spec-native field combining package name and version constraint (e.g., "ai@^4.2.0"). Self-describing and preferred for version drift detection via \`check\`.
+- \`product-version\` — (Deprecated fallback) Semver version of the product this skill targets (e.g., "4.2.0"). Use \`compatibility\` instead when possible.
 - \`author\` — Skill author name or organization
 - \`license\` — SPDX license identifier (e.g., "MIT", "Apache-2.0"). Supports OR/AND expressions.
 - \`repository\` — URL to the skill's source repository
+
+When both \`compatibility\` and \`product-version\` are present, \`compatibility\` takes precedence.
 
 ### Example
 
@@ -166,7 +169,7 @@ Each SKILL.md file should include YAML frontmatter with the following fields:
 ---
 name: ai-sdk-core
 description: Core patterns for the Vercel AI SDK
-product-version: "4.2.0"
+compatibility: "ai@^4.2.0"
 author: "Your Name"
 license: "MIT"
 repository: "https://github.com/your-org/skills"

--- a/packages/web/app/reference/page.tsx
+++ b/packages/web/app/reference/page.tsx
@@ -166,8 +166,8 @@ export default function ReferencePage() {
       "file": "SKILL.md",
       "rule": "required-field",
       "severity": "error",
-      "field": "product-version",
-      "message": "Missing required field: product-version"
+      "field": "compatibility",
+      "message": "Missing required field: compatibility (or product-version)"
     }
   ]
 }`}

--- a/packages/web/components/explainer.tsx
+++ b/packages/web/components/explainer.tsx
@@ -52,9 +52,9 @@ export function Explainer() {
 							<span className={styles.yamlDelimiter}>: </span>
 							<span className={styles.yamlValue}>1.2.0</span>
 							{"\n"}
-							<span className={styles.yamlKey}>product-version</span>
+							<span className={styles.yamlKey}>compatibility</span>
 							<span className={styles.yamlDelimiter}>: </span>
-							<span className={styles.yamlValue}>&quot;19.1&quot;</span>
+							<span className={styles.yamlValue}>&quot;react@^19.1.0&quot;</span>
 							{"\n"}
 							<span className={styles.yamlKey}>author</span>
 							<span className={styles.yamlDelimiter}>: </span>

--- a/packages/web/lib/commands.ts
+++ b/packages/web/lib/commands.ts
@@ -24,13 +24,13 @@ export const commands: CommandInfo[] = [
 		tagline: "Detect version drift by comparing skill frontmatter against the npm registry.",
 		group: "Freshness & Currency",
 		description:
-			"Compare the product-version in your SKILL.md frontmatter against the latest version on npm. Instantly know which skills are stale and by how much.",
+			"Compare the compatibility (or product-version) in your SKILL.md frontmatter against the latest version on npm. Instantly know which skills are stale and by how much.",
 		whyItMatters:
 			"Agent skills that reference outdated APIs lead to hallucinated code, broken builds, and wasted developer time. A skill written for React 18 won't generate correct React 19 Server Component patterns. Version drift is the #1 source of skill quality decay.",
 		whatItDoes: [
 			"Reads your skills-check.json registry to map products to npm packages",
 			"Fetches the latest version from the npm registry for each product",
-			"Compares it against the product-version declared in each skill's frontmatter",
+			"Compares it against the compatibility (or product-version) declared in each skill's frontmatter",
 			"Reports stale products with the exact version gap (e.g. 4.2.0 → 4.5.1)",
 			"Exits with code 1 in CI mode when staleness is detected",
 		],
@@ -218,11 +218,11 @@ export const commands: CommandInfo[] = [
 		description:
 			"Enforce metadata standards across your skill fleet. Validates required frontmatter fields, checks SPDX license identifiers, verifies URLs, and can auto-fix missing fields from git context.",
 		whyItMatters:
-			"Incomplete metadata breaks downstream tooling. Without a name, skills-check can't track a skill. Without product-version, check can't detect drift. Without a license, legal compliance is impossible. Lint ensures every skill meets the bar before it ships.",
+			"Incomplete metadata breaks downstream tooling. Without a name, skills-check can't track a skill. Without compatibility (or product-version), check can't detect drift. Without a license, legal compliance is impossible. Lint ensures every skill meets the bar before it ships.",
 		whatItDoes: [
 			"Validates required fields: name, description (always required)",
 			"Checks publish-ready fields: author, license, repository",
-			"Validates conditional fields: product-version when products are referenced, agents when agent-specific",
+			"Validates conditional fields: compatibility or product-version when products are referenced, agents when agent-specific",
 			"Verifies format: semver syntax, SPDX license identifiers (100+ supported with OR/AND expressions), valid URLs",
 			"Auto-fix mode populates missing fields from git context (author from git config, repo from git remote)",
 		],
@@ -249,7 +249,7 @@ export const commands: CommandInfo[] = [
 			{ slug: "audit", relationship: "Validate format, then audit content" },
 		],
 		commonFindings: [
-			"Missing product-version — no version tracking possible",
+			"Missing compatibility/product-version — no version tracking possible",
 			"Invalid SPDX license — unrecognized license identifier",
 			"Missing author — skill has no attribution",
 		],


### PR DESCRIPTION
## Summary

- **Compatibility field migration**: Treats the spec-native `compatibility` field (`"next@^15.0.0, react@19.0.0"`) as the primary version tracking mechanism across all 12 commands, with `product-version` as a deprecated fallback. Precedence chain: `compatibility` → `product-version` → `metadata.product-version`.
- **Spec alignment**: Aligns all lint/validation rules with the [Agent Skills specification](https://agentskills.io). 9 alignment gaps identified and resolved — name validation, description limits, license severity, metadata namespace, unknown field warnings, `allowed-tools` recognition, `skill.md` discovery, compatibility length, and metadata type checking.
- **Editor configuration**: Adds `.editorconfig`, `.vscode/settings.json`, and `.zed/settings.json` to enforce tab indentation matching `biome.jsonc`.

### Key changes

| Area | Change |
|------|--------|
| New module | `compatibility/parser.ts` — parses `"pkg@^1.0, docker"` into `CompatibilityEntry[]` |
| New module | `lint/field-resolver.ts` — resolves fields from both top-level and `metadata.*` |
| Name validation | Spec-compliant: lowercase, digits, hyphens only, 64-char max, NFKC, directory match |
| Description limits | Changed from 20–500 to 1–1024 per spec |
| License SPDX | Downgraded from `error` to `info`/`warning` (spec allows any string) |
| Unknown fields | Info-level warning for non-spec top-level fields suggesting `metadata.*` |
| Discovery | Accepts both `SKILL.md` and `skill.md` (prefers uppercase per spec) |
| All commands | `check`, `lint`, `audit`, `verify`, `fingerprint`, `refresh`, `init`, `policy` use compatibility-first precedence |

### Backward compatibility

- Skills with `product-version` continue to work unchanged
- `lint` emits `info`-level migration notice encouraging `compatibility` adoption
- Name validation changes are `warning` level (not `error`) for migration period
- All non-spec field changes accept both locations (top-level and `metadata.*`)

## Test plan

- [x] 908 tests pass across 111 test files (up from 869)
- [x] 16 new parser tests for compatibility field edge cases
- [x] Updated tests for name validation (spec-compliant regex, 64-char max, directory match)
- [x] Updated tests for description limits (1–1024)
- [x] Updated tests for license SPDX level change (info/warning)
- [x] Updated tests for metadata field resolution (top-level + metadata.*)
- [x] Updated tests for freshness policy (accepts compatibility)
- [x] `npm run build` succeeds (all 3 packages)
- [x] `npx biome check` passes