### PR TITLE
feat: Phase 1 — Production-ready governance layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - "packages/schema/src/**"
       - "packages/web/**"
       - "package.json"
-      - "package-lock.json"
+      - "pnpm-lock.yaml"
   pull_request:
     branches: [main]
     paths:
@@ -16,7 +16,7 @@ on:
       - "packages/schema/src/**"
       - "packages/web/**"
       - "package.json"
-      - "package-lock.json"
+      - "pnpm-lock.yaml"
 
 permissions:
   contents: read
@@ -28,24 +28,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
-          cache: npm
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: npm run build
+        run: pnpm run build
 
       - name: Lint
-        run: npm run lint
+        run: pnpm run lint
 
       - name: Typecheck
-        run: npm run typecheck
+        run: pnpm run typecheck
 
       - name: Test
-        run: npm run test
+        run: pnpm run test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,20 +21,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
+          cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: npm run build
+        run: pnpm run build
 
       - name: Test
-        run: npm run test
+        run: pnpm run test
 
       - name: Set version
         env:
@@ -50,6 +54,6 @@ jobs:
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Publish
-        run: cd packages/cli && npm publish --provenance --access public
+        run: cd packages/cli && pnpm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ packages/web/tsconfig.tsbuildinfo
 
 # Beads local state (task tracker runtime)
 .beads/
+.worktrees/

--- a/.sisyphus/plans/phase-1-production-ready.md
+++ b/.sisyphus/plans/phase-1-production-ready.md
@@ -1,0 +1,425 @@
+# Phase 1: Production-Ready
+
+> **Goal**: Make skills-check trustworthy in a real CI pipeline. After Phase 1, a team can add `skills-check health --frozen-lockfile` to CI and enforce skill governance with exemptions, tamper detection, and deprecation controls.
+>
+> **Scope exclusions**: No registry work. No deep security analysis (Snyk's domain). No cryptographic signatures (Ed25519 deferred to Phase 2). No remote revocation feeds. No inline comment suppression for policy.
+>
+> **Design decisions baked in**:
+> 1. Lock file: Clean v2 replacement (current stub has 1 consumer)
+> 2. Exemptions: In `.skill-policy.yml` only (cargo-deny style)
+> 3. `--frozen-lockfile` when lock missing: Hard-fail (npm model)
+> 4. Revocation: Local `.skill-revocations.json` only
+> 5. `max_version_drift`: Stays stubbed in freshness; delegated to audit-integration
+
+---
+
+## Wave 1: Foundation (Schema + Lock File + Exemptions + Test Gaps)
+
+Three workstreams run in parallel after the schema types land. Schema types are the first task because Lock File, Exemptions, and Revocation (Wave 3) all depend on shared types.
+
+### 1A. Schema Types (must land first, blocks everything)
+
+**Files**: `packages/schema/src/types.ts`, `packages/schema/src/index.ts`
+
+**Add `SkillsLockFile` type**:
+```typescript
+export interface SkillsLockFileEntry {
+  /** Skill name (directory basename or frontmatter name) */
+  name: string;
+  /** Resolved source URI (file path, git URL, registry URL) */
+  source: string;
+  /** SHA-256 content hash from fingerprint */
+  contentHash: string;
+  /** SHA-256 frontmatter hash from fingerprint */
+  frontmatterHash: string;
+  /** SHA-256 prefix hash from fingerprint */
+  prefixHash: string;
+  /** Watermark string injected by fingerprint command */
+  watermark?: string;
+  /** Estimated token count at time of lock */
+  tokenCount?: number;
+  /** ISO 8601 timestamp when this entry was resolved */
+  resolvedAt: string;
+  /** Semver version from frontmatter, if present */
+  version?: string;
+  /** Skill status */
+  status?: 'active' | 'deprecated' | 'revoked';
+  /** Deprecation message if status is deprecated */
+  deprecatedMessage?: string;
+  /** Deprecation sunset date (ISO 8601) if status is deprecated */
+  deprecatedSunsetDate?: string;
+}
+
+export interface SkillsLockFile {
+  /** Lock file format version for forward compatibility */
+  lockfileVersion: 2;
+  /** Tool and version that generated this lock file */
+  generatedBy: string;
+  /** ISO 8601 timestamp of last generation */
+  generatedAt: string;
+  /** Map of skill name -> locked entry */
+  skills: Record<string, SkillsLockFileEntry>;
+}
+```
+
+**Add `PolicyExemption` type**:
+```typescript
+export interface PolicyExemption {
+  /** Skill name or glob pattern (e.g., "my-skill" or "internal/*") */
+  skill: string;
+  /** Validator rule ID to exempt (e.g., "banned-pattern", "source-not-allowed") */
+  rule: string;
+  /** Human-readable reason for the exemption */
+  reason: string;
+  /** ISO 8601 expiry date (exemption auto-expires and starts failing) */
+  expires?: string;
+  /** Who granted the exemption */
+  grantedBy?: string;
+}
+```
+
+**Extend `FingerprintEntry`**:
+```typescript
+// ADD to existing FingerprintEntry interface:
+status?: 'active' | 'deprecated' | 'revoked';
+deprecatedMessage?: string;
+```
+
+**Tasks**:
+- [ ] Add `SkillsLockFile`, `SkillsLockFileEntry` types to `packages/schema/src/types.ts`
+- [ ] Add `PolicyExemption` type to `packages/schema/src/types.ts`
+- [ ] Add `status`, `deprecatedMessage` fields to `FingerprintEntry`
+- [ ] Export all new types from `packages/schema/src/index.ts`
+- [ ] Run `pnpm run typecheck` from root (must pass)
+- [ ] Run `pnpm run build` from root (must pass)
+- [ ] Verify skills-trace still compiles: `cd ../skills-trace && pnpm run typecheck` (should pass since it duplicates types rather than importing, but verify no naming collisions)
+
+**Acceptance**: All new types exported, build green, no type errors.
+
+---
+
+### 1B. Lock File Overhaul (after 1A)
+
+**New files**:
+- `packages/cli/src/lockfile/index.ts` - Read/write/diff lock file
+- `packages/cli/src/lockfile/index.test.ts` - Unit tests
+- `packages/cli/src/lockfile/migrate.ts` - Migrate v1 stub to v2 format
+
+**Modified files**:
+- `packages/cli/src/commands/fingerprint.ts` - Auto-update lock file after fingerprinting
+- `packages/cli/src/commands/refresh.ts` - Auto-update lock file after refresh
+- `packages/cli/src/commands/health.ts` - Add `--frozen-lockfile` flag
+- `packages/cli/src/commands/report.ts` - Include lock file drift in report output
+- `skills-lock.json` (root) - Migrate to v2 format
+
+**Implementation pattern**: Follow `packages/cli/src/registry.ts` for file I/O patterns (JSON read/write, error handling).
+
+#### Lock File Module (`packages/cli/src/lockfile/index.ts`)
+
+```typescript
+// Core API surface:
+export function readLockFile(dir: string): SkillsLockFile | null;
+export function writeLockFile(dir: string, lock: SkillsLockFile): void;
+export function updateLockEntry(lock: SkillsLockFile, entry: FingerprintEntry): SkillsLockFile;
+export function diffLockFiles(prev: SkillsLockFile, next: SkillsLockFile): LockFileDiff;
+export function migrateLockFileV1(v1: unknown): SkillsLockFile;
+
+export interface LockFileDiff {
+  added: string[];      // skill names
+  removed: string[];    // skill names
+  changed: Array<{
+    name: string;
+    field: string;
+    from: string;
+    to: string;
+  }>;
+  unchanged: string[];
+}
+```
+
+#### `--frozen-lockfile` behavior:
+1. If lock file missing: **hard-fail** with error message and exit code 1
+2. If lock file exists but would change (new skills detected, hashes differ): **hard-fail** with diff output
+3. If lock file matches current state: **pass silently**
+
+**Tasks**:
+- [ ] Create `packages/cli/src/lockfile/index.ts` with `readLockFile`, `writeLockFile`, `updateLockEntry`, `diffLockFiles`
+- [ ] Create `packages/cli/src/lockfile/migrate.ts` with `migrateLockFileV1` (converts current stub format)
+- [ ] Wire `fingerprint` command to call `updateLockEntry` after successful fingerprinting
+- [ ] Wire `refresh` command to call `updateLockEntry` after successful refresh
+- [ ] Add `--frozen-lockfile` option to `health` command (Commander option)
+- [ ] In `health` command: if `--frozen-lockfile`, read lock → compute current state → diff → fail if changed
+- [ ] Add lock file diff output to `report` command (show what changed since last lock)
+- [ ] Migrate root `skills-lock.json` to v2 format
+- [ ] Write unit tests for all lockfile module functions (`packages/cli/src/lockfile/index.test.ts`)
+- [ ] Write integration test: fingerprint → verify lock file updated → read back → validate
+
+**Acceptance**: `skills-check fingerprint` auto-updates `skills-lock.json` in v2 format. `skills-check health --frozen-lockfile` fails if lock would change. All lock file functions have unit tests.
+
+---
+
+### 1C. Policy Exemption System (after 1A, parallel with 1B)
+
+**Modified files**:
+- `packages/cli/src/policy/types.ts` - Import `PolicyExemption`, extend `SkillPolicy`
+- `packages/cli/src/policy/parser.ts` - Parse `exemptions` section from YAML
+- `packages/cli/src/policy/parser.test.ts` - Test exemption parsing
+- `packages/cli/src/policy/index.ts` - Filter violations through exemptions AFTER validators run
+- `packages/cli/src/policy/reporters/terminal.ts` - Show exempted findings (dimmed/separate section)
+- `packages/cli/src/policy/reporters/json.ts` - Include `exemptions` and `exemptedViolations` in output
+- `packages/cli/src/policy/reporters/sarif.ts` - Mark exempted results with `suppressions` array (SARIF 2.1.0 spec)
+- `packages/cli/src/policy/reporters/markdown.ts` - Exempted section in output
+- `packages/cli/src/commands/policy.ts` - Add `--show-exemptions` flag
+
+#### Policy File Format Addition
+
+```yaml
+# .skill-policy.yml (new section)
+exemptions:
+  - skill: "legacy-deploy-skill"
+    rule: "banned-pattern"
+    reason: "Uses exec for legacy deployment scripts, migrating in Q3"
+    expires: "2025-09-30"
+    grantedBy: "jane@company.com"
+  - skill: "internal/*"
+    rule: "source-not-allowed"
+    reason: "Internal skills hosted on private registry"
+```
+
+#### Exemption Evaluation Logic
+
+**Critical**: Filter exemptions AFTER validators run, not during. Validators must not know about exemptions. This keeps validators pure and testable.
+
+```typescript
+// In packages/cli/src/policy/index.ts
+function applyExemptions(
+  violations: PolicyViolation[],
+  exemptions: PolicyExemption[]
+): { active: PolicyViolation[]; exempted: PolicyViolation[] } {
+  // 1. For each violation, check if any exemption matches (skill glob + rule ID)
+  // 2. Check expiry: if exemption.expires < now, it's expired → violation stays active
+  // 3. Return both lists so reporters can show what was exempted
+}
+```
+
+**Tasks**:
+- [ ] Add `exemptions?: PolicyExemption[]` to `SkillPolicy` in `packages/cli/src/policy/types.ts`
+- [ ] Update YAML parser to handle `exemptions` array in `packages/cli/src/policy/parser.ts`
+- [ ] Add exemption parsing tests to `packages/cli/src/policy/parser.test.ts` (valid, expired, glob patterns, missing fields)
+- [ ] Implement `applyExemptions()` in `packages/cli/src/policy/index.ts` — AFTER validators, before reporters
+- [ ] Handle expired exemptions: treat as active violations, include warning "exemption expired"
+- [ ] Implement glob matching for skill names (use `minimatch` or `picomatch` — check if already a dependency)
+- [ ] Update terminal reporter: show exempted findings in dimmed/italic section
+- [ ] Update JSON reporter: add `exemptions` and `exemptedViolations` fields
+- [ ] Update SARIF reporter: use SARIF `suppressions` array on exempted results (standard field)
+- [ ] Update markdown reporter: add "Exempted Findings" section
+- [ ] Add `--show-exemptions` flag to `policy` command (default: hide exempted, flag shows them)
+- [ ] Write unit tests for `applyExemptions()` (match, no match, expired, glob, multiple exemptions)
+- [ ] Write integration test: policy with exemptions → verify violation count matches
+
+**Acceptance**: `.skill-policy.yml` with `exemptions` section correctly suppresses matching violations. Expired exemptions fail. `--show-exemptions` displays what was suppressed. SARIF output uses standard `suppressions` field.
+
+---
+
+### 1D. Test Gap Remediation (parallel with 1B and 1C)
+
+Address the three critical test blind spots identified in the gap analysis. These are for EXISTING untested code, not new Phase 1 code (new code gets tests inline).
+
+**New files**:
+- `packages/cli/src/usage/readers/sqlite.test.ts`
+- `packages/cli/src/policy/reporters/terminal.test.ts`
+- `packages/cli/src/policy/reporters/json.test.ts`
+- `packages/cli/src/policy/reporters/sarif.test.ts`
+- `packages/cli/src/policy/reporters/markdown.test.ts`
+- `packages/cli/test/e2e/health-pipeline.test.ts`
+
+#### 1D.1: SQLiteReader Tests
+
+- [ ] Create `packages/cli/src/usage/readers/sqlite.test.ts`
+- [ ] Test: reads valid SQLite database with telemetry events
+- [ ] Test: handles missing/corrupt database file gracefully
+- [ ] Test: deduplication works correctly
+- [ ] Test: date range filtering works
+- [ ] Use temp directory with real SQLite file (not mocks — this is the gap)
+- [ ] Verify against JSONL reader output for same dataset (cross-validate)
+
+#### 1D.2: Reporter Snapshot Tests
+
+For each reporter (terminal, JSON, markdown, SARIF):
+- [ ] Create test file in `packages/cli/src/policy/reporters/<name>.test.ts`
+- [ ] Test with zero violations (clean output)
+- [ ] Test with multiple violations across different rules
+- [ ] Test with mixed severities (error, warning, info)
+- [ ] Use Vitest `toMatchSnapshot()` for output stability
+- [ ] For SARIF: validate output against SARIF 2.1.0 schema (JSON Schema validation)
+
+#### 1D.3: E2E Pipeline Test
+
+- [ ] Create `packages/cli/test/e2e/health-pipeline.test.ts`
+- [ ] Set up fixture directory with real SKILL.md files (valid + invalid)
+- [ ] Set up fixture `.skill-policy.yml`
+- [ ] Run `health` command programmatically against fixtures
+- [ ] Assert: exit code, output format, violation count
+- [ ] Assert: audit + lint + budget + policy all execute
+- [ ] This test must NOT mock any module — real file I/O, real validators
+
+**Acceptance**: `pnpm test` passes with SQLite, reporter, and E2E tests. Coverage for existing code measurably improved.
+
+---
+
+## Wave 2: Tamper Detection (blocked by Wave 1B — Lock File)
+
+**Modified files**:
+- `packages/cli/src/lockfile/index.ts` - Add `verifyIntegrity()` function
+- `packages/cli/src/lockfile/index.test.ts` - Integrity verification tests
+- `packages/cli/src/registry.ts` - Add hash verification on registry load
+- `packages/cli/src/commands/verify.ts` - Wire integrity check into verify command
+- `packages/cli/src/commands/health.ts` - Add integrity check to health pipeline
+
+#### Integrity Verification
+
+```typescript
+// Add to packages/cli/src/lockfile/index.ts
+export interface IntegrityResult {
+  skill: string;
+  status: 'ok' | 'modified' | 'missing' | 'new';
+  expected?: string;  // hash from lock file
+  actual?: string;    // hash from current file
+  field?: string;     // which hash differs (contentHash, frontmatterHash, prefixHash)
+}
+
+export function verifyIntegrity(
+  lock: SkillsLockFile,
+  currentFingerprints: FingerprintRegistry
+): IntegrityResult[];
+```
+
+#### Verification behavior:
+1. On `health` command (always): compare current hashes vs lock file hashes
+2. `modified` → **warning** by default, **error** with `--frozen-lockfile`
+3. `missing` (skill in lock but not on disk) → **error** always
+4. `new` (skill on disk but not in lock) → **warning** by default, **error** with `--frozen-lockfile`
+
+**Tasks**:
+- [ ] Implement `verifyIntegrity()` in lockfile module
+- [ ] Wire into `health` command: run after fingerprinting, before policy
+- [ ] Wire into `verify` command: add `--check-integrity` flag
+- [ ] Add integrity results to all output formats (terminal, JSON, SARIF, markdown)
+- [ ] Unit tests: all 4 status cases (ok, modified, missing, new)
+- [ ] Unit tests: hash field identification (which specific hash changed)
+- [ ] Integration test: modify a SKILL.md → run health → verify tamper detected
+
+**Acceptance**: Modified skill files are detected and reported. `--frozen-lockfile` fails on any integrity mismatch.
+
+---
+
+## Wave 3: Revocation & Deprecation (blocked by Wave 1A schema + Wave 1C exemptions)
+
+**New files**:
+- `packages/cli/src/revocation/index.ts` - Read/check revocation list
+- `packages/cli/src/revocation/index.test.ts` - Unit tests
+
+**Modified files**:
+- `packages/cli/src/commands/audit.ts` - Check revocations during audit
+- `packages/cli/src/commands/health.ts` - Add `--check-revocations` flag
+- `packages/cli/src/scanner.ts` - Parse `deprecated` and `deprecatedMessage` from frontmatter
+
+#### Revocation List Format (`.skill-revocations.json`)
+
+```json
+{
+  "revocationVersion": 1,
+  "updatedAt": "2025-04-18T00:00:00Z",
+  "entries": [
+    {
+      "skill": "malicious-skill",
+      "reason": "Contains prompt injection targeting financial data",
+      "revokedAt": "2025-04-15T00:00:00Z",
+      "severity": "critical",
+      "advisory": "https://example.com/advisories/SK-2025-001"
+    }
+  ]
+}
+```
+
+#### Deprecation in Frontmatter
+
+```yaml
+---
+name: old-deploy-skill
+version: 2.1.0
+deprecated: true
+deprecatedMessage: "Use new-deploy-skill instead. Sunset: 2025-12-31"
+---
+```
+
+**Tasks**:
+- [ ] Create `packages/cli/src/revocation/index.ts` with `readRevocationList()`, `checkRevocations()`
+- [ ] Define `RevocationList`, `RevocationEntry` types in schema
+- [ ] Scanner: parse `deprecated` and `deprecatedMessage` from SKILL.md frontmatter
+- [ ] `checkRevocations()`: match skill names against revocation list, return matches with severity
+- [ ] Wire into `audit` command: check revocations as part of audit pipeline
+- [ ] Wire into `health` command: add `--check-revocations` flag (path to revocation file)
+- [ ] Deprecation: when scanner finds `deprecated: true`, populate `FingerprintEntry.status = 'deprecated'`
+- [ ] Deprecation warnings in `lint` output (separate from errors)
+- [ ] Unit tests: revocation matching, missing file handling, severity levels
+- [ ] Unit tests: deprecated frontmatter parsing, status propagation
+- [ ] Integration test: revoked skill → audit fails with critical finding
+
+**Acceptance**: Revoked skills cause audit failure. Deprecated skills emit warnings. Revocation list is read from local file path.
+
+---
+
+## Wave 4: Coverage Sweep (after all waves)
+
+Final pass to ensure all new Phase 1 code has adequate test coverage.
+
+**Tasks**:
+- [ ] Run `pnpm vitest --coverage` and identify any Phase 1 code below 80% line coverage
+- [ ] Add missing tests for edge cases found during coverage analysis
+- [ ] Verify all new reporters handle the new fields (exemptions, integrity, revocations)
+- [ ] Run `pnpm run typecheck` — zero type errors
+- [ ] Run `pnpm run build` — clean build
+- [ ] Run `pnpm run lint` — no new warnings
+- [ ] Run full test suite: `pnpm test` — all green
+- [ ] Manual smoke test: run `skills-check health --frozen-lockfile` against real skills directory
+
+**Acceptance**: Build green. Tests green. No type errors. Coverage >= 80% on all new code.
+
+---
+
+## Dependency Graph
+
+```
+Wave 1A (Schema) ─────┬──── Wave 1B (Lock File) ──── Wave 2 (Tamper Detection)
+                       │
+                       ├──── Wave 1C (Exemptions) ───┐
+                       │                              ├── Wave 3 (Revocation)
+                       └──── Wave 1D (Test Gaps)      │
+                                                      │
+                                              Wave 4 (Coverage Sweep)
+```
+
+## Risk Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Lock file format churn | Define v2 schema once in Wave 1A, freeze it. No mid-phase schema changes. |
+| Exemption glob matching adds dependency | Check if `picomatch` or `minimatch` is already in the dep tree (Commander/Vitest may bring one). Prefer existing. |
+| Breaking existing `skills-lock.json` consumers | `migrateLockFileV1()` handles upgrade. Old format auto-detected by missing `lockfileVersion` field. |
+| SARIF suppressions spec compliance | Validate against official SARIF 2.1.0 JSON Schema in reporter tests. |
+| skills-trace type divergence | After Wave 1A, open GitHub issue on skills-trace to consume `@skills-check/schema` directly. |
+| E2E test flakiness (file I/O, timing) | Use Vitest `beforeAll`/`afterAll` with temp directories. No shared state between tests. |
+
+## Estimated Effort
+
+| Wave | Effort | Parallelizable |
+|------|--------|----------------|
+| 1A (Schema) | 0.5 day | No (blocks all) |
+| 1B (Lock File) | 2-3 days | Yes (after 1A) |
+| 1C (Exemptions) | 2-3 days | Yes (after 1A, parallel with 1B) |
+| 1D (Test Gaps) | 1-2 days | Yes (after 1A, parallel with 1B/1C) |
+| 2 (Tamper) | 1-2 days | No (after 1B) |
+| 3 (Revocation) | 2 days | No (after 1A + 1C) |
+| 4 (Coverage) | 0.5 day | No (after all) |
+| **Total** | **~10-13 days** | 1B/1C/1D run in parallel |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,14 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+This project uses **GitHub Issues** for issue tracking. Use `gh` CLI for all issue operations.
 
 ## Quick Reference
 
 ```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --claim  # Claim work atomically
-bd close <id>         # Complete work
-bd sync               # Sync with git
+gh issue list                          # Find available work
+gh issue view <number>                 # View issue details
+gh issue edit <number> --add-assignee @me  # Claim work
+gh issue close <number>                # Complete work
 ```
 
 ## Non-Interactive Shell Commands
@@ -36,92 +35,28 @@ cp -rf source dest          # NOT: cp -r source dest
 - `apt-get` - use `-y` flag
 - `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
 
-<!-- BEGIN BEADS INTEGRATION -->
-## Issue Tracking with bd (beads)
+## Issue Tracking with GitHub Issues
 
-**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
+**IMPORTANT**: This project uses **GitHub Issues** for ALL issue tracking. Use `gh` CLI for programmatic access.
 
-### Why bd?
+### Workflow for AI Agents
 
-- Dependency-aware: Track blockers and relationships between issues
-- Git-friendly: Auto-syncs to JSONL for version control
-- Agent-optimized: JSON output, ready work detection, discovered-from links
-- Prevents duplicate tracking systems and confusion
+1. **Check available work**: `gh issue list --assignee @me` or `gh issue list --label "ready"`
+2. **Claim a task**: `gh issue edit <number> --add-assignee @me`
+3. **Work on it**: Implement, test, document
+4. **Discover new work?** Create a linked issue:
+   ```bash
+   gh issue create --title "Found bug" --body "Details about what was found" --label bug
+   ```
+5. **Complete**: `gh issue close <number> --reason completed`
 
-### Quick Start
-
-**Check for ready work:**
-
-```bash
-bd ready --json
-```
-
-**Create new issues:**
-
-```bash
-bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
-bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
-```
-
-**Claim and update:**
-
-```bash
-bd update <id> --claim --json
-bd update bd-42 --priority 1 --json
-```
-
-**Complete work:**
-
-```bash
-bd close bd-42 --reason "Completed" --json
-```
-
-### Issue Types
+### Labels
 
 - `bug` - Something broken
 - `feature` - New functionality
 - `task` - Work item (tests, docs, refactoring)
-- `epic` - Large feature with subtasks
 - `chore` - Maintenance (dependencies, tooling)
-
-### Priorities
-
-- `0` - Critical (security, data loss, broken builds)
-- `1` - High (major features, important bugs)
-- `2` - Medium (default, nice-to-have)
-- `3` - Low (polish, optimization)
-- `4` - Backlog (future ideas)
-
-### Workflow for AI Agents
-
-1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task atomically**: `bd update <id> --claim`
-3. **Work on it**: Implement, test, document
-4. **Discover new work?** Create linked issue:
-   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
-
-### Auto-Sync
-
-bd automatically syncs with git:
-
-- Exports to `.beads/issues.jsonl` after changes (5s debounce)
-- Imports from JSONL when newer (e.g., after `git pull`)
-- No manual export/import needed!
-
-### Important Rules
-
-- ✅ Use bd for ALL task tracking
-- ✅ Always use `--json` flag for programmatic use
-- ✅ Link discovered work with `discovered-from` dependencies
-- ✅ Check `bd ready` before asking "what should I work on?"
-- ❌ Do NOT create markdown TODO lists
-- ❌ Do NOT use external issue trackers
-- ❌ Do NOT duplicate tracking systems
-
-For more details, see README.md and docs/QUICKSTART.md.
-
-<!-- END BEADS INTEGRATION -->
+- `P0-critical` / `P1-high` / `P2-medium` / `P3-low` - Priority levels
 
 ## Landing the Plane (Session Completion)
 
@@ -135,7 +70,6 @@ For more details, see README.md and docs/QUICKSTART.md.
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd sync
    git push
    git status  # MUST show "up to date with origin"
    ```

--- a/GITHUB_ISSUES_BACKLOG.md
+++ b/GITHUB_ISSUES_BACKLOG.md
@@ -1,0 +1,409 @@
+# GitHub Issues Backlog
+
+Prepared from the April 12, 2026 production-readiness audit.
+
+GitHub write access was unavailable in the current session, so these issues were not created remotely. Existing related issues:
+
+- `#5` `fix: harden test command against command injection from untrusted cases.yaml`
+- `#6` `fix: pin npx skills-check version in action.yml to prevent supply chain attacks`
+
+## 1. tracking: production readiness and roadmap hardening audit
+
+### Summary
+
+Track the release-hardening backlog identified in the April 12, 2026 production-readiness audit.
+
+This issue should serve as the umbrella tracker for the remaining blockers and roadmap additions. The two existing overlapping blockers are:
+
+- `#5` test command injection / trust-boundary hardening
+- `#6` GitHub Action execution source and supply-chain hardening
+
+### Release blockers
+
+- CI and publish workflows are not reproducible from a clean checkout
+- Shell-string execution remains in critical testing paths
+- Isolated test execution is serialized through shell strings and detached from checked-out source
+- CI can fall back to unsafe local execution when isolation is unavailable
+- Runtime support declarations are inconsistent across the repo
+
+### Exit criteria
+
+- [ ] CI and publish are reproducible from a clean checkout
+- [ ] Critical shell-string execution paths are removed or tightly constrained
+- [ ] Isolated test execution uses structured argv and checked-out source
+- [ ] Unsafe CI fallback behavior is removed
+- [ ] Runtime and docs contracts are aligned
+- [ ] Security automation baseline is enabled
+
+### Related issues
+
+- `#5`
+- `#6`
+- Link the issues below once created
+
+---
+
+## 2. fix: migrate CI and publish workflows from npm to pnpm
+
+### Problem
+
+The repository declares PNPM as the package manager and only includes `pnpm-lock.yaml`, but both CI and publish workflows currently use `npm ci`. The workflows also trigger on `package-lock.json`, which does not exist in the repository.
+
+This makes the release path non-reproducible and currently broken from a clean checkout.
+
+### Evidence
+
+- Root package manager declaration: `packageManager: pnpm@10.24.0`
+- `pnpm-lock.yaml` exists
+- `package-lock.json` does not exist
+- `.github/workflows/ci.yml` runs `npm ci`
+- `.github/workflows/publish.yml` runs `npm ci`
+
+### Files
+
+- `package.json`
+- `.github/workflows/ci.yml`
+- `.github/workflows/publish.yml`
+
+### Required changes
+
+- Replace npm setup/install flow with PNPM-native setup
+- Add `pnpm/action-setup`
+- Use `pnpm install --frozen-lockfile`
+- Configure dependency caching for PNPM
+- Trigger workflows on `pnpm-lock.yaml` instead of `package-lock.json`
+- Verify workspace-aware build/test commands run correctly in CI
+
+### Acceptance criteria
+
+- [ ] Fresh GitHub runner can install dependencies from scratch
+- [ ] `build`, `lint`, `typecheck`, and `test` pass in CI using PNPM
+- [ ] Publish workflow uses PNPM consistently
+- [ ] Workflow triggers watch the correct lockfile
+
+### Priority
+
+P0 release blocker
+
+---
+
+## 3. fix: refactor isolated test execution to use argv and checked-out source
+
+### Problem
+
+The isolated `skills-check test` execution path currently serializes CLI options into a single command string and passes that through shell execution inside the isolation provider.
+
+This introduces parsing fragility, makes command behavior diverge from the non-isolated path, and runs code that is detached from the checked-out repository by installing the npm package inside the container.
+
+### Evidence
+
+- `commands/test.ts` builds a command string from CLI args
+- `isolation/providers/oci.ts` wraps execution via `sh -c`
+- OCI path installs `skills-check` from npm instead of using repo source
+
+### Files
+
+- `packages/cli/src/commands/test.ts`
+- `packages/cli/src/isolation/providers/oci.ts`
+- any shared isolation interfaces/types
+
+### Required changes
+
+- Refactor isolation provider contract to accept argv arrays rather than a single shell command string
+- Remove shell-based CLI reconstruction from `test`
+- Mount and execute the checked-out workspace or built local artifacts in the container
+- Ensure isolated and non-isolated execution parse the same options identically
+- Document the isolation model clearly
+
+### Acceptance criteria
+
+- [ ] Isolation providers accept structured argv
+- [ ] No critical `sh -c` wrapping for CLI argument transport
+- [ ] Container execution uses checked-out source or built local artifacts
+- [ ] Isolated and local runs produce equivalent argument handling
+
+### Priority
+
+P0 release blocker
+
+---
+
+## 4. fix: fail closed in CI when no isolation runtime is available
+
+### Problem
+
+The `test` command currently continues in CI when no isolation runtime is available. That behavior can run agent harnesses directly on the runner, including high-trust modes that intentionally disable permission checks.
+
+For CI, this should fail closed rather than warn and continue.
+
+### Evidence
+
+- CI path currently allows fallback to local execution
+- Claude harness uses `--dangerously-skip-permissions`
+
+### Files
+
+- `packages/cli/src/commands/test.ts`
+- `packages/cli/src/testing/harness/claude-code.ts`
+- related docs
+
+### Required changes
+
+- In CI, exit with an error when isolation is requested but unavailable
+- Require an explicit local-only override for unsafe execution modes
+- Revisit whether dangerous harness flags should be exposed by default
+- Document the trust boundary for all test harnesses
+
+### Acceptance criteria
+
+- [ ] CI never silently falls back to local unsafe execution
+- [ ] Unsafe local overrides require explicit opt-in
+- [ ] Harness trust model is documented
+
+### Priority
+
+P1 high priority
+
+---
+
+## 5. fix: unify Node runtime requirements across repo, package, CI, and docs
+
+### Problem
+
+Node version requirements are inconsistent. The monorepo root requires Node 22, while the published CLI package claims support for Node 18+. At the same time, some functionality depends on Node 22 features such as `node:sqlite`.
+
+This creates support ambiguity and production risk.
+
+### Evidence
+
+- Root `engines.node` is `>=22`
+- CLI package `engines.node` is `>=18`
+- usage telemetry includes a Node 22-specific SQLite reader
+
+### Files
+
+- `package.json`
+- `packages/cli/package.json`
+- `packages/cli/src/usage/readers/sqlite.ts`
+- docs and README
+
+### Required changes
+
+- Choose and document one supported minimum Node version
+- Align root package, CLI package, CI, publish, and docs
+- Make feature gating explicit if mixed support is retained
+
+### Acceptance criteria
+
+- [ ] Runtime declarations match across all package manifests
+- [ ] CI and publish use the documented supported version
+- [ ] Docs and error messages reflect the actual support policy
+
+### Priority
+
+P1 high priority
+
+---
+
+## 6. docs: correct invalid command examples and add trust-boundary guidance
+
+### Problem
+
+The docs include at least one invalid command example and do not clearly explain trust boundaries around commands that execute code or contact external systems.
+
+This will create support churn and unsafe operator expectations.
+
+### Evidence
+
+- Docs include `audit --fail-on warning`, but valid values are `critical`, `high`, `medium`, `low`
+
+### Files
+
+- `packages/web/app/docs/page.tsx`
+- `README.md`
+- any command reference pages
+
+### Required changes
+
+- Correct invalid CLI examples
+- Add a section explaining trusted vs. untrusted execution
+- Document isolation expectations for `test`
+- Clarify which commands are deterministic vs. LLM-assisted vs. externally networked
+
+### Acceptance criteria
+
+- [ ] All command examples are valid
+- [ ] Trust-boundary and execution-risk guidance is documented
+- [ ] Docs are consistent across README and website
+
+### Priority
+
+P1 high priority
+
+---
+
+## 7. security: add repository security baseline and dependency automation
+
+### Summary
+
+Establish a baseline security posture for the repository itself.
+
+This project is positioned as a security and quality tool for agent skills, so the repo should hold itself to a higher operational standard.
+
+### Scope
+
+- Add `SECURITY.md`
+- Add Dependabot or Renovate
+- Add CodeQL
+- Add dependency audit or OSV scanning in CI
+- Add SBOM generation during release
+
+### Why
+
+- Improve supply-chain visibility
+- Reduce time-to-detect for vulnerable dependencies
+- Provide a documented disclosure path
+- Align project operations with product positioning
+
+### Acceptance criteria
+
+- [ ] Security disclosure process is documented
+- [ ] Dependency updates are automated
+- [ ] Static/code scanning runs on PRs
+- [ ] Release flow emits or stores an SBOM
+
+### Priority
+
+P2 medium priority
+
+---
+
+## 8. test: add adversarial regression coverage for execution and isolation paths
+
+### Summary
+
+Add exploit-shaped regression tests for execution, parsing, and isolation-sensitive code paths.
+
+### Scope
+
+- Hostile prompt strings for generic harness
+- Shell metacharacters and quoting edge cases
+- Isolation argv parity tests
+- SSRF/private-network URL fixtures
+- Typo-package and prompt-injection fixtures
+
+### Files
+
+- `packages/cli/src/testing/harness/generic.test.ts`
+- `packages/cli/src/isolation/providers/oci.test.ts`
+- audit checker tests
+- any related integration tests
+
+### Required changes
+
+- Add negative tests that mirror real exploit shapes
+- Ensure CI exercises these regressions
+- Verify shell-string execution is not reintroduced
+
+### Acceptance criteria
+
+- [ ] Malicious prompt and quoting payloads are covered
+- [ ] Isolation behavior is tested for argv parity
+- [ ] SSRF and supply-chain style fixtures are covered
+
+### Priority
+
+P2 medium priority
+
+---
+
+## 9. feature: add skills-check doctor for environment and release readiness
+
+### Summary
+
+Add a diagnostic command that validates environment prerequisites and release-readiness assumptions.
+
+### Motivation
+
+This would reduce operator confusion and catch setup drift earlier, including package-manager mismatches, missing isolation runtimes, unsupported Node versions, and missing API keys.
+
+### Proposed scope
+
+- Validate Node version
+- Validate package manager / lockfile consistency
+- Validate registry/network reachability
+- Detect available isolation runtimes
+- Detect installed provider SDKs and API key env vars
+- Emit terminal and JSON output
+
+### Acceptance criteria
+
+- [ ] `skills-check doctor` exists
+- [ ] Terminal and JSON output are supported
+- [ ] CI can fail on invalid environment assumptions
+
+### Priority
+
+Roadmap feature
+
+---
+
+## 10. feature: add deterministic skills-check fix mode for safe autofixes
+
+### Summary
+
+Add a deterministic non-LLM autofix path for safe repairs.
+
+### Motivation
+
+Today there is a gap between validation and LLM-assisted `refresh`. A deterministic `fix` mode would support safer CI/autofix workflows and give operators a trusted option for routine normalization.
+
+### Proposed scope
+
+- Frontmatter normalization
+- Metadata repair
+- Registry scaffolding and alignment
+- Safe docs/example normalization
+- Dry-run plus write modes
+
+### Acceptance criteria
+
+- [ ] Only deterministic transforms are applied
+- [ ] Dry-run and write modes are supported
+- [ ] Output clearly shows proposed and applied changes
+
+### Priority
+
+Roadmap feature
+
+---
+
+## 11. feature: add enterprise policy packs, signed fingerprints, and drift bot automation
+
+### Summary
+
+Explore the next step beyond CLI checking by turning `skills-check` into a governance and provenance layer.
+
+### Proposed areas
+
+- Reusable organization policy packs
+- Signed or attested fingerprint outputs
+- Automated drift bot for stale packages, broken links, and policy regressions
+
+### Why
+
+This is the strongest long-term roadmap direction from the audit. It expands the product from local checking into enforceable governance and trust infrastructure.
+
+### Suggested approach
+
+- Start with a design issue or RFC
+- Split implementation into separate issues after the architecture is defined
+
+### Acceptance criteria
+
+- [ ] Design or RFC exists
+- [ ] MVP scope is broken into implementation tickets
+
+### Priority
+
+Roadmap / strategic

--- a/PLAN.md
+++ b/PLAN.md
@@ -1247,4 +1247,4 @@ After all Wave 3 merges complete:
 - [ ] Run `npm run build` to verify Turbo build order
 - [ ] Update README.md CLI Reference section with new commands
 - [ ] Update CLAUDE.md commands table (Current vs Planned → mark as shipped)
-- [ ] Close beads issues: `bd close ss-0dh.4 ss-0dh.5`
+- [ ] Close GitHub issues for ss-0dh.4 and ss-0dh.5

--- a/action.yml
+++ b/action.yml
@@ -130,6 +130,8 @@ outputs:
 
 runs:
   using: "composite"
+  # NOTE: skills-check is pinned to a specific version (currently 1.3.0) to prevent
+  # supply chain attacks. Update the pinned version in all npx commands when releasing.
   steps:
     # ── Setup ──────────────────────────────────────────────────────────
     - name: Setup Node.js
@@ -181,7 +183,7 @@ runs:
         INPUT_REGISTRY: ${{ inputs.registry }}
       run: |
         set +e
-        OUTPUT=$(npx --yes skills-check check --registry "$INPUT_REGISTRY" --json --ci 2>&1)
+        OUTPUT=$(npx --yes skills-check@1.3.0 check --registry "$INPUT_REGISTRY" --json --ci 2>&1)
         EXIT_CODE=$?
         set -e
 
@@ -208,7 +210,7 @@ runs:
       env:
         INPUT_REGISTRY: ${{ inputs.registry }}
       run: |
-        REPORT=$(npx --yes skills-check report --registry "$INPUT_REGISTRY" --format markdown 2>/dev/null)
+        REPORT=$(npx --yes skills-check@1.3.0 report --registry "$INPUT_REGISTRY" --format markdown 2>/dev/null)
 
         # Write multiline output
         {
@@ -246,7 +248,7 @@ runs:
         INPUT_AUDIT_FAIL_ON: ${{ inputs.audit-fail-on }}
       run: |
         set +e
-        AUDIT_OUTPUT=$(npx --yes skills-check audit "$INPUT_SKILLS_DIR" \
+        AUDIT_OUTPUT=$(npx --yes skills-check@1.3.0 audit "$INPUT_SKILLS_DIR" \
           --format json \
           --fail-on "$INPUT_AUDIT_FAIL_ON" 2>&1)
         EXIT_CODE=$?
@@ -277,7 +279,7 @@ runs:
         INPUT_LINT_FAIL_ON: ${{ inputs.lint-fail-on }}
       run: |
         set +e
-        LINT_OUTPUT=$(npx --yes skills-check lint "$INPUT_SKILLS_DIR" \
+        LINT_OUTPUT=$(npx --yes skills-check@1.3.0 lint "$INPUT_SKILLS_DIR" \
           --ci \
           --format json \
           --fail-on "$INPUT_LINT_FAIL_ON" 2>&1)
@@ -314,7 +316,7 @@ runs:
         fi
 
         set +e
-        BUDGET_OUTPUT=$(npx --yes skills-check budget "${BUDGET_ARGS[@]}" 2>&1)
+        BUDGET_OUTPUT=$(npx --yes skills-check@1.3.0 budget "${BUDGET_ARGS[@]}" 2>&1)
         EXIT_CODE=$?
         set -e
 
@@ -350,7 +352,7 @@ runs:
         POLICY_ARGS+=(--fail-on "$INPUT_POLICY_FAIL_ON")
 
         set +e
-        POLICY_OUTPUT=$(npx --yes skills-check policy check "${POLICY_ARGS[@]}" 2>&1)
+        POLICY_OUTPUT=$(npx --yes skills-check@1.3.0 policy check "${POLICY_ARGS[@]}" 2>&1)
         EXIT_CODE=$?
         set -e
 
@@ -376,7 +378,7 @@ runs:
       shell: bash
       run: |
         set +e
-        VERIFY_OUTPUT=$(npx --yes skills-check verify --all --format json --skip-llm 2>&1)
+        VERIFY_OUTPUT=$(npx --yes skills-check@1.3.0 verify --all --format json --skip-llm 2>&1)
         EXIT_CODE=$?
         set -e
 
@@ -404,7 +406,7 @@ runs:
         INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
       run: |
         set +e
-        TEST_OUTPUT=$(npx --yes skills-check test "$INPUT_SKILLS_DIR" --ci --format json 2>&1)
+        TEST_OUTPUT=$(npx --yes skills-check@1.3.0 test "$INPUT_SKILLS_DIR" --ci --format json 2>&1)
         EXIT_CODE=$?
         set -e
 
@@ -432,7 +434,7 @@ runs:
         INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
       run: |
         set +e
-        FP_OUTPUT=$(npx --yes skills-check fingerprint "$INPUT_SKILLS_DIR" --json 2>&1)
+        FP_OUTPUT=$(npx --yes skills-check@1.3.0 fingerprint "$INPUT_SKILLS_DIR" --json 2>&1)
         EXIT_CODE=$?
         set -e
 
@@ -469,7 +471,7 @@ runs:
         fi
 
         set +e
-        USAGE_OUTPUT=$(npx --yes skills-check usage "${USAGE_ARGS[@]}" 2>&1)
+        USAGE_OUTPUT=$(npx --yes skills-check@1.3.0 usage "${USAGE_ARGS[@]}" 2>&1)
         EXIT_CODE=$?
         set -e
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/semver": "^7.7.0",
+    "@vitest/coverage-v8": "^4.1.4",
     "tsup": "^8.5.0",
     "tsx": "^4.21.0",
     "typescript": "^5.8.0",

--- a/packages/cli/src/audit/types.ts
+++ b/packages/cli/src/audit/types.ts
@@ -9,7 +9,8 @@ export type AuditCategory =
 	| "metadata-incomplete"
 	| "url-liveness"
 	| "advisory-match"
-	| "registry-audit";
+	| "registry-audit"
+	| "revoked-skill";
 
 export interface AuditFinding {
 	category: AuditCategory;

--- a/packages/cli/src/commands/audit.integration.test.ts
+++ b/packages/cli/src/commands/audit.integration.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { auditCommand } from "./audit.js";
+
+describe("auditCommand integration", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skills-check-audit-integration-"));
+		const skillDir = join(tempDir, "revoked-skill");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: revoked-skill
+description: Test skill
+---
+
+# Revoked Skill
+`,
+			"utf-8"
+		);
+		vi.spyOn(console, "log").mockImplementation(() => undefined);
+		vi.spyOn(console, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("fails audit when a skill is revoked", async () => {
+		const revocationPath = join(tempDir, ".skill-revocations.json");
+		await writeFile(
+			revocationPath,
+			JSON.stringify(
+				{
+					revocationVersion: 1,
+					updatedAt: "2026-04-18T00:00:00Z",
+					entries: [
+						{
+							skill: "revoked-skill",
+							reason: "Contains prompt injection",
+							revokedAt: "2026-04-17T00:00:00Z",
+							severity: "critical",
+						},
+					],
+				},
+				null,
+				2
+			),
+			"utf-8"
+		);
+
+		const code = await auditCommand(tempDir, {
+			checkRevocations: revocationPath,
+			format: "json",
+			packagesOnly: true,
+			skipUrls: true,
+		});
+
+		expect(code).toBe(1);
+		const output = JSON.parse(String(vi.mocked(console.log).mock.calls[0][0]));
+		expect(output.summary.critical).toBe(1);
+		expect(output.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					category: "revoked-skill",
+					severity: "critical",
+					message: 'Skill "revoked-skill" has been revoked',
+				}),
+			])
+		);
+	});
+});

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -4,8 +4,10 @@ import { formatJson } from "../audit/reporters/json.js";
 import { formatMarkdown } from "../audit/reporters/markdown.js";
 import { formatSarif } from "../audit/reporters/sarif.js";
 import { formatTerminal } from "../audit/reporters/terminal.js";
-import type { AuditOptions, AuditSeverity } from "../audit/types.js";
+import type { AuditFinding, AuditOptions, AuditReport, AuditSeverity } from "../audit/types.js";
+import { runFingerprint } from "../fingerprint/index.js";
 import type { IsolationChoice } from "../isolation/types.js";
+import { createRevocationAuditFindings, readRevocationList } from "../revocation/index.js";
 import { auditThreshold, formatAndOutput } from "../shared/index.js";
 
 interface AuditCommandOptions {
@@ -16,6 +18,7 @@ interface AuditCommandOptions {
 	isolation?: IsolationChoice | boolean;
 	output?: string;
 	packagesOnly?: boolean;
+	checkRevocations?: string;
 	quiet?: boolean;
 	skipUrls?: boolean;
 	uniqueOnly?: boolean;
@@ -95,6 +98,9 @@ export async function auditCommand(dir: string, options: AuditCommandOptions): P
 			if (options.ignore) {
 				cmdParts.push("--ignore", options.ignore);
 			}
+			if (options.checkRevocations) {
+				cmdParts.push("--check-revocations", options.checkRevocations);
+			}
 			if (options.verbose) {
 				cmdParts.push("--verbose");
 			}
@@ -139,6 +145,9 @@ export async function auditCommand(dir: string, options: AuditCommandOptions): P
 		if (options.ignore) {
 			console.error(chalk.dim(`Ignore file: ${options.ignore}`));
 		}
+		if (options.checkRevocations) {
+			console.error(chalk.dim(`Revocation file: ${options.checkRevocations}`));
+		}
 	}
 
 	const auditOptions: AuditOptions = {
@@ -152,7 +161,9 @@ export async function auditCommand(dir: string, options: AuditCommandOptions): P
 		includeRegistryAudits: options.includeRegistryAudits,
 	};
 
-	const report = await runAudit([dir], auditOptions);
+	const baseReport = await runAudit([dir], auditOptions);
+	const revocationFindings = await loadRevocationFindings(dir, options.checkRevocations);
+	const report = mergeAuditReport(baseReport, revocationFindings);
 
 	if (options.verbose) {
 		console.error(
@@ -177,4 +188,41 @@ export async function auditCommand(dir: string, options: AuditCommandOptions): P
 		auditThreshold.meetsThreshold(f.severity, failOn)
 	);
 	return hasFailingFindings ? 1 : 0;
+}
+
+async function loadRevocationFindings(
+	dir: string,
+	revocationPath?: string
+): Promise<AuditFinding[]> {
+	if (!revocationPath) {
+		return [];
+	}
+
+	const revocations = readRevocationList(revocationPath);
+	if (!revocations) {
+		throw new Error(`Revocation list not found: ${revocationPath}`);
+	}
+
+	const registry = await runFingerprint([dir]);
+	return createRevocationAuditFindings(registry, revocations);
+}
+
+function mergeAuditReport(report: AuditReport, extraFindings: AuditFinding[]): AuditReport {
+	if (extraFindings.length === 0) {
+		return report;
+	}
+
+	const findings = [...report.findings, ...extraFindings];
+
+	return {
+		...report,
+		findings,
+		summary: {
+			critical: findings.filter((finding) => finding.severity === "critical").length,
+			high: findings.filter((finding) => finding.severity === "high").length,
+			medium: findings.filter((finding) => finding.severity === "medium").length,
+			low: findings.filter((finding) => finding.severity === "low").length,
+			total: findings.length,
+		},
+	};
 }

--- a/packages/cli/src/commands/fingerprint.ts
+++ b/packages/cli/src/commands/fingerprint.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import type { FingerprintOptions } from "../fingerprint/index.js";
 import { runFingerprint } from "../fingerprint/index.js";
+import { readLockFile, synchronizeLockFile, writeLockFile } from "../lockfile/index.js";
 import { formatAndOutput } from "../shared/index.js";
 
 interface FingerprintCommandOptions {
@@ -71,6 +72,20 @@ export async function fingerprintCommand(
 	};
 
 	const registry = await runFingerprint([dir], fpOptions);
+
+	try {
+		const nextLock = synchronizeLockFile(readLockFile(dir), registry);
+		writeLockFile(dir, nextLock);
+	} catch (error) {
+		console.error(
+			chalk.yellow(
+				`Warning: failed to update lock file: ${error instanceof Error ? error.message : String(error)}`
+			)
+		);
+		if (options.ci) {
+			return 2;
+		}
+	}
 
 	const format = options.json ? "json" : (options.format ?? "terminal");
 	await formatAndOutput(

--- a/packages/cli/src/commands/health.test.ts
+++ b/packages/cli/src/commands/health.test.ts
@@ -1,3 +1,4 @@
+import type { SkillsLockFile } from "@skills-check/schema";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../audit/index.js", () => ({
@@ -25,28 +26,57 @@ vi.mock("../budget/index.js", () => ({
 	}),
 }));
 
+vi.mock("../fingerprint/index.js", () => ({
+	runFingerprint: vi.fn().mockResolvedValue({
+		version: 1,
+		generatedAt: "2026-04-18T00:00:00.000Z",
+		entries: [],
+	}),
+}));
+
+vi.mock("../lockfile/index.js", () => ({
+	readLockFile: vi.fn().mockReturnValue(null),
+	verifyIntegrity: vi.fn().mockReturnValue([]),
+}));
+
 vi.mock("../policy/parser.js", () => ({
 	discoverPolicyFile: vi.fn().mockResolvedValue(null),
 	loadPolicyFile: vi.fn(),
 }));
 
+import { readLockFile, verifyIntegrity } from "../lockfile/index.js";
 import { healthCommand } from "./health.js";
+
+const mockedReadLockFile = vi.mocked(readLockFile);
+const mockedVerifyIntegrity = vi.mocked(verifyIntegrity);
+
+function makeLockFile(): SkillsLockFile {
+	return {
+		lockfileVersion: 2,
+		generatedBy: "skills-check@1.0.0",
+		generatedAt: "2026-04-18T00:00:00.000Z",
+		skills: {},
+	};
+}
 
 describe("healthCommand", () => {
 	let logSpy: ReturnType<typeof vi.spyOn>;
 	let errorSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		mockedReadLockFile.mockReturnValue(null);
+		mockedVerifyIntegrity.mockReturnValue([]);
 		logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
 		errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 	});
 
 	afterEach(() => {
+		vi.clearAllMocks();
 		logSpy.mockRestore();
 		errorSpy.mockRestore();
 	});
 
-	it("returns 0 when all checks pass", async () => {
+	it("returns 0 when checks pass and integrity only warns about missing lock file", async () => {
 		const code = await healthCommand(".", {});
 		expect(code).toBe(0);
 	});
@@ -63,6 +93,9 @@ describe("healthCommand", () => {
 		const output = JSON.parse(logSpy.mock.calls[0][0]);
 		expect(output.results).toBeDefined();
 		expect(output.results.length).toBeGreaterThan(0);
+		expect(output.results.some((result: { command: string }) => result.command === "integrity")).toBe(
+			true
+		);
 	});
 
 	it("skips commands when skip flags provided", async () => {
@@ -75,7 +108,8 @@ describe("healthCommand", () => {
 		});
 		expect(code).toBe(0);
 		const output = JSON.parse(logSpy.mock.calls[0][0]);
-		expect(output.results).toHaveLength(0);
+		expect(output.results).toHaveLength(1);
+		expect(output.results[0].command).toBe("integrity");
 	});
 
 	it("suppresses output with --quiet", async () => {
@@ -86,6 +120,50 @@ describe("healthCommand", () => {
 
 	it("returns 1 when budget exceeds max-tokens", async () => {
 		const code = await healthCommand(".", { maxTokens: "100" });
+		expect(code).toBe(1);
+	});
+
+	it("returns 1 when frozen lockfile is requested and lock file is missing", async () => {
+		const code = await healthCommand(".", { frozenLockfile: true });
+		expect(code).toBe(1);
+	});
+
+	it("treats modified integrity results as warnings by default", async () => {
+		mockedReadLockFile.mockReturnValue(makeLockFile());
+		mockedVerifyIntegrity.mockReturnValue([
+			{
+				skill: "react-patterns",
+				status: "modified",
+				field: "contentHash",
+				expected: "old",
+				actual: "new",
+			},
+		]);
+
+		const code = await healthCommand(".", { format: "json" });
+		expect(code).toBe(0);
+		const output = JSON.parse(logSpy.mock.calls[0][0]);
+		expect(output.results.find((result: { command: string }) => result.command === "integrity")).toMatchObject(
+			{
+				exitCode: 0,
+				status: "warning",
+			}
+		);
+	});
+
+	it("treats modified integrity results as failures with frozen lockfile", async () => {
+		mockedReadLockFile.mockReturnValue(makeLockFile());
+		mockedVerifyIntegrity.mockReturnValue([
+			{
+				skill: "react-patterns",
+				status: "modified",
+				field: "contentHash",
+				expected: "old",
+				actual: "new",
+			},
+		]);
+
+		const code = await healthCommand(".", { frozenLockfile: true });
 		expect(code).toBe(1);
 	});
 });

--- a/packages/cli/src/commands/health.ts
+++ b/packages/cli/src/commands/health.ts
@@ -1,16 +1,21 @@
 import chalk from "chalk";
 import { runAudit } from "../audit/index.js";
-import type { AuditOptions, AuditSeverity } from "../audit/types.js";
+import type { AuditFinding, AuditOptions, AuditSeverity } from "../audit/types.js";
 import { runBudget } from "../budget/index.js";
 import type { BudgetOptions } from "../budget/types.js";
+import { runFingerprint } from "../fingerprint/index.js";
 import { runLint } from "../lint/index.js";
 import type { LintOptions } from "../lint/types.js";
+import { readLockFile, verifyIntegrity, type IntegrityResult } from "../lockfile/index.js";
 import { runPolicyCheck } from "../policy/index.js";
 import { discoverPolicyFile, loadPolicyFile } from "../policy/parser.js";
+import { createRevocationAuditFindings, readRevocationList } from "../revocation/index.js";
 import { auditThreshold, lintThreshold, policyThreshold } from "../shared/index.js";
 
 interface HealthCommandOptions {
+	checkRevocations?: string;
 	format?: "terminal" | "json";
+	frozenLockfile?: boolean;
 	maxTokens?: string;
 	output?: string;
 	quiet?: boolean;
@@ -23,8 +28,96 @@ interface HealthCommandOptions {
 
 interface HealthResult {
 	command: string;
+	details?: string[];
 	exitCode: number;
+	status: "error" | "failure" | "ok" | "warning";
 	summary: string;
+}
+
+function createHealthResult(
+	command: string,
+	status: HealthResult["status"],
+	summary: string,
+	details?: string[]
+): HealthResult {
+	return {
+		command,
+		status,
+		summary,
+		details,
+		exitCode: status === "error" ? 2 : status === "failure" ? 1 : 0,
+	};
+}
+
+function summarizeIntegrity(results: IntegrityResult[]): {
+	missing: number;
+	modified: number;
+	new: number;
+	ok: number;
+} {
+	return results.reduce(
+		(summary, result) => {
+			summary[result.status] += 1;
+			return summary;
+		},
+		{ ok: 0, modified: 0, missing: 0, new: 0 }
+	);
+}
+
+function formatIntegrityDetails(results: IntegrityResult[]): string[] {
+	return results.flatMap((result) => {
+		switch (result.status) {
+			case "modified":
+				return [
+					`${result.skill}.${result.field}: ${result.expected ?? "<missing>"} → ${result.actual ?? "<missing>"}`,
+				];
+			case "missing":
+				return [`missing: ${result.skill}`];
+			case "new":
+				return [`new: ${result.skill}`];
+			default:
+				return [];
+		}
+	});
+}
+
+function formatIntegritySummary(results: IntegrityResult[]): string {
+	const counts = summarizeIntegrity(results);
+	const parts: string[] = [];
+
+	if (counts.modified > 0) {
+		parts.push(`${counts.modified} modified`);
+	}
+
+	if (counts.missing > 0) {
+		parts.push(`${counts.missing} missing`);
+	}
+
+	if (counts.new > 0) {
+		parts.push(`${counts.new} new`);
+	}
+
+	if (parts.length === 0) {
+		return `${counts.ok} skill(s) verified`;
+	}
+
+	return `${parts.join(", ")} (${results.length} checked)`;
+}
+
+function getIntegrityStatus(
+	results: IntegrityResult[],
+	frozenLockfile: boolean | undefined
+): HealthResult["status"] {
+	const counts = summarizeIntegrity(results);
+	if (counts.missing > 0 || (frozenLockfile && (counts.modified > 0 || counts.new > 0))) {
+		return "failure";
+	}
+
+	if (counts.modified > 0 || counts.new > 0) {
+		return "warning";
+	}
+
+	return "ok";
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator function
@@ -47,17 +140,21 @@ export async function healthCommand(dir: string, options: HealthCommandOptions):
 			const hasErrors = report.findings.some((f) =>
 				lintThreshold.meetsThreshold(f.level as "error" | "warning", "error")
 			);
-			results.push({
-				command: "lint",
-				exitCode: hasErrors ? 1 : 0,
-				summary: `${report.findings.length} finding(s)`,
-			});
+			results.push(
+				createHealthResult(
+					"lint",
+					hasErrors ? "failure" : "ok",
+					`${report.findings.length} finding(s)`
+				)
+			);
 		} catch (err) {
-			results.push({
-				command: "lint",
-				exitCode: 2,
-				summary: `error: ${err instanceof Error ? err.message : String(err)}`,
-			});
+			results.push(
+				createHealthResult(
+					"lint",
+					"error",
+					`error: ${err instanceof Error ? err.message : String(err)}`
+				)
+			);
 		}
 	}
 
@@ -69,20 +166,29 @@ export async function healthCommand(dir: string, options: HealthCommandOptions):
 		try {
 			const auditOptions: AuditOptions = { failOn: "high" as AuditSeverity, skipUrls: true };
 			const report = await runAudit([dir], auditOptions);
-			const hasFindings = report.findings.some((f) =>
-				auditThreshold.meetsThreshold(f.severity, "high" as AuditSeverity)
+			const revocationFindings = await loadHealthRevocationFindings(
+				dir,
+				options.checkRevocations
 			);
-			results.push({
-				command: "audit",
-				exitCode: hasFindings ? 1 : 0,
-				summary: `${report.summary.total} finding(s)`,
-			});
+			const findings = [...report.findings, ...revocationFindings];
+			results.push(
+				createHealthResult(
+					"audit",
+					findings.some((finding) => auditThreshold.meetsThreshold(finding.severity, "high"))
+						? "failure"
+						: "ok",
+					`${findings.length} finding(s)`,
+					revocationFindings.map((finding) => `${finding.file}: ${finding.message}`)
+				)
+			);
 		} catch (err) {
-			results.push({
-				command: "audit",
-				exitCode: 2,
-				summary: `error: ${err instanceof Error ? err.message : String(err)}`,
-			});
+			results.push(
+				createHealthResult(
+					"audit",
+					"error",
+					`error: ${err instanceof Error ? err.message : String(err)}`
+				)
+			);
 		}
 	}
 
@@ -96,21 +202,63 @@ export async function healthCommand(dir: string, options: HealthCommandOptions):
 			const budgetOptions: BudgetOptions = { maxTokens };
 			const report = await runBudget([dir], budgetOptions);
 			const overBudget = maxTokens !== undefined && report.totalTokens > maxTokens;
-			results.push({
-				command: "budget",
-				exitCode: overBudget ? 1 : 0,
-				summary: `${report.totalTokens.toLocaleString()} tokens`,
-			});
+			results.push(
+				createHealthResult(
+					"budget",
+					overBudget ? "failure" : "ok",
+					`${report.totalTokens.toLocaleString()} tokens`
+				)
+			);
 		} catch (err) {
-			results.push({
-				command: "budget",
-				exitCode: 2,
-				summary: `error: ${err instanceof Error ? err.message : String(err)}`,
-			});
+			results.push(
+				createHealthResult(
+					"budget",
+					"error",
+					`error: ${err instanceof Error ? err.message : String(err)}`
+				)
+			);
 		}
 	}
 
-	// 4. Policy
+	// 4. Integrity
+	if (options.verbose) {
+		console.error(chalk.dim("Running integrity check..."));
+	}
+	try {
+		const fingerprintRegistry = await runFingerprint([dir]);
+		const currentLock = readLockFile(dir);
+
+		if (!currentLock) {
+			results.push(
+				createHealthResult(
+					"integrity",
+					options.frozenLockfile ? "failure" : "warning",
+					"skills-lock.json missing",
+					['Run "skills-check fingerprint" to generate one.']
+				)
+			);
+		} else {
+			const integrityResults = verifyIntegrity(currentLock, fingerprintRegistry);
+			results.push(
+				createHealthResult(
+					"integrity",
+					getIntegrityStatus(integrityResults, options.frozenLockfile),
+					formatIntegritySummary(integrityResults),
+					formatIntegrityDetails(integrityResults)
+				)
+			);
+		}
+	} catch (err) {
+		results.push(
+			createHealthResult(
+				"integrity",
+				"error",
+				`error: ${err instanceof Error ? err.message : String(err)}`
+			)
+		);
+	}
+
+	// 5. Policy
 	if (!options.skipPolicy) {
 		if (options.verbose) {
 			console.error(chalk.dim("Running policy check..."));
@@ -123,28 +271,27 @@ export async function healthCommand(dir: string, options: HealthCommandOptions):
 				const hasFindings = report.findings.some((f) =>
 					policyThreshold.meetsThreshold(f.severity, "blocked")
 				);
-				results.push({
-					command: "policy",
-					exitCode: hasFindings ? 1 : 0,
-					summary: `${report.findings.length} finding(s)`,
-				});
+				results.push(
+					createHealthResult(
+						"policy",
+						hasFindings ? "failure" : "ok",
+						`${report.findings.length} finding(s)`
+					)
+				);
 			} else {
-				results.push({
-					command: "policy",
-					exitCode: 0,
-					summary: "no policy file found, skipped",
-				});
+				results.push(createHealthResult("policy", "ok", "no policy file found, skipped"));
 			}
 		} catch (err) {
-			results.push({
-				command: "policy",
-				exitCode: 2,
-				summary: `error: ${err instanceof Error ? err.message : String(err)}`,
-			});
+			results.push(
+				createHealthResult(
+					"policy",
+					"error",
+					`error: ${err instanceof Error ? err.message : String(err)}`
+				)
+			);
 		}
 	}
 
-	// Output results
 	if (options.format === "json") {
 		const output = JSON.stringify({ results }, null, 2);
 		if (!options.quiet) {
@@ -153,21 +300,42 @@ export async function healthCommand(dir: string, options: HealthCommandOptions):
 	} else if (!options.quiet) {
 		console.log(chalk.bold("\nHealth Check Results"));
 		console.log("=".repeat(40));
-		for (const r of results) {
+		for (const result of results) {
 			let icon: string;
-			if (r.exitCode === 0) {
+			if (result.status === "ok") {
 				icon = chalk.green("✓");
-			} else if (r.exitCode === 1) {
+			} else if (result.status === "warning") {
+				icon = chalk.yellow("⚠");
+			} else if (result.status === "failure") {
 				icon = chalk.red("✗");
 			} else {
 				icon = chalk.yellow("!");
 			}
-			console.log(`  ${icon} ${chalk.bold(r.command)}: ${r.summary}`);
+			console.log(`  ${icon} ${chalk.bold(result.command)}: ${result.summary}`);
+			for (const detail of result.details ?? []) {
+				console.log(`    ${chalk.dim(detail)}`);
+			}
 		}
 		console.log("");
 	}
 
-	// Exit code: 1 if any command failed, 2 if any errored
-	const maxExit = Math.max(0, ...results.map((r) => r.exitCode));
+	const maxExit = Math.max(0, ...results.map((result) => result.exitCode));
 	return maxExit > 1 ? 2 : maxExit;
+}
+
+async function loadHealthRevocationFindings(
+	dir: string,
+	revocationPath?: string
+): Promise<AuditFinding[]> {
+	if (!revocationPath) {
+		return [];
+	}
+
+	const revocations = readRevocationList(revocationPath);
+	if (!revocations) {
+		throw new Error(`Revocation list not found: ${revocationPath}`);
+	}
+
+	const registry = await runFingerprint([dir]);
+	return createRevocationAuditFindings(registry, revocations);
 }

--- a/packages/cli/src/commands/lockfile.integration.test.ts
+++ b/packages/cli/src/commands/lockfile.integration.test.ts
@@ -1,0 +1,277 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateObject } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchChangelog } from "../changelog.js";
+import { readLockFile } from "../lockfile/index.js";
+import { resolveModel } from "../llm/providers.js";
+import { fetchLatestVersions } from "../npm.js";
+import { loadRegistry, saveRegistry } from "../registry.js";
+import type { Registry } from "../types.js";
+import { fingerprintCommand } from "./fingerprint.js";
+import { healthCommand } from "./health.js";
+import { refreshCommand } from "./refresh.js";
+
+vi.mock("../npm.js", () => ({
+	fetchLatestVersions: vi.fn(),
+}));
+
+vi.mock("../registry.js", () => ({
+	loadRegistry: vi.fn(),
+	saveRegistry: vi.fn(),
+}));
+
+vi.mock("../changelog.js", () => ({
+	fetchChangelog: vi.fn(),
+}));
+
+vi.mock("../llm/providers.js", () => ({
+	resolveModel: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+	generateObject: vi.fn(),
+}));
+
+const mockedLoadRegistry = vi.mocked(loadRegistry);
+const mockedSaveRegistry = vi.mocked(saveRegistry);
+const mockedFetchLatestVersions = vi.mocked(fetchLatestVersions);
+const mockedFetchChangelog = vi.mocked(fetchChangelog);
+const mockedResolveModel = vi.mocked(resolveModel);
+const mockedGenerateObject = vi.mocked(generateObject);
+
+const SKILL_CONTENT = `---
+name: nextjs-routing
+product-version: "14.0.0"
+source: internal/nextjs-routing
+---
+# Next.js Routing
+
+Initial content.
+`;
+
+describe("lockfile command integration", () => {
+	let tempDir: string;
+	let skillsDir: string;
+
+	beforeEach(async () => {
+		vi.restoreAllMocks();
+		tempDir = await mkdtemp(join(tmpdir(), "skills-check-command-lockfile-"));
+		skillsDir = join(tempDir, "skills");
+		await mkdir(join(skillsDir, "nextjs-routing"), { recursive: true });
+		await writeFile(join(skillsDir, "nextjs-routing", "SKILL.md"), SKILL_CONTENT, "utf-8");
+		vi.spyOn(console, "log").mockImplementation(() => undefined);
+		vi.spyOn(console, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("fingerprint auto-updates the lock file", async () => {
+		const code = await fingerprintCommand(skillsDir, { quiet: true });
+
+		expect(code).toBe(0);
+		const lock = readLockFile(skillsDir);
+		expect(lock?.lockfileVersion).toBe(2);
+		expect(lock?.skills["nextjs-routing"]).toEqual(
+			expect.objectContaining({
+				name: "nextjs-routing",
+				source: "internal/nextjs-routing",
+				version: "14.0.0",
+			})
+		);
+	});
+
+	it("refresh auto-updates the lock file after rewriting a skill", async () => {
+		const registry: Registry = {
+			version: 1,
+			lastCheck: "2026-04-17T00:00:00.000Z",
+			skillsDir,
+			products: {
+				nextjs: {
+					displayName: "Next.js",
+					package: "next",
+					verifiedVersion: "14.0.0",
+					verifiedAt: "2026-04-17T00:00:00.000Z",
+					skills: ["nextjs-routing"],
+				},
+			},
+		};
+
+		mockedLoadRegistry.mockResolvedValue(registry);
+		mockedSaveRegistry.mockResolvedValue(join(tempDir, "skills-check.json"));
+		mockedFetchLatestVersions.mockResolvedValue(new Map([["next", "15.0.0"]]));
+		mockedFetchChangelog.mockResolvedValue("## Next.js 15\n- Updated routing guidance");
+		mockedResolveModel.mockResolvedValue({} as Awaited<ReturnType<typeof resolveModel>>);
+		mockedGenerateObject.mockResolvedValue({
+			object: {
+				summary: "Updated for Next.js 15",
+				confidence: "high",
+				breakingChanges: false,
+				changes: [{ section: "routing", description: "Version bump" }],
+				updatedContent: `---
+name: nextjs-routing
+product-version: "15.0.0"
+source: internal/nextjs-routing
+---
+# Next.js Routing
+
+Updated content.
+`,
+			},
+		} as Awaited<ReturnType<typeof generateObject>>);
+
+		const code = await refreshCommand(undefined, { yes: true });
+
+		expect(code).toBe(0);
+		const skillAfter = await readFile(join(skillsDir, "nextjs-routing", "SKILL.md"), "utf-8");
+		expect(skillAfter).toContain('product-version: "15.0.0"');
+		const lock = readLockFile(skillsDir);
+		expect(lock?.skills["nextjs-routing"]).toEqual(
+			expect.objectContaining({
+				version: "15.0.0",
+				source: "internal/nextjs-routing",
+			})
+		);
+	});
+
+	it("health --frozen-lockfile fails when the lock file is missing", async () => {
+		const code = await healthCommand(skillsDir, {
+			frozenLockfile: true,
+			skipAudit: true,
+			skipBudget: true,
+			skipLint: true,
+			skipPolicy: true,
+			quiet: true,
+		});
+
+		expect(code).toBe(1);
+	});
+
+	it("health --frozen-lockfile passes when the lock file matches", async () => {
+		await fingerprintCommand(skillsDir, { quiet: true });
+
+		const code = await healthCommand(skillsDir, {
+			frozenLockfile: true,
+			skipAudit: true,
+			skipBudget: true,
+			skipLint: true,
+			skipPolicy: true,
+			quiet: true,
+		});
+
+		expect(code).toBe(0);
+	});
+
+	it("health detects tampering after a skill changes", async () => {
+		await fingerprintCommand(skillsDir, { quiet: true });
+		await writeFile(
+			join(skillsDir, "nextjs-routing", "SKILL.md"),
+			SKILL_CONTENT.replace("Initial content.", "Modified content."),
+			"utf-8"
+		);
+
+		const code = await healthCommand(skillsDir, {
+			skipAudit: true,
+			skipBudget: true,
+			skipLint: true,
+			skipPolicy: true,
+			format: "json",
+		});
+
+		expect(code).toBe(0);
+		const output = JSON.parse(String(vi.mocked(console.log).mock.calls[0][0]));
+		expect(output.results[0]).toEqual(
+			expect.objectContaining({
+				command: "integrity",
+				exitCode: 0,
+				status: "warning",
+			})
+		);
+		expect(output.results[0].details.join(" ")).toContain("contentHash");
+	});
+
+	it("health --frozen-lockfile fails with integrity details when skills change", async () => {
+		await fingerprintCommand(skillsDir, { quiet: true });
+		await writeFile(
+			join(skillsDir, "nextjs-routing", "SKILL.md"),
+			SKILL_CONTENT.replace("Initial content.", "Modified content."),
+			"utf-8"
+		);
+
+		const code = await healthCommand(skillsDir, {
+			frozenLockfile: true,
+			skipAudit: true,
+			skipBudget: true,
+			skipLint: true,
+			skipPolicy: true,
+			format: "json",
+		});
+
+		expect(code).toBe(1);
+		const output = JSON.parse(String(vi.mocked(console.log).mock.calls[0][0]));
+		expect(output.results[0]).toEqual(
+			expect.objectContaining({
+				command: "integrity",
+				exitCode: 1,
+			})
+		);
+		expect(output.results[0].details.join(" ")).toContain("contentHash");
+	});
+
+	it("health --check-revocations fails when a skill is revoked", async () => {
+		const revocationPath = join(tempDir, ".skill-revocations.json");
+		await writeFile(
+			revocationPath,
+			JSON.stringify(
+				{
+					revocationVersion: 1,
+					updatedAt: "2026-04-18T00:00:00Z",
+					entries: [
+						{
+							skill: "nextjs-routing",
+							reason: "Compromised workflow",
+							revokedAt: "2026-04-17T00:00:00Z",
+							severity: "critical",
+						},
+					],
+				},
+				null,
+				2
+			),
+			"utf-8"
+		);
+
+		const code = await healthCommand(skillsDir, {
+			checkRevocations: revocationPath,
+			skipBudget: true,
+			skipLint: true,
+			skipPolicy: true,
+			format: "json",
+		});
+
+		expect(code).toBe(1);
+		const output = JSON.parse(String(vi.mocked(console.log).mock.calls[0][0]));
+		expect(output.results).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					command: "audit",
+					exitCode: 1,
+					status: "failure",
+					summary: expect.stringContaining("finding"),
+					details: expect.arrayContaining([
+						expect.stringContaining('Skill "nextjs-routing" has been revoked'),
+					]),
+				}),
+				expect.objectContaining({
+					command: "integrity",
+					exitCode: 0,
+					status: "warning",
+				}),
+			])
+		);
+	});
+});

--- a/packages/cli/src/commands/policy.test.ts
+++ b/packages/cli/src/commands/policy.test.ts
@@ -29,6 +29,8 @@ const mockedDiscoverPolicyFile = vi.mocked(discoverPolicyFile);
 
 function makeReport(overrides?: Partial<PolicyReport>): PolicyReport {
 	return {
+		exemptedViolations: [],
+		exemptions: [],
 		policyFile: ".skill-policy.yml",
 		files: 1,
 		findings: [],
@@ -131,6 +133,16 @@ describe("policyCheckCommand", () => {
 	it("uses specified policy path", async () => {
 		await policyCheckCommand(".", { policy: "/custom/policy.yml" });
 		expect(mockedLoadPolicyFile).toHaveBeenCalledWith("/custom/policy.yml");
+	});
+
+	it("passes --show-exemptions to the policy runner", async () => {
+		await policyCheckCommand(".", { showExemptions: true });
+		expect(mockedRunPolicyCheck).toHaveBeenCalledWith(
+			["."],
+			{ version: 1 },
+			"/project/.skill-policy.yml",
+			expect.objectContaining({ showExemptions: true })
+		);
 	});
 
 	it("outputs json format", async () => {

--- a/packages/cli/src/commands/policy.ts
+++ b/packages/cli/src/commands/policy.ts
@@ -17,6 +17,7 @@ interface PolicyCheckCommandOptions {
 	output?: string;
 	policy?: string;
 	quiet?: boolean;
+	showExemptions?: boolean;
 	skill?: string;
 	verbose?: boolean;
 }
@@ -85,6 +86,7 @@ export async function policyCheckCommand(
 		format: options.format,
 		output: options.output,
 		failOn,
+		showExemptions: options.showExemptions,
 	};
 
 	const report = await runPolicyCheck([dir], policy, policyPath, policyOptions);

--- a/packages/cli/src/commands/refresh.ts
+++ b/packages/cli/src/commands/refresh.ts
@@ -13,6 +13,8 @@ import { diffStats, formatDiff } from "../diff.js";
 import { buildSystemPrompt, buildUserPrompt } from "../llm/prompts.js";
 import { resolveModel } from "../llm/providers.js";
 import { RefreshResultSchema } from "../llm/schemas.js";
+import { runFingerprint } from "../fingerprint/index.js";
+import { readLockFile, synchronizeLockFile, writeLockFile } from "../lockfile/index.js";
 import { fetchLatestVersions } from "../npm.js";
 import { loadRegistry, saveRegistry } from "../registry.js";
 import { getSeverity, normalizeVersion } from "../severity.js";
@@ -342,6 +344,19 @@ export async function refreshCommand(
 		registry.lastCheck = new Date().toISOString();
 		const savedPath = await saveRegistry(registry, options.registry);
 		console.log(chalk.dim(`\nRegistry updated: ${savedPath}`));
+
+		try {
+			const fingerprintRegistry = await runFingerprint([resolvedSkillsDir]);
+			const nextLock = synchronizeLockFile(readLockFile(resolvedSkillsDir), fingerprintRegistry);
+			writeLockFile(resolvedSkillsDir, nextLock);
+			console.log(chalk.dim(`Lock file updated: ${resolvedSkillsDir}/skills-lock.json`));
+		} catch (error) {
+			console.error(
+				chalk.yellow(
+					`Warning: failed to update lock file: ${error instanceof Error ? error.message : String(error)}`
+				)
+			);
+		}
 	}
 
 	// Summary

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -1,4 +1,6 @@
 import chalk from "chalk";
+import { runFingerprint } from "../fingerprint/index.js";
+import { diffLockFiles, readLockFile, synchronizeLockFile } from "../lockfile/index.js";
 import { fetchLatestVersions } from "../npm.js";
 import { loadRegistry } from "../registry.js";
 import { getSeverity, normalizeVersion } from "../severity.js";
@@ -14,6 +16,7 @@ interface ReportOptions {
  */
 export async function reportCommand(options: ReportOptions): Promise<number> {
 	const registry = await loadRegistry(options.registry);
+	const skillsDir = registry.skillsDir ?? ".";
 	const productEntries = Object.entries(registry.products);
 
 	// Fetch all latest versions in parallel
@@ -63,6 +66,7 @@ export async function reportCommand(options: ReportOptions): Promise<number> {
 	const stale = results.filter((r) => r.stale);
 	const current = results.filter((r) => !r.stale);
 	const now = new Date().toISOString().split("T")[0];
+	const lockFile = readLockFile(skillsDir);
 
 	const lines: string[] = [];
 	lines.push("# Skills Check Report");
@@ -75,6 +79,34 @@ export async function reportCommand(options: ReportOptions): Promise<number> {
 	lines.push(`- **Stale**: ${stale.length}`);
 	lines.push(`- **Current**: ${current.length}`);
 	lines.push("");
+
+	lines.push("## Lock File Drift");
+	lines.push("");
+
+	if (!lockFile) {
+		lines.push(`- No ${skillsDir}/skills-lock.json found.`);
+		lines.push("");
+	} else {
+		const fingerprintRegistry = await runFingerprint([skillsDir]);
+		const nextLock = synchronizeLockFile(lockFile, fingerprintRegistry);
+		const diff = diffLockFiles(lockFile, nextLock);
+
+		if (diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0) {
+			lines.push("- No lock file drift detected.");
+			lines.push("");
+		} else {
+			if (diff.added.length > 0) {
+				lines.push(`- Added: ${diff.added.join(", ")}`);
+			}
+			if (diff.removed.length > 0) {
+				lines.push(`- Removed: ${diff.removed.join(", ")}`);
+			}
+			for (const change of diff.changed) {
+				lines.push(`- Changed ${change.name}.${change.field}: ${change.from} → ${change.to}`);
+			}
+			lines.push("");
+		}
+	}
 
 	if (stale.length > 0) {
 		lines.push("## Stale Products");

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,4 +1,6 @@
 import { writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import type { IsolationChoice } from "../isolation/types.js";
 import { runTests } from "../testing/index.js";
@@ -7,6 +9,16 @@ import { formatMarkdown } from "../testing/reporters/markdown.js";
 import { formatTestSarif } from "../testing/reporters/sarif.js";
 import { formatTerminal } from "../testing/reporters/terminal.js";
 import type { TestOptions } from "../testing/types.js";
+
+/**
+ * Resolve the local CLI package root for mounting into containers.
+ * Uses import.meta.url to find the dist directory relative to the current module.
+ */
+function getLocalBuildPath(): string {
+	const currentDir = dirname(fileURLToPath(import.meta.url));
+	// commands/ is inside src/ or dist/ — go up to the package root
+	return resolve(currentDir, "..", "..");
+}
 
 interface TestCommandOptions {
 	agent?: string;
@@ -107,57 +119,60 @@ export async function testCommand(dir: string, options: TestCommandOptions): Pro
 				console.error(chalk.dim(`Running tests in isolated environment (${provider.name})...`));
 			}
 
-			// Rebuild the CLI command string from options
-			const cmdParts = [dir];
+			// Build structured argv array instead of a command string
+			const argv: string[] = ["test", dir];
 			if (options.skill) {
-				cmdParts.push("--skill", options.skill);
+				argv.push("--skill", options.skill);
 			}
 			if (options.type) {
-				cmdParts.push("--type", options.type);
+				argv.push("--type", options.type);
 			}
 			if (options.agent) {
-				cmdParts.push("--agent", options.agent);
+				argv.push("--agent", options.agent);
 			}
 			if (options.agentCmd) {
-				cmdParts.push("--agent-cmd", `"${options.agentCmd}"`);
+				argv.push("--agent-cmd", options.agentCmd);
 			}
 			if (options.format) {
-				cmdParts.push("--format", options.format);
+				argv.push("--format", options.format);
 			}
 			if (options.output) {
-				cmdParts.push("--output", options.output);
+				argv.push("--output", options.output);
 			}
 			if (options.trials) {
-				cmdParts.push("--trials", options.trials);
+				argv.push("--trials", options.trials);
 			}
 			if (options.passThreshold) {
-				cmdParts.push("--pass-threshold", options.passThreshold);
+				argv.push("--pass-threshold", options.passThreshold);
 			}
 			if (options.timeout) {
-				cmdParts.push("--timeout", options.timeout);
+				argv.push("--timeout", options.timeout);
 			}
 			if (options.maxCost) {
-				cmdParts.push("--max-cost", options.maxCost);
+				argv.push("--max-cost", options.maxCost);
 			}
 			if (options.dry) {
-				cmdParts.push("--dry");
+				argv.push("--dry");
 			}
 			if (options.updateBaseline) {
-				cmdParts.push("--update-baseline");
+				argv.push("--update-baseline");
 			}
 			if (options.ci) {
-				cmdParts.push("--ci");
+				argv.push("--ci");
 			}
 			if (options.provider) {
-				cmdParts.push("--provider", options.provider);
+				argv.push("--provider", options.provider);
 			}
 			if (options.model) {
-				cmdParts.push("--model", options.model);
+				argv.push("--model", options.model);
 			}
 			if (options.verbose) {
-				cmdParts.push("--verbose");
+				argv.push("--verbose");
 			}
-			cmdParts.push("--no-isolation"); // Prevent recursion inside the container
+			argv.push("--no-isolation"); // Prevent recursion inside the container
+
+			// Resolve local build path for mounting into the container
+			const localBuildPath = getLocalBuildPath();
 
 			// Forward LLM API keys for rubric grading
 			const env: Record<string, string> = {};
@@ -169,7 +184,9 @@ export async function testCommand(dir: string, options: TestCommandOptions): Pro
 			}
 
 			const result = await provider.execute({
-				command: `test ${cmdParts.join(" ")}`,
+				argv,
+				command: `test ${argv.slice(1).join(" ")}`, // backward compat
+				localBuild: localBuildPath,
 				skillsDir: dir,
 				workDir: dir,
 				timeout: options.timeout ? Number.parseInt(options.timeout, 10) * 2 : 600,

--- a/packages/cli/src/commands/verify.test.ts
+++ b/packages/cli/src/commands/verify.test.ts
@@ -140,4 +140,32 @@ describe("verifyCommand", () => {
 		await verifyCommand({ all: true, skipLlm: true });
 		expect(mockedRunVerify).toHaveBeenCalledWith(expect.objectContaining({ skipLlm: true }));
 	});
+
+	it("passes checkIntegrity option", async () => {
+		await verifyCommand({ all: true, checkIntegrity: true });
+		expect(mockedRunVerify).toHaveBeenCalledWith(expect.objectContaining({ checkIntegrity: true }));
+	});
+
+	it("returns 1 when integrity issues are found", async () => {
+		mockedRunVerify.mockResolvedValue(
+			makeReport({
+				integrity: {
+					lockFound: true,
+					results: [
+						{
+							skill: "react-patterns",
+							status: "modified",
+							field: "contentHash",
+							expected: "old",
+							actual: "new",
+						},
+					],
+					summary: { ok: 0, modified: 1, missing: 0, new: 0 },
+				},
+			})
+		);
+
+		const code = await verifyCommand({ all: true, checkIntegrity: true });
+		expect(code).toBe(1);
+	});
 });

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -11,6 +11,7 @@ interface VerifyCommandOptions {
 	after?: string;
 	all?: boolean;
 	before?: string;
+	checkIntegrity?: boolean;
 	format?: "terminal" | "json" | "markdown" | "sarif";
 	model?: string;
 	output?: string;
@@ -60,6 +61,7 @@ export async function verifyCommand(options: VerifyCommandOptions): Promise<numb
 		skill: options.skill,
 		all: options.all,
 		before: options.before,
+		checkIntegrity: options.checkIntegrity,
 		after: options.after,
 		suggest: options.suggest,
 		format: options.format,
@@ -91,6 +93,13 @@ export async function verifyCommand(options: VerifyCommandOptions): Promise<numb
 		}
 	);
 
-	// Exit code: 1 if any mismatches found
-	return report.summary.failed > 0 ? 1 : 0;
+	const hasIntegrityIssues =
+		options.checkIntegrity &&
+		(!report.integrity?.lockFound ||
+			(report.integrity.summary.modified ?? 0) > 0 ||
+			(report.integrity.summary.missing ?? 0) > 0 ||
+			(report.integrity.summary.new ?? 0) > 0);
+
+	// Exit code: 1 if any mismatches or integrity issues found
+	return report.summary.failed > 0 || hasIntegrityIssues ? 1 : 0;
 }

--- a/packages/cli/src/fingerprint/index.test.ts
+++ b/packages/cli/src/fingerprint/index.test.ts
@@ -144,4 +144,32 @@ describe("runFingerprint", () => {
 		const result = await runFingerprint(["."]);
 		expect(result.entries[0].version).toBe("19.1.0");
 	});
+
+	it("propagates deprecated status and message to fingerprint entries", async () => {
+		const raw =
+			"---\nname: old-skill\nversion: 1.0.0\ndeprecated: true\ndeprecatedMessage: Use new-skill instead.\n---\n# Content";
+		mockDiscover.mockResolvedValue(["/skills/old-skill/SKILL.md"]);
+		mockRead.mockResolvedValue({
+			path: "/skills/old-skill/SKILL.md",
+			frontmatter: {
+				name: "old-skill",
+				version: "1.0.0",
+				deprecated: true,
+				deprecatedMessage: "Use new-skill instead.",
+			},
+			content: "# Content",
+			raw,
+			status: "deprecated",
+			deprecatedMessage: "Use new-skill instead.",
+		});
+
+		const result = await runFingerprint(["."]);
+
+		expect(result.entries[0]).toEqual(
+			expect.objectContaining({
+				status: "deprecated",
+				deprecatedMessage: "Use new-skill instead.",
+			})
+		);
+	});
 });

--- a/packages/cli/src/fingerprint/index.ts
+++ b/packages/cli/src/fingerprint/index.ts
@@ -116,6 +116,10 @@ export async function runFingerprint(
 			watermark: watermarkStr,
 			tokenCount,
 			path: filePath,
+			...(skillFile.status ? { status: skillFile.status } : {}),
+			...(skillFile.deprecatedMessage
+				? { deprecatedMessage: skillFile.deprecatedMessage }
+				: {}),
 		});
 	}
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -96,6 +96,7 @@ program
 	)
 	.option("--include-registry-audits", "fetch Snyk/Socket/Gen results from skills.sh")
 	.option("--ignore <path>", "path to .skills-checkignore file")
+	.option("--check-revocations <path>", "path to .skill-revocations.json file")
 	.option("--verbose", "show progress and scan details")
 	.option("--quiet", "suppress output, exit code only")
 	.option(
@@ -209,6 +210,7 @@ program
 	.option("-o, --output <path>", "write report to file")
 	.option("--provider <name>", "LLM provider: anthropic, openai, google")
 	.option("--model <id>", "specific model ID")
+	.option("--check-integrity", "compare current skill fingerprints against skills-lock.json")
 	.option("--skip-llm", "disable LLM-assisted analysis")
 	.option("--verbose", "show progress and details")
 	.option("--quiet", "suppress output, exit code only")
@@ -236,6 +238,7 @@ policyCmd
 	.option("-f, --format <type>", "output format: terminal, json, markdown, or sarif", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--fail-on <severity>", "exit code 1 threshold: blocked, violation, warning", "blocked")
+	.option("--show-exemptions", "show exempted findings in terminal and markdown output")
 	.option("--verbose", "show progress and details")
 	.option("--quiet", "suppress output, exit code only")
 	.action(async (dir, options) => {
@@ -346,6 +349,8 @@ program
 	.option("-f, --format <type>", "output format: terminal or json", "terminal")
 	.option("-o, --output <path>", "write report to file")
 	.option("--max-tokens <n>", "budget threshold for token count")
+	.option("--frozen-lockfile", "fail if skills-lock.json is missing or would change")
+	.option("--check-revocations <path>", "path to .skill-revocations.json file")
 	.option("--skip-audit", "skip audit check")
 	.option("--skip-lint", "skip lint check")
 	.option("--skip-budget", "skip budget check")

--- a/packages/cli/src/isolation/providers/apple.ts
+++ b/packages/cli/src/isolation/providers/apple.ts
@@ -25,7 +25,6 @@ export class AppleContainerProvider implements IsolationProvider {
 	}
 
 	async execute(options: IsolationExecuteOptions): Promise<IsolationResult> {
-		const fullCommand = `npx skills-check ${options.command}`;
 		const args = [
 			"run",
 			"--name",
@@ -36,6 +35,11 @@ export class AppleContainerProvider implements IsolationProvider {
 
 		if (options.workDir) {
 			args.push("--mount", `type=bind,source=${options.workDir},target=/work`);
+		}
+
+		// Mount local build read-only if provided
+		if (options.localBuild) {
+			args.push("--mount", `type=bind,source=${options.localBuild},target=/app,readonly`);
 		}
 
 		if (!options.networkAccess) {
@@ -49,7 +53,14 @@ export class AppleContainerProvider implements IsolationProvider {
 			}
 		}
 
-		args.push("--", "sh", "-c", `cd /skills && ${fullCommand}`);
+		if (options.argv && options.localBuild) {
+			// Preferred: structured argv with local build — no shell, no npm install
+			args.push("--", "node", "/app/dist/index.js", ...options.argv);
+		} else {
+			// Legacy: shell-based execution
+			const fullCommand = `npx skills-check ${options.command}`;
+			args.push("--", "sh", "-c", `cd /skills && ${fullCommand}`);
+		}
 
 		const result = await new Promise<{ exitCode: number; stdout: string; stderr: string }>(
 			(resolve) => {

--- a/packages/cli/src/isolation/providers/oci.ts
+++ b/packages/cli/src/isolation/providers/oci.ts
@@ -114,7 +114,6 @@ export class OCIProvider implements IsolationProvider {
 	}
 
 	async execute(options: IsolationExecuteOptions): Promise<IsolationResult> {
-		const escapedCommand = shellEscape(options.command);
 		const args = ["run", "--rm"];
 
 		// Mount skills directory read-only
@@ -123,6 +122,11 @@ export class OCIProvider implements IsolationProvider {
 		// Mount writable work directory if provided
 		if (options.workDir) {
 			args.push("-v", `${options.workDir}:/work`);
+		}
+
+		// Mount local build read-only if provided
+		if (options.localBuild) {
+			args.push("-v", `${options.localBuild}:/app:ro`);
 		}
 
 		// Network policy
@@ -137,13 +141,30 @@ export class OCIProvider implements IsolationProvider {
 			}
 		}
 
-		// Use a slim Node 22 image
-		args.push("node:22-alpine");
-		args.push(
-			"sh",
-			"-c",
-			`cd /skills && npm install -g skills-check && npx skills-check ${escapedCommand}`
-		);
+		if (options.argv && options.localBuild) {
+			// Preferred path: use structured argv with local build (no shell, no npm install)
+			args.push("--entrypoint", "node");
+			args.push("node:22-alpine");
+			args.push("/app/dist/index.js", ...options.argv);
+		} else if (options.argv) {
+			// Structured argv without local build: still need npm install, but use argv for command
+			const escapedCommand = shellEscape(options.argv.join(" "));
+			args.push("node:22-alpine");
+			args.push(
+				"sh",
+				"-c",
+				`cd /skills && npm install -g skills-check && npx skills-check ${escapedCommand}`
+			);
+		} else {
+			// Legacy path: use command string
+			const escapedCommand = shellEscape(options.command);
+			args.push("node:22-alpine");
+			args.push(
+				"sh",
+				"-c",
+				`cd /skills && npm install -g skills-check && npx skills-check ${escapedCommand}`
+			);
+		}
 
 		const result = await new Promise<{ exitCode: number; stdout: string; stderr: string }>(
 			(resolve) => {

--- a/packages/cli/src/isolation/providers/vercel.ts
+++ b/packages/cli/src/isolation/providers/vercel.ts
@@ -34,8 +34,6 @@ export class VercelSandboxProvider implements IsolationProvider {
 	}
 
 	async execute(options: IsolationExecuteOptions): Promise<IsolationResult> {
-		const fullCommand = `npx skills-check ${options.command}`;
-
 		// Build env flags for the sandbox
 		const envFlags: string[] = [];
 		if (options.env) {
@@ -45,6 +43,16 @@ export class VercelSandboxProvider implements IsolationProvider {
 		}
 
 		// Use Vercel's sandbox execution API via the CLI
+		let execArgs: string[];
+		if (options.argv && options.localBuild) {
+			// Preferred: structured argv with local build — no shell
+			execArgs = ["node", "/app/dist/index.js", ...options.argv];
+		} else {
+			// Legacy: shell-based execution
+			const fullCommand = `npx skills-check ${options.command}`;
+			execArgs = ["sh", "-c", fullCommand];
+		}
+
 		const args = [
 			"sandbox",
 			"exec",
@@ -52,9 +60,7 @@ export class VercelSandboxProvider implements IsolationProvider {
 			"--timeout",
 			String(options.timeout * 1000),
 			"--",
-			"sh",
-			"-c",
-			fullCommand,
+			...execArgs,
 		];
 
 		const result = await new Promise<{ exitCode: number; stdout: string; stderr: string }>(

--- a/packages/cli/src/isolation/types.ts
+++ b/packages/cli/src/isolation/types.ts
@@ -32,10 +32,14 @@ export const OCI_PROVIDER_NAMES = new Set<IsolationProviderName>([
 ]);
 
 export interface IsolationExecuteOptions {
+	/** Structured argument array (preferred over command string) */
+	argv?: string[];
 	/** The full skills-check CLI command (e.g. "audit ./skills --format json") */
 	command: string;
 	/** Environment variables to forward (API keys, etc.) */
 	env?: Record<string, string>;
+	/** Path to local skills-check build to mount into container */
+	localBuild?: string;
 	/** Whether the command needs outbound network access */
 	networkAccess: boolean;
 	/** Directory containing skill files — mounted read-only into the container */

--- a/packages/cli/src/lint/index.ts
+++ b/packages/cli/src/lint/index.ts
@@ -5,6 +5,7 @@ import { discoverSkillFiles } from "../shared/discovery.js";
 import { readSkillFile, writeSkillFile } from "../skill-io.js";
 import { autofix } from "./autofix.js";
 import { checkConditional } from "./rules/conditional.js";
+import { checkDeprecation } from "./rules/deprecation.js";
 import { checkFormats } from "./rules/format.js";
 import { checkPublishReady } from "./rules/publish.js";
 import { checkRecommended } from "./rules/recommended.js";
@@ -83,6 +84,7 @@ export async function runLint(paths: string[], options: LintOptions = {}): Promi
 			...checkRequired(skillFile),
 			...checkPublishReady(skillFile),
 			...checkConditional(skillFile),
+			...checkDeprecation(skillFile),
 			...checkRecommended(skillFile),
 			...checkFormats(skillFile),
 		];

--- a/packages/cli/src/lint/rules/deprecation.test.ts
+++ b/packages/cli/src/lint/rules/deprecation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { SkillFile } from "../../skill-io.js";
+import { checkDeprecation } from "./deprecation.js";
+
+function makeFile(overrides: Partial<SkillFile> = {}): SkillFile {
+	return {
+		path: "test/SKILL.md",
+		frontmatter: {},
+		content: "Some content here.",
+		raw: "---\n---\nSome content here.",
+		...overrides,
+	};
+}
+
+describe("checkDeprecation", () => {
+	it("returns no findings for active skills", () => {
+		expect(checkDeprecation(makeFile())).toEqual([]);
+	});
+
+	it("emits a warning for deprecated skills", () => {
+		expect(
+			checkDeprecation(
+				makeFile({
+					status: "deprecated",
+					deprecatedMessage: "Use new-skill instead.",
+				})
+			)
+		).toEqual([
+			{
+				file: "test/SKILL.md",
+				field: "deprecated",
+				level: "warning",
+				message: "Skill is deprecated: Use new-skill instead.",
+				fixable: false,
+			},
+		]);
+	});
+});

--- a/packages/cli/src/lint/rules/deprecation.ts
+++ b/packages/cli/src/lint/rules/deprecation.ts
@@ -1,0 +1,20 @@
+import type { SkillFile } from "../../skill-io.js";
+import type { LintFinding } from "../types.js";
+
+export function checkDeprecation(file: SkillFile): LintFinding[] {
+	if (file.status !== "deprecated") {
+		return [];
+	}
+
+	return [
+		{
+			file: file.path,
+			field: "deprecated",
+			level: "warning",
+			message: file.deprecatedMessage
+				? `Skill is deprecated: ${file.deprecatedMessage}`
+				: "Skill is deprecated",
+			fixable: false,
+		},
+	];
+}

--- a/packages/cli/src/lockfile/index.test.ts
+++ b/packages/cli/src/lockfile/index.test.ts
@@ -1,0 +1,423 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FingerprintEntry, FingerprintRegistry, SkillsLockFile } from "@skills-check/schema";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	diffLockFiles,
+	LOCK_FILE_NAME,
+	migrateLockFileV1,
+	readLockFile,
+	synchronizeLockFile,
+	updateLockEntry,
+	verifyIntegrity,
+	writeLockFile,
+} from "./index.js";
+
+const TEST_NOW = new Date("2026-04-18T12:00:00.000Z");
+
+function makeFingerprintEntry(overrides: Partial<FingerprintEntry> = {}): FingerprintEntry {
+	return {
+		skillId: "react-patterns",
+		version: "1.2.3",
+		source: "skills/react-patterns/SKILL.md",
+		contentHash: "content-hash",
+		frontmatterHash: "frontmatter-hash",
+		prefixHash: "prefix-hash",
+		watermark: "skill:react-patterns/1.2.3",
+		tokenCount: 321,
+		status: "active",
+		...overrides,
+	};
+}
+
+function makeLockFile(overrides: Partial<SkillsLockFile> = {}): SkillsLockFile {
+	return {
+		lockfileVersion: 2,
+		generatedBy: "skills-check@1.3.0",
+		generatedAt: "2026-04-17T00:00:00.000Z",
+		skills: {
+			"react-patterns": {
+				name: "react-patterns",
+				source: "skills/react-patterns/SKILL.md",
+				contentHash: "content-hash",
+				frontmatterHash: "frontmatter-hash",
+				prefixHash: "prefix-hash",
+				watermark: "skill:react-patterns/1.2.3",
+				tokenCount: 321,
+				resolvedAt: "2026-04-17T00:00:00.000Z",
+				version: "1.2.3",
+				status: "active",
+			},
+		},
+		...overrides,
+	};
+}
+
+describe("lockfile module", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(TEST_NOW);
+		tempDir = await mkdtemp(join(tmpdir(), "skills-check-lockfile-"));
+	});
+
+	afterEach(async () => {
+		vi.useRealTimers();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns null when lock file is missing", () => {
+		expect(readLockFile(tempDir)).toBeNull();
+	});
+
+	it("writes and reads v2 lock files", () => {
+		const lock = makeLockFile({
+			skills: {
+				zeta: {
+					name: "zeta",
+					source: "skills/zeta/SKILL.md",
+					contentHash: "zeta-content",
+					frontmatterHash: "zeta-frontmatter",
+					prefixHash: "zeta-prefix",
+					resolvedAt: TEST_NOW.toISOString(),
+				},
+				alpha: {
+					name: "alpha",
+					source: "skills/alpha/SKILL.md",
+					contentHash: "alpha-content",
+					frontmatterHash: "alpha-frontmatter",
+					prefixHash: "alpha-prefix",
+					resolvedAt: TEST_NOW.toISOString(),
+				},
+			},
+		});
+
+		writeLockFile(tempDir, lock);
+		const parsed = readLockFile(tempDir);
+
+		expect(parsed).not.toBeNull();
+		expect(Object.keys(parsed?.skills ?? {})).toEqual(["alpha", "zeta"]);
+		expect(parsed?.generatedAt).toBe(lock.generatedAt);
+	});
+
+	it("throws for invalid JSON", async () => {
+		await import("node:fs/promises").then(({ writeFile }) =>
+			writeFile(join(tempDir, LOCK_FILE_NAME), "{not-json", "utf-8")
+		);
+
+		expect(() => readLockFile(tempDir)).toThrow(/Invalid JSON/);
+	});
+
+	it("auto-migrates legacy v1 files on read", async () => {
+		await import("node:fs/promises").then(({ writeFile }) =>
+			writeFile(
+				join(tempDir, LOCK_FILE_NAME),
+				JSON.stringify(
+					{
+						version: 1,
+						skills: {
+							beads: {
+								source: "steveyegge/beads",
+								sourceType: "github",
+								computedHash: "legacy-hash",
+							},
+						},
+					},
+					null,
+					2
+				),
+				"utf-8"
+			)
+		);
+
+		const parsed = readLockFile(tempDir);
+
+		expect(parsed).toEqual(
+			expect.objectContaining({
+				lockfileVersion: 2,
+				skills: {
+					beads: expect.objectContaining({
+						contentHash: "legacy-hash",
+						frontmatterHash: "legacy-hash",
+						prefixHash: "legacy-hash",
+						source: "steveyegge/beads",
+					}),
+				},
+			})
+		);
+	});
+
+	it("updates a lock entry from a fingerprint entry", () => {
+		const nextLock = updateLockEntry(makeLockFile({ skills: {} }), makeFingerprintEntry());
+
+		expect(nextLock.generatedAt).toBe(TEST_NOW.toISOString());
+		expect(nextLock.skills["react-patterns"]).toEqual(
+			expect.objectContaining({
+				name: "react-patterns",
+				source: "skills/react-patterns/SKILL.md",
+				contentHash: "content-hash",
+				frontmatterHash: "frontmatter-hash",
+				prefixHash: "prefix-hash",
+				resolvedAt: TEST_NOW.toISOString(),
+			})
+		);
+	});
+
+	it("preserves resolvedAt when the entry is unchanged", () => {
+		const nextLock = updateLockEntry(makeLockFile(), makeFingerprintEntry());
+
+		expect(nextLock.skills["react-patterns"].resolvedAt).toBe("2026-04-17T00:00:00.000Z");
+	});
+
+	it("refreshes resolvedAt when the entry changes", () => {
+		const nextLock = updateLockEntry(
+			makeLockFile(),
+			makeFingerprintEntry({ contentHash: "changed-content-hash" })
+		);
+
+		expect(nextLock.skills["react-patterns"].resolvedAt).toBe(TEST_NOW.toISOString());
+		expect(nextLock.skills["react-patterns"].contentHash).toBe("changed-content-hash");
+	});
+
+	it("throws when required fingerprint hashes are missing", () => {
+		expect(() =>
+			updateLockEntry(
+				makeLockFile({ skills: {} }),
+				makeFingerprintEntry({ contentHash: undefined })
+			)
+		).toThrow(/missing one or more required hashes/);
+	});
+
+	it("synchronizes the lock file with current fingerprints", () => {
+		const registry: FingerprintRegistry = {
+			version: 1,
+			generatedAt: TEST_NOW.toISOString(),
+			entries: [
+				makeFingerprintEntry({ skillId: "alpha", source: "skills/alpha/SKILL.md" }),
+				makeFingerprintEntry({
+					skillId: "beta",
+					source: "skills/beta/SKILL.md",
+					contentHash: "beta-content",
+					frontmatterHash: "beta-frontmatter",
+					prefixHash: "beta-prefix",
+					watermark: undefined,
+				}),
+			],
+		};
+
+		const nextLock = synchronizeLockFile(
+			makeLockFile({
+				skills: {
+					"react-patterns": makeLockFile().skills["react-patterns"],
+					alpha: {
+						name: "alpha",
+						source: "skills/alpha/SKILL.md",
+						contentHash: "content-hash",
+						frontmatterHash: "frontmatter-hash",
+						prefixHash: "prefix-hash",
+						resolvedAt: "2026-04-10T00:00:00.000Z",
+					},
+				},
+			}),
+			registry
+		);
+
+		expect(Object.keys(nextLock.skills)).toEqual(["alpha", "beta"]);
+		expect(nextLock.generatedAt).toBe(TEST_NOW.toISOString());
+		expect(nextLock.skills.alpha.resolvedAt).toBe(TEST_NOW.toISOString());
+	});
+
+	it("reports added removed changed and unchanged entries", () => {
+		const prev = makeLockFile({
+			skills: {
+				alpha: {
+					name: "alpha",
+					source: "skills/alpha/SKILL.md",
+					contentHash: "same-content",
+					frontmatterHash: "same-frontmatter",
+					prefixHash: "same-prefix",
+					resolvedAt: "2026-04-10T00:00:00.000Z",
+				},
+				beta: {
+					name: "beta",
+					source: "skills/beta/SKILL.md",
+					contentHash: "old-content",
+					frontmatterHash: "old-frontmatter",
+					prefixHash: "old-prefix",
+					resolvedAt: "2026-04-10T00:00:00.000Z",
+				},
+				gamma: {
+					name: "gamma",
+					source: "skills/gamma/SKILL.md",
+					contentHash: "gone-content",
+					frontmatterHash: "gone-frontmatter",
+					prefixHash: "gone-prefix",
+					resolvedAt: "2026-04-10T00:00:00.000Z",
+				},
+			},
+		});
+
+		const next = makeLockFile({
+			skills: {
+				alpha: prev.skills.alpha,
+				beta: {
+					...prev.skills.beta,
+					contentHash: "new-content",
+				},
+				delta: {
+					name: "delta",
+					source: "skills/delta/SKILL.md",
+					contentHash: "delta-content",
+					frontmatterHash: "delta-frontmatter",
+					prefixHash: "delta-prefix",
+					resolvedAt: TEST_NOW.toISOString(),
+				},
+			},
+		});
+
+		const diff = diffLockFiles(prev, next);
+
+		expect(diff.added).toEqual(["delta"]);
+		expect(diff.removed).toEqual(["gamma"]);
+		expect(diff.unchanged).toEqual(["alpha"]);
+		expect(diff.changed).toEqual([
+			{
+				name: "beta",
+				field: "contentHash",
+				from: "old-content",
+				to: "new-content",
+			},
+		]);
+	});
+
+	it("reports ok status when lock hashes match current fingerprints", () => {
+		const registry: FingerprintRegistry = {
+			version: 1,
+			generatedAt: TEST_NOW.toISOString(),
+			entries: [makeFingerprintEntry()],
+		};
+
+		expect(verifyIntegrity(makeLockFile(), registry)).toEqual([
+			{
+				skill: "react-patterns",
+				status: "ok",
+			},
+		]);
+	});
+
+	it("reports modified status with the changed content hash field", () => {
+		const registry: FingerprintRegistry = {
+			version: 1,
+			generatedAt: TEST_NOW.toISOString(),
+			entries: [makeFingerprintEntry({ contentHash: "changed-content" })],
+		};
+
+		expect(verifyIntegrity(makeLockFile(), registry)).toEqual([
+			{
+				skill: "react-patterns",
+				status: "modified",
+				field: "contentHash",
+				expected: "content-hash",
+				actual: "changed-content",
+			},
+		]);
+	});
+
+	it("reports modified status with the changed frontmatter hash field", () => {
+		const registry: FingerprintRegistry = {
+			version: 1,
+			generatedAt: TEST_NOW.toISOString(),
+			entries: [makeFingerprintEntry({ frontmatterHash: "changed-frontmatter" })],
+		};
+
+		expect(verifyIntegrity(makeLockFile(), registry)).toEqual([
+			{
+				skill: "react-patterns",
+				status: "modified",
+				field: "frontmatterHash",
+				expected: "frontmatter-hash",
+				actual: "changed-frontmatter",
+			},
+		]);
+	});
+
+	it("reports modified status with the changed prefix hash field", () => {
+		const registry: FingerprintRegistry = {
+			version: 1,
+			generatedAt: TEST_NOW.toISOString(),
+			entries: [makeFingerprintEntry({ prefixHash: "changed-prefix" })],
+		};
+
+		expect(verifyIntegrity(makeLockFile(), registry)).toEqual([
+			{
+				skill: "react-patterns",
+				status: "modified",
+				field: "prefixHash",
+				expected: "prefix-hash",
+				actual: "changed-prefix",
+			},
+		]);
+	});
+
+	it("reports missing status when a locked skill is absent on disk", () => {
+		const registry: FingerprintRegistry = {
+			version: 1,
+			generatedAt: TEST_NOW.toISOString(),
+			entries: [],
+		};
+
+		expect(verifyIntegrity(makeLockFile(), registry)).toEqual([
+			{
+				skill: "react-patterns",
+				status: "missing",
+			},
+		]);
+	});
+
+	it("reports new status when a fingerprinted skill is not in the lock file", () => {
+		const registry: FingerprintRegistry = {
+			version: 1,
+			generatedAt: TEST_NOW.toISOString(),
+			entries: [makeFingerprintEntry({ skillId: "new-skill", source: "skills/new-skill/SKILL.md" })],
+		};
+
+		expect(verifyIntegrity(makeLockFile({ skills: {} }), registry)).toEqual([
+			{
+				skill: "new-skill",
+				status: "new",
+			},
+		]);
+	});
+
+	it("migrates the current legacy stub format", () => {
+		const migrated = migrateLockFileV1({
+			version: 1,
+			skills: {
+				beads: {
+					source: "steveyegge/beads",
+					sourceType: "github",
+					computedHash: "legacy-hash",
+				},
+			},
+		});
+
+		expect(migrated).toEqual(
+			expect.objectContaining({
+				lockfileVersion: 2,
+				generatedAt: TEST_NOW.toISOString(),
+				skills: {
+					beads: {
+						name: "beads",
+						source: "steveyegge/beads",
+						contentHash: "legacy-hash",
+						frontmatterHash: "legacy-hash",
+						prefixHash: "legacy-hash",
+						resolvedAt: TEST_NOW.toISOString(),
+					},
+				},
+			})
+		);
+	});
+});

--- a/packages/cli/src/lockfile/index.ts
+++ b/packages/cli/src/lockfile/index.ts
@@ -1,0 +1,447 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import type {
+	FingerprintEntry,
+	FingerprintRegistry,
+	SkillsLockFile,
+	SkillsLockFileEntry,
+} from "@skills-check/schema";
+import { migrateLockFileV1 } from "./migrate.js";
+
+const LOCK_FILE_NAME = "skills-lock.json";
+const require = createRequire(import.meta.url);
+const { version } = require("../../package.json") as { version: string };
+
+const ENTRY_DIFF_FIELDS = [
+	"source",
+	"contentHash",
+	"frontmatterHash",
+	"prefixHash",
+	"watermark",
+	"tokenCount",
+	"version",
+	"status",
+	"deprecatedMessage",
+	"deprecatedSunsetDate",
+] as const;
+
+const INTEGRITY_HASH_FIELDS = ["contentHash", "frontmatterHash", "prefixHash"] as const;
+
+type DiffableEntryField = (typeof ENTRY_DIFF_FIELDS)[number];
+type IntegrityHashField = (typeof INTEGRITY_HASH_FIELDS)[number];
+type LockStatus = SkillsLockFileEntry["status"];
+
+export interface LockFileDiff {
+	added: string[];
+	removed: string[];
+	changed: Array<{
+		name: string;
+		field: string;
+		from: string;
+		to: string;
+	}>;
+	unchanged: string[];
+}
+
+export interface IntegrityResult {
+	actual?: string;
+	expected?: string;
+	field?: IntegrityHashField;
+	skill: string;
+	status: "ok" | "modified" | "missing" | "new";
+}
+
+function getGeneratedBy(): string {
+	return `skills-check@${version}`;
+}
+
+function getLockFilePath(dir: string): string {
+	return join(dir, LOCK_FILE_NAME);
+}
+
+function stringifyFieldValue(value: string | number | undefined): string {
+	return value === undefined ? "<unset>" : String(value);
+}
+
+function getRecord(value: unknown, message: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(message);
+	}
+
+	return value as Record<string, unknown>;
+}
+
+function getOptionalString(value: unknown, fieldName: string): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	if (typeof value !== "string") {
+		throw new Error(`Lock file entry field "${fieldName}" must be a string.`);
+	}
+
+	return value;
+}
+
+function getOptionalNumber(value: unknown, fieldName: string): number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	if (typeof value !== "number") {
+		throw new Error(`Lock file entry field "${fieldName}" must be a number.`);
+	}
+
+	return value;
+}
+
+function getRequiredString(value: unknown, fieldName: string, entryName: string): string {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`Lock file entry "${entryName}" is missing required field: ${fieldName}`);
+	}
+
+	return value;
+}
+
+function getOptionalStatus(value: unknown, fieldName: string): LockStatus {
+	const status = getOptionalString(value, fieldName);
+	if (status === undefined) {
+		return undefined;
+	}
+
+	if (status === "active" || status === "deprecated" || status === "revoked") {
+		return status;
+	}
+
+	throw new Error(`Lock file entry field "${fieldName}" has invalid status: ${status}`);
+}
+
+function validateLockEntry(name: string, value: unknown): SkillsLockFileEntry {
+	const entry = getRecord(value, `Invalid lock file entry: ${name}`);
+	const requiredFields = {
+		name: getRequiredString(entry.name, "name", name),
+		source: getRequiredString(entry.source, "source", name),
+		contentHash: getRequiredString(entry.contentHash, "contentHash", name),
+		frontmatterHash: getRequiredString(entry.frontmatterHash, "frontmatterHash", name),
+		prefixHash: getRequiredString(entry.prefixHash, "prefixHash", name),
+		resolvedAt: getRequiredString(entry.resolvedAt, "resolvedAt", name),
+	};
+	const status = getOptionalStatus(entry.status, `${name}.status`);
+
+	return {
+		name: requiredFields.name,
+		source: requiredFields.source,
+		contentHash: requiredFields.contentHash,
+		frontmatterHash: requiredFields.frontmatterHash,
+		prefixHash: requiredFields.prefixHash,
+		resolvedAt: requiredFields.resolvedAt,
+		watermark: getOptionalString(entry.watermark, `${name}.watermark`),
+		tokenCount: getOptionalNumber(entry.tokenCount, `${name}.tokenCount`),
+		version: getOptionalString(entry.version, `${name}.version`),
+		status,
+		deprecatedMessage: getOptionalString(entry.deprecatedMessage, `${name}.deprecatedMessage`),
+		deprecatedSunsetDate: getOptionalString(
+			entry.deprecatedSunsetDate,
+			`${name}.deprecatedSunsetDate`
+		),
+	};
+}
+
+function validateLockFile(value: unknown): SkillsLockFile {
+	const root = getRecord(value, "Lock file is not a valid object.");
+
+	if (root.lockfileVersion !== 2) {
+		throw new Error(
+			`Unsupported lock file version: ${String(root.lockfileVersion)} (expected 2)`
+		);
+	}
+
+	if (typeof root.generatedBy !== "string" || root.generatedBy.length === 0) {
+		throw new Error('Lock file is missing "generatedBy" string.');
+	}
+
+	if (typeof root.generatedAt !== "string" || root.generatedAt.length === 0) {
+		throw new Error('Lock file is missing "generatedAt" string.');
+	}
+
+	const skills = getRecord(root.skills, 'Lock file is missing "skills" object.');
+
+	return {
+		lockfileVersion: 2,
+		generatedBy: root.generatedBy,
+		generatedAt: root.generatedAt,
+		skills: Object.fromEntries(
+			Object.entries(skills)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([name, entry]) => [name, validateLockEntry(name, entry)])
+		),
+	};
+}
+
+function sortLockSkills(skills: Record<string, SkillsLockFileEntry>): Record<string, SkillsLockFileEntry> {
+	return Object.fromEntries(
+		Object.entries(skills).sort(([left], [right]) => left.localeCompare(right))
+	);
+}
+
+function isEntryFieldUnchanged(
+	existing: SkillsLockFileEntry | undefined,
+	next: SkillsLockFileEntry
+): boolean {
+	if (!existing) {
+		return false;
+	}
+
+	return ENTRY_DIFF_FIELDS.every((field) => existing[field] === next[field]);
+}
+
+function toLockEntry(
+	entry: FingerprintEntry,
+	existing: SkillsLockFileEntry | undefined,
+	resolvedAt: string
+): SkillsLockFileEntry {
+	if (!entry.contentHash || !entry.frontmatterHash || !entry.prefixHash) {
+		throw new Error(`Fingerprint entry "${entry.skillId}" is missing one or more required hashes.`);
+	}
+
+	const nextEntry: SkillsLockFileEntry = {
+		name: entry.skillId,
+		source: entry.source ?? entry.path ?? entry.skillId,
+		contentHash: entry.contentHash,
+		frontmatterHash: entry.frontmatterHash,
+		prefixHash: entry.prefixHash,
+		watermark: entry.watermark,
+		tokenCount: entry.tokenCount,
+		resolvedAt,
+		version: entry.version,
+		status: entry.status,
+		deprecatedMessage: entry.deprecatedMessage,
+		deprecatedSunsetDate: existing?.deprecatedSunsetDate,
+	};
+
+	const existingResolvedAt = existing?.resolvedAt;
+	if (existingResolvedAt && isEntryFieldUnchanged(existing, nextEntry)) {
+		return {
+			...nextEntry,
+			resolvedAt: existingResolvedAt,
+		};
+	}
+
+	return nextEntry;
+}
+
+function createBaseLockFile(lock: SkillsLockFile | null, generatedAt?: string): SkillsLockFile {
+	return {
+		lockfileVersion: 2,
+		generatedBy: getGeneratedBy(),
+		generatedAt: generatedAt ?? lock?.generatedAt ?? new Date().toISOString(),
+		skills: sortLockSkills(lock?.skills ?? {}),
+	};
+}
+
+export function readLockFile(dir: string): SkillsLockFile | null {
+	const filePath = getLockFilePath(dir);
+
+	let raw: string;
+	try {
+		raw = readFileSync(filePath, "utf-8");
+	} catch (error) {
+		if (
+			typeof error === "object" &&
+			error !== null &&
+			"code" in error &&
+			error.code === "ENOENT"
+		) {
+			return null;
+		}
+
+		throw error;
+	}
+
+	let data: unknown;
+	try {
+		data = JSON.parse(raw);
+	} catch {
+		throw new Error(`Invalid JSON in lock file: ${filePath}`);
+	}
+
+	if (data && typeof data === "object" && !Array.isArray(data) && "lockfileVersion" in data) {
+		return validateLockFile(data);
+	}
+
+	return migrateLockFileV1(data);
+}
+
+export function writeLockFile(dir: string, lock: SkillsLockFile): void {
+	const filePath = getLockFilePath(dir);
+	const content = `${JSON.stringify(
+		{
+			...lock,
+			generatedBy: getGeneratedBy(),
+			skills: sortLockSkills(lock.skills),
+		},
+		null,
+		2
+	)}\n`;
+
+	writeFileSync(filePath, content, "utf-8");
+}
+
+export function updateLockEntry(lock: SkillsLockFile, entry: FingerprintEntry): SkillsLockFile {
+	const generatedAt = new Date().toISOString();
+	const nextLock = createBaseLockFile(lock, generatedAt);
+	const existing = lock.skills[entry.skillId];
+
+	return {
+		...nextLock,
+		skills: sortLockSkills({
+			...nextLock.skills,
+			[entry.skillId]: toLockEntry(entry, existing, generatedAt),
+		}),
+	};
+}
+
+export function synchronizeLockFile(
+	lock: SkillsLockFile | null,
+	registry: FingerprintRegistry
+): SkillsLockFile {
+	let nextLock = createBaseLockFile(lock, registry.generatedAt);
+	const currentSkillIds = new Set<string>();
+
+	for (const entry of registry.entries) {
+		currentSkillIds.add(entry.skillId);
+		nextLock = updateLockEntry(nextLock, entry);
+	}
+
+	return {
+		...nextLock,
+		generatedAt: registry.generatedAt,
+		skills: sortLockSkills(
+			Object.fromEntries(
+				Object.entries(nextLock.skills).filter(([name]) => currentSkillIds.has(name))
+			)
+		),
+	};
+}
+
+export function diffLockFiles(prev: SkillsLockFile, next: SkillsLockFile): LockFileDiff {
+	const prevNames = new Set(Object.keys(prev.skills));
+	const nextNames = new Set(Object.keys(next.skills));
+	const names = Array.from(new Set([...prevNames, ...nextNames])).sort((left, right) =>
+		left.localeCompare(right)
+	);
+
+	const diff: LockFileDiff = {
+		added: [],
+		removed: [],
+		changed: [],
+		unchanged: [],
+	};
+
+	for (const name of names) {
+		const previousEntry = prev.skills[name];
+		const nextEntry = next.skills[name];
+
+		if (!previousEntry && nextEntry) {
+			diff.added.push(name);
+			continue;
+		}
+
+		if (previousEntry && !nextEntry) {
+			diff.removed.push(name);
+			continue;
+		}
+
+		if (!previousEntry || !nextEntry) {
+			continue;
+		}
+
+		const entryChanges = ENTRY_DIFF_FIELDS.flatMap((field) => {
+			const previousValue = previousEntry[field as DiffableEntryField];
+			const nextValue = nextEntry[field as DiffableEntryField];
+
+			if (previousValue === nextValue) {
+				return [];
+			}
+
+			return [
+				{
+					name,
+					field,
+					from: stringifyFieldValue(previousValue),
+					to: stringifyFieldValue(nextValue),
+				},
+			];
+		});
+
+		if (entryChanges.length === 0) {
+			diff.unchanged.push(name);
+			continue;
+		}
+
+		diff.changed.push(...entryChanges);
+	}
+
+	return diff;
+}
+
+export function verifyIntegrity(
+	lock: SkillsLockFile,
+	currentFingerprints: FingerprintRegistry
+): IntegrityResult[] {
+	const currentBySkill = new Map(
+		currentFingerprints.entries.map((entry) => [entry.skillId, entry] as const)
+	);
+	const skillNames = Array.from(
+		new Set([...Object.keys(lock.skills), ...currentFingerprints.entries.map((entry) => entry.skillId)])
+	).sort((left, right) => left.localeCompare(right));
+
+	return skillNames.map((skill) => {
+		const lockedEntry = lock.skills[skill];
+		const currentEntry = currentBySkill.get(skill);
+
+		if (!lockedEntry && currentEntry) {
+			return {
+				skill,
+				status: "new",
+			};
+		}
+
+		if (lockedEntry && !currentEntry) {
+			return {
+				skill,
+				status: "missing",
+			};
+		}
+
+		if (!lockedEntry || !currentEntry) {
+			return {
+				skill,
+				status: "ok",
+			};
+		}
+
+		for (const field of INTEGRITY_HASH_FIELDS) {
+			const expected = lockedEntry[field];
+			const actual = currentEntry[field];
+
+			if (actual !== expected) {
+				return {
+					skill,
+					status: "modified",
+					field,
+					expected,
+					actual,
+				};
+			}
+		}
+
+		return {
+			skill,
+			status: "ok",
+		};
+	});
+}
+
+export { LOCK_FILE_NAME, migrateLockFileV1 };

--- a/packages/cli/src/lockfile/migrate.ts
+++ b/packages/cli/src/lockfile/migrate.ts
@@ -1,0 +1,66 @@
+import { createRequire } from "node:module";
+import type { SkillsLockFile } from "@skills-check/schema";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../../package.json") as { version: string };
+
+function getGeneratedBy(): string {
+	return `skills-check@${version}`;
+}
+
+function getRecord(value: unknown, message: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(message);
+	}
+
+	return value as Record<string, unknown>;
+}
+
+/**
+ * Migrate the legacy v1 stub lock file into the v2 schema.
+ */
+export function migrateLockFileV1(v1: unknown): SkillsLockFile {
+	const root = getRecord(v1, "Lock file is not a valid object.");
+
+	if (root.version !== 1) {
+		throw new Error(`Unsupported lock file version: ${String(root.version)} (expected 1)`);
+	}
+
+	const skills = getRecord(root.skills, 'Lock file is missing "skills" object.');
+	const resolvedAt = new Date().toISOString();
+
+	return {
+		lockfileVersion: 2,
+		generatedBy: getGeneratedBy(),
+		generatedAt: resolvedAt,
+		skills: Object.fromEntries(
+			Object.entries(skills)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([name, rawEntry]) => {
+					const entry = getRecord(rawEntry, `Invalid legacy lock file entry: ${name}`);
+					const source = entry.source;
+					const computedHash = entry.computedHash;
+
+					if (typeof source !== "string" || source.length === 0) {
+						throw new Error(`Legacy lock file entry "${name}" is missing source.`);
+					}
+
+					if (typeof computedHash !== "string" || computedHash.length === 0) {
+						throw new Error(`Legacy lock file entry "${name}" is missing computedHash.`);
+					}
+
+					return [
+						name,
+						{
+							name,
+							source,
+							contentHash: computedHash,
+							frontmatterHash: computedHash,
+							prefixHash: computedHash,
+							resolvedAt,
+						},
+					];
+				})
+		),
+	};
+}

--- a/packages/cli/src/policy/index.test.ts
+++ b/packages/cli/src/policy/index.test.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PolicyExemption } from "@skills-check/schema";
+import { applyExemptions, runPolicyCheck } from "./index.js";
+import type { PolicyFinding, SkillPolicy } from "./types.js";
+
+function createViolation(overrides?: Partial<PolicyFinding>): PolicyFinding {
+	return {
+		file: "skills/example/SKILL.md",
+		message: "Violation",
+		rule: "banned",
+		severity: "blocked",
+		skill: "example-skill",
+		...overrides,
+	};
+}
+
+function createExemption(overrides?: Partial<PolicyExemption>): PolicyExemption {
+	return {
+		skill: "example-skill",
+		rule: "banned",
+		reason: "Approved exception",
+		...overrides,
+	};
+}
+
+describe("applyExemptions", () => {
+	it("exempts a matching violation", () => {
+		const result = applyExemptions([createViolation()], [createExemption()], new Date("2026-01-01"));
+
+		expect(result.active).toEqual([]);
+		expect(result.exempted).toHaveLength(1);
+		expect(result.exempted[0]?.exemption.reason).toBe("Approved exception");
+	});
+
+	it("keeps non-matching violations active", () => {
+		const result = applyExemptions(
+			[createViolation()],
+			[createExemption({ skill: "other-skill" })],
+			new Date("2026-01-01")
+		);
+
+		expect(result.active).toHaveLength(1);
+		expect(result.exempted).toEqual([]);
+	});
+
+	it("keeps expired exemptions active and annotates the warning", () => {
+		const result = applyExemptions(
+			[createViolation()],
+			[createExemption({ expires: "2025-01-01" })],
+			new Date("2026-01-01")
+		);
+
+		expect(result.active).toHaveLength(1);
+		expect(result.active[0]?.detail).toContain("Exemption expired on 2025-01-01");
+		expect(result.exempted).toEqual([]);
+	});
+
+	it("supports glob matching for skill names", () => {
+		const result = applyExemptions(
+			[createViolation({ skill: "internal/deploy" })],
+			[createExemption({ skill: "internal/*" })],
+			new Date("2026-01-01")
+		);
+
+		expect(result.active).toEqual([]);
+		expect(result.exempted).toHaveLength(1);
+	});
+
+	it("uses the first matching exemption when multiple exist", () => {
+		const result = applyExemptions(
+			[createViolation()],
+			[
+				createExemption({ reason: "First reason" }),
+				createExemption({ reason: "Second reason" }),
+			],
+			new Date("2026-01-01")
+		);
+
+		expect(result.exempted).toHaveLength(1);
+		expect(result.exempted[0]?.exemption.reason).toBe("First reason");
+	});
+});
+
+describe("runPolicyCheck exemptions integration", () => {
+	let tempDir: string;
+
+	afterEach(async () => {
+		if (tempDir) {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("filters exempted findings after validators run", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "policy-exemptions-"));
+		const skillDir = join(tempDir, "example-skill");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: example-skill
+source: third-party/skills
+---
+
+# Example Skill
+`,
+			"utf-8"
+		);
+
+		const policy: SkillPolicy = {
+			version: 1,
+			sources: {
+				allow: ["our-org/*"],
+			},
+			exemptions: [
+				{
+					skill: "example-skill",
+					rule: "sources.allow",
+					reason: "Temporary third-party exception",
+				},
+			],
+		};
+
+		const report = await runPolicyCheck([tempDir], policy, join(tempDir, ".skill-policy.yml"), {
+			showExemptions: true,
+		});
+
+		expect(report.findings).toEqual([]);
+		expect(report.summary).toEqual({ blocked: 0, violations: 0, warnings: 0 });
+		expect(report.exemptedViolations).toHaveLength(1);
+		expect(report.exemptedViolations?.[0]?.rule).toBe("sources.allow");
+		expect(report.showExemptions).toBe(true);
+	});
+});

--- a/packages/cli/src/policy/index.ts
+++ b/packages/cli/src/policy/index.ts
@@ -1,8 +1,16 @@
 import { stat } from "node:fs/promises";
+import { basename, dirname } from "node:path";
+import type { PolicyExemption } from "@skills-check/schema";
 import { discoverSkillFiles } from "../shared/discovery.js";
 import type { SkillFile } from "../skill-io.js";
 import { readSkillFile } from "../skill-io.js";
-import type { PolicyFinding, PolicyOptions, PolicyReport, SkillPolicy } from "./types.js";
+import type {
+	PolicyExemptedViolation,
+	PolicyFinding,
+	PolicyOptions,
+	PolicyReport,
+	SkillPolicy,
+} from "./types.js";
 import { checkAuditClean } from "./validators/audit-integration.js";
 import { checkBanned } from "./validators/banned.js";
 import { checkContent } from "./validators/content.js";
@@ -10,6 +18,108 @@ import { checkFreshness } from "./validators/freshness.js";
 import { checkMetadata } from "./validators/metadata.js";
 import { checkRequired } from "./validators/required.js";
 import { checkSources } from "./validators/sources.js";
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+}
+
+function matchesSkillPattern(skill: string, pattern: string): boolean {
+	const regexPattern = escapeRegex(
+		pattern
+			.replaceAll("**", "__DOUBLE_STAR__")
+			.replaceAll("*", "__SINGLE_STAR__")
+			.replaceAll("?", "__QUESTION_MARK__")
+	)
+		.replaceAll("__DOUBLE_STAR__", ".*")
+		.replaceAll("__SINGLE_STAR__", "[^/]*")
+		.replaceAll("__QUESTION_MARK__", "[^/]");
+
+	return new RegExp(`^${regexPattern}$`).test(skill);
+}
+
+function normalizeExpiryDate(expires: string): number | null {
+	if (/^\d{4}-\d{2}-\d{2}$/.test(expires)) {
+		return Date.parse(`${expires}T23:59:59.999Z`);
+	}
+
+	const parsed = Date.parse(expires);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getSkillName(file: SkillFile): string | undefined {
+	const frontmatterName = file.frontmatter.name;
+	if (typeof frontmatterName === "string" && frontmatterName.length > 0) {
+		return frontmatterName;
+	}
+
+	const directoryName = basename(dirname(file.path));
+	return directoryName.length > 0 ? directoryName : undefined;
+}
+
+function attachSkill(findings: PolicyFinding[], skill: string | undefined): PolicyFinding[] {
+	if (!skill) {
+		return findings;
+	}
+
+	return findings.map((finding) => ({
+		...finding,
+		skill,
+	}));
+}
+
+function withExpiredExemptionWarning(
+	finding: PolicyFinding,
+	exemption: PolicyExemption
+): PolicyFinding {
+	const warning = `Exemption expired on ${exemption.expires}: ${exemption.reason}`;
+	return {
+		...finding,
+		detail: finding.detail ? `${finding.detail}\n${warning}` : warning,
+	};
+}
+
+export function applyExemptions(
+	violations: PolicyFinding[],
+	exemptions: PolicyExemption[],
+	now = new Date()
+): { active: PolicyFinding[]; exempted: PolicyExemptedViolation[] } {
+	if (exemptions.length === 0) {
+		return { active: violations, exempted: [] };
+	}
+
+	const active: PolicyFinding[] = [];
+	const exempted: PolicyExemptedViolation[] = [];
+
+	for (const violation of violations) {
+		const matchingExemption = exemptions.find((exemption) => {
+			if (!violation.skill) {
+				return false;
+			}
+
+			return exemption.rule === violation.rule && matchesSkillPattern(violation.skill, exemption.skill);
+		});
+
+		if (!matchingExemption) {
+			active.push(violation);
+			continue;
+		}
+
+		if (matchingExemption.expires) {
+			const expiry = normalizeExpiryDate(matchingExemption.expires);
+			if (expiry !== null && expiry < now.getTime()) {
+				active.push(withExpiredExemptionWarning(violation, matchingExemption));
+				continue;
+			}
+		}
+
+		exempted.push({
+			...violation,
+			exemption: matchingExemption,
+		});
+	}
+
+	return { active, exempted };
+}
 
 /**
  * Run a policy check against discovered skill files.
@@ -58,18 +168,23 @@ export async function runPolicyCheck(
 
 	const allFindings: PolicyFinding[] = [];
 	const skillFiles: SkillFile[] = [];
+	const skillNameByPath = new Map<string, string>();
 
 	// Read and validate each skill file
 	for (const filePath of filesToCheck) {
 		const sf = await readSkillFile(filePath);
 		skillFiles.push(sf);
+		const skillName = getSkillName(sf);
+		if (skillName) {
+			skillNameByPath.set(sf.path, skillName);
+		}
 
 		// Run per-file validators
-		allFindings.push(...checkSources(sf, policy));
-		allFindings.push(...checkBanned(sf, policy));
-		allFindings.push(...checkMetadata(sf, policy));
-		allFindings.push(...checkContent(sf, policy));
-		allFindings.push(...checkFreshness(sf, policy));
+		allFindings.push(...attachSkill(checkSources(sf, policy), skillName));
+		allFindings.push(...attachSkill(checkBanned(sf, policy), skillName));
+		allFindings.push(...attachSkill(checkMetadata(sf, policy), skillName));
+		allFindings.push(...attachSkill(checkContent(sf, policy), skillName));
+		allFindings.push(...attachSkill(checkFreshness(sf, policy), skillName));
 	}
 
 	// Check required skills (across all discovered files, not just filtered)
@@ -91,6 +206,7 @@ export async function runPolicyCheck(
 				severity: "violation",
 				rule: "required",
 				message: `Required skill "${req.skill}" is not installed`,
+				skill: req.skill,
 			});
 		}
 	}
@@ -98,21 +214,31 @@ export async function runPolicyCheck(
 	// Audit integration (only if paths are provided and audit required)
 	if (policy.audit?.require_clean) {
 		const auditFindings = await checkAuditClean(paths, policy);
-		allFindings.push(...auditFindings);
+		allFindings.push(
+			...auditFindings.map((finding) => ({
+				...finding,
+				skill: skillNameByPath.get(finding.file),
+			}))
+		);
 	}
+
+	const { active, exempted } = applyExemptions(allFindings, policy.exemptions ?? []);
 
 	// Compute summary
 	const summary = {
-		blocked: allFindings.filter((f) => f.severity === "blocked").length,
-		violations: allFindings.filter((f) => f.severity === "violation").length,
-		warnings: allFindings.filter((f) => f.severity === "warning").length,
+		blocked: active.filter((f) => f.severity === "blocked").length,
+		violations: active.filter((f) => f.severity === "violation").length,
+		warnings: active.filter((f) => f.severity === "warning").length,
 	};
 
 	return {
+		exemptedViolations: exempted,
+		exemptions: policy.exemptions ?? [],
 		policyFile,
 		files: filesToCheck.length,
-		findings: allFindings,
+		findings: active,
 		required,
+		showExemptions: options.showExemptions,
 		summary,
 		generatedAt: new Date().toISOString(),
 	};

--- a/packages/cli/src/policy/parser.test.ts
+++ b/packages/cli/src/policy/parser.test.ts
@@ -46,6 +46,15 @@ freshness:
 audit:
   require_clean: true
   min_severity_to_block: high
+exemptions:
+  - skill: "legacy-deploy-skill"
+    rule: "banned"
+    reason: "Legacy migration in progress"
+    expires: "2026-12-31"
+    grantedBy: "jane@company.com"
+  - skill: "internal/*"
+    rule: "sources.allow"
+    reason: "Internal registry allowlist exception"
 `;
 		const policy = await parsePolicy(yaml);
 		expect(policy.version).toBe(1);
@@ -61,6 +70,40 @@ audit:
 		expect(policy.freshness?.max_version_drift).toBe("minor");
 		expect(policy.audit?.require_clean).toBe(true);
 		expect(policy.audit?.min_severity_to_block).toBe("high");
+		expect(policy.exemptions).toEqual([
+			{
+				skill: "legacy-deploy-skill",
+				rule: "banned",
+				reason: "Legacy migration in progress",
+				expires: "2026-12-31",
+				grantedBy: "jane@company.com",
+			},
+			{
+				skill: "internal/*",
+				rule: "sources.allow",
+				reason: "Internal registry allowlist exception",
+			},
+		]);
+	});
+
+	it("parses exemption glob and expired date values", async () => {
+		const policy = await parsePolicy(`
+version: 1
+exemptions:
+  - skill: "internal/*"
+    rule: "sources.allow"
+    reason: "Private registry"
+    expires: "2020-01-01"
+`);
+
+		expect(policy.exemptions).toEqual([
+			{
+				skill: "internal/*",
+				rule: "sources.allow",
+				reason: "Private registry",
+				expires: "2020-01-01",
+			},
+		]);
 	});
 
 	it("throws on empty content", async () => {
@@ -146,6 +189,33 @@ describe("validatePolicy", () => {
 			audit: { min_severity_to_block: "invalid" as "high" },
 		});
 		expect(errors.some((e) => e.includes("min_severity_to_block"))).toBe(true);
+	});
+
+	it("catches exemption entries with missing required fields", () => {
+		const errors = validatePolicy({
+			version: 1,
+			exemptions: [{ skill: "", rule: "", reason: "" }],
+		});
+
+		expect(errors).toContain('exemptions[0] must have a "skill" string field');
+		expect(errors).toContain('exemptions[0] must have a "rule" string field');
+		expect(errors).toContain('exemptions[0] must have a "reason" string field');
+	});
+
+	it("catches invalid exemption expiry values", () => {
+		const errors = validatePolicy({
+			version: 1,
+			exemptions: [
+				{
+					skill: "internal/*",
+					rule: "sources.allow",
+					reason: "Private registry",
+					expires: "not-a-date",
+				},
+			],
+		});
+
+		expect(errors).toContain("exemptions[0].expires must be a valid ISO 8601 date");
 	});
 });
 

--- a/packages/cli/src/policy/parser.ts
+++ b/packages/cli/src/policy/parser.ts
@@ -1,7 +1,53 @@
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import type { PolicyExemption } from "@skills-check/schema";
 import { isSafeRegex } from "../shared/safe-regex.js";
 import type { SkillPolicy } from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function normalizeExemption(value: unknown): PolicyExemption {
+	if (!isRecord(value)) {
+		return {
+			skill: "",
+			rule: "",
+			reason: "",
+		};
+	}
+
+	const expires =
+		typeof value.expires === "string"
+			? value.expires
+			: value.expires instanceof Date
+				? value.expires.toISOString()
+				: undefined;
+
+	return {
+		grantedBy: typeof value.grantedBy === "string" ? value.grantedBy : undefined,
+		expires,
+		reason: typeof value.reason === "string" ? value.reason : "",
+		rule: typeof value.rule === "string" ? value.rule : "",
+		skill: typeof value.skill === "string" ? value.skill : "",
+	};
+}
+
+function normalizePolicy(policy: Record<string, unknown>): SkillPolicy {
+	const exemptions = Array.isArray(policy.exemptions)
+		? policy.exemptions.map((exemption) => normalizeExemption(exemption))
+		: undefined;
+
+	return {
+		...policy,
+		exemptions,
+		version: policy.version as number,
+	} as SkillPolicy;
+}
+
+function isValidDateString(value: string): boolean {
+	return Number.isFinite(Date.parse(value));
+}
 
 /**
  * Dynamically import js-yaml (transitive dep via gray-matter).
@@ -40,7 +86,7 @@ export async function parsePolicy(content: string): Promise<SkillPolicy> {
 		throw new Error(`Unsupported policy version: ${policy.version}. Only version 1 is supported`);
 	}
 
-	return raw as SkillPolicy;
+	return normalizePolicy(policy);
 }
 
 /**
@@ -168,6 +214,39 @@ export function validatePolicy(policy: SkillPolicy): string[] {
 			typeof policy.freshness.max_age_days !== "number"
 		) {
 			errors.push("freshness.max_age_days must be a number");
+		}
+	}
+
+	// Validate exemptions
+	if (policy.exemptions !== undefined) {
+		if (!Array.isArray(policy.exemptions)) {
+			errors.push("exemptions must be an array");
+		} else {
+			for (let i = 0; i < policy.exemptions.length; i++) {
+				const exemption = policy.exemptions[i];
+				if (!exemption.skill || typeof exemption.skill !== "string") {
+					errors.push(`exemptions[${i}] must have a "skill" string field`);
+				}
+				if (!exemption.rule || typeof exemption.rule !== "string") {
+					errors.push(`exemptions[${i}] must have a "rule" string field`);
+				}
+				if (!exemption.reason || typeof exemption.reason !== "string") {
+					errors.push(`exemptions[${i}] must have a "reason" string field`);
+				}
+				if (exemption.expires !== undefined) {
+					if (typeof exemption.expires !== "string") {
+						errors.push(`exemptions[${i}].expires must be a string`);
+					} else if (!isValidDateString(exemption.expires)) {
+						errors.push(`exemptions[${i}].expires must be a valid ISO 8601 date`);
+					}
+				}
+				if (
+					exemption.grantedBy !== undefined &&
+					typeof exemption.grantedBy !== "string"
+				) {
+					errors.push(`exemptions[${i}].grantedBy must be a string`);
+				}
+			}
 		}
 	}
 

--- a/packages/cli/src/policy/reporters/__snapshots__/json.snapshots.test.ts.snap
+++ b/packages/cli/src/policy/reporters/__snapshots__/json.snapshots.test.ts.snap
@@ -1,0 +1,100 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`formatPolicyJson snapshots > renders clean output 1`] = `
+"{
+  "policyFile": ".skill-policy.yml",
+  "files": 2,
+  "findings": [],
+  "required": [
+    {
+      "skill": "security-review",
+      "satisfied": true
+    }
+  ],
+  "summary": {
+    "blocked": 0,
+    "violations": 0,
+    "warnings": 0
+  },
+  "generatedAt": "2026-04-18T12:00:00.000Z",
+  "exemptedViolations": [],
+  "exemptions": []
+}"
+`;
+
+exports[`formatPolicyJson snapshots > renders mixed severities 1`] = `
+"{
+  "policyFile": ".skill-policy.yml",
+  "files": 2,
+  "findings": [
+    {
+      "file": "skills/vendor/rogue/SKILL.md",
+      "severity": "blocked",
+      "rule": "sources.deny",
+      "message": "Source \\"evil/skills\\" is in the deny list"
+    },
+    {
+      "file": "skills/internal/deploy/SKILL.md",
+      "severity": "violation",
+      "rule": "content.deny_patterns",
+      "message": "Contains denied pattern: exec",
+      "detail": "Runtime shell execution is not allowed.",
+      "line": 14
+    },
+    {
+      "file": "skills/internal/legacy/SKILL.md",
+      "severity": "warning",
+      "rule": "freshness.max_age_days",
+      "message": "Last verified 142 days ago",
+      "detail": "Review the upstream changelog."
+    }
+  ],
+  "required": [
+    {
+      "skill": "incident-response",
+      "satisfied": false
+    }
+  ],
+  "summary": {
+    "blocked": 1,
+    "violations": 1,
+    "warnings": 1
+  },
+  "generatedAt": "2026-04-18T12:00:00.000Z",
+  "exemptedViolations": [],
+  "exemptions": []
+}"
+`;
+
+exports[`formatPolicyJson snapshots > renders multiple violations 1`] = `
+"{
+  "policyFile": ".skill-policy.yml",
+  "files": 2,
+  "findings": [
+    {
+      "file": "skills/internal/deploy/SKILL.md",
+      "severity": "violation",
+      "rule": "content.deny_patterns",
+      "message": "Contains denied pattern: exec",
+      "detail": "Runtime shell execution is not allowed.",
+      "line": 14
+    },
+    {
+      "file": "skills/internal/deploy/SKILL.md",
+      "severity": "violation",
+      "rule": "content.require_patterns",
+      "message": "Missing required pattern: rollback",
+      "detail": "Deployment skills must document rollback steps."
+    }
+  ],
+  "required": [],
+  "summary": {
+    "blocked": 0,
+    "violations": 2,
+    "warnings": 0
+  },
+  "generatedAt": "2026-04-18T12:00:00.000Z",
+  "exemptedViolations": [],
+  "exemptions": []
+}"
+`;

--- a/packages/cli/src/policy/reporters/__snapshots__/markdown.test.ts.snap
+++ b/packages/cli/src/policy/reporters/__snapshots__/markdown.test.ts.snap
@@ -1,0 +1,95 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`formatPolicyMarkdown > renders clean output snapshot 1`] = `
+"# Skills Check Policy Report
+
+Generated: 2026-04-18
+Policy: .skill-policy.yml
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Blocked | 0 |
+| Violations | 0 |
+| Warnings | 0 |
+| Exempted | 0 |
+| **Total** | **0** |
+
+Files checked: 2
+
+All skills comply with policy.
+"
+`;
+
+exports[`formatPolicyMarkdown > renders mixed severities snapshot 1`] = `
+"# Skills Check Policy Report
+
+Generated: 2026-04-18
+Policy: .skill-policy.yml
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Blocked | 1 |
+| Violations | 1 |
+| Warnings | 1 |
+| Exempted | 0 |
+| **Total** | **3** |
+
+Files checked: 2
+
+## Blocked (1)
+
+| File | Rule | Message |
+|------|------|---------|
+| skills/vendor/rogue/SKILL.md | sources.deny | Source "evil/skills" is in the deny list |
+
+## Violation (1)
+
+| File | Rule | Message |
+|------|------|---------|
+| skills/internal/deploy/SKILL.md (line 14) | content.deny_patterns | Contains denied pattern: exec |
+
+## Warning (1)
+
+| File | Rule | Message |
+|------|------|---------|
+| skills/internal/legacy/SKILL.md | freshness.max_age_days | Last verified 142 days ago |
+
+## Required Skills
+
+| Skill | Status |
+|-------|--------|
+| security-review | Installed |
+| incident-response | **MISSING** |
+"
+`;
+
+exports[`formatPolicyMarkdown > renders multiple violations snapshot 1`] = `
+"# Skills Check Policy Report
+
+Generated: 2026-04-18
+Policy: .skill-policy.yml
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Blocked | 0 |
+| Violations | 2 |
+| Warnings | 0 |
+| Exempted | 0 |
+| **Total** | **2** |
+
+Files checked: 2
+
+## Violation (2)
+
+| File | Rule | Message |
+|------|------|---------|
+| skills/internal/deploy/SKILL.md (line 14) | content.deny_patterns | Contains denied pattern: exec |
+| skills/internal/deploy/SKILL.md | content.require_patterns | Missing required pattern: rollback \\| recovery |
+"
+`;

--- a/packages/cli/src/policy/reporters/__snapshots__/sarif.test.ts.snap
+++ b/packages/cli/src/policy/reporters/__snapshots__/sarif.test.ts.snap
@@ -1,0 +1,239 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`formatPolicySarif > renders clean SARIF snapshot 1`] = `
+"{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "skills-check/policy",
+          "informationUri": "https://skillscheck.ai",
+          "rules": []
+        }
+      },
+      "results": [],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "endTimeUtc": "2026-04-18T12:00:00.000Z"
+        }
+      ]
+    }
+  ]
+}"
+`;
+
+exports[`formatPolicySarif > renders mixed severities with SARIF 2.1.0 level mapping 1`] = `
+"{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "skills-check/policy",
+          "informationUri": "https://skillscheck.ai",
+          "rules": [
+            {
+              "id": "skills-check/policy/sources.deny",
+              "shortDescription": {
+                "text": "sources.deny"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              }
+            },
+            {
+              "id": "skills-check/policy/content.deny_patterns",
+              "shortDescription": {
+                "text": "content.deny_patterns"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "skills-check/policy/freshness.max_age_days",
+              "shortDescription": {
+                "text": "freshness.max_age_days"
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "skills-check/policy/sources.deny",
+          "level": "error",
+          "message": {
+            "text": "Source \\"evil/skills\\" is in the deny list"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "skills/vendor/rogue/SKILL.md"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "properties": {
+            "severity": "blocked"
+          }
+        },
+        {
+          "ruleId": "skills-check/policy/content.deny_patterns",
+          "level": "warning",
+          "message": {
+            "text": "Contains denied pattern: exec"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "skills/internal/deploy/SKILL.md"
+                },
+                "region": {
+                  "startLine": 14
+                }
+              }
+            }
+          ],
+          "properties": {
+            "severity": "violation",
+            "detail": "Runtime shell execution is not allowed."
+          }
+        },
+        {
+          "ruleId": "skills-check/policy/freshness.max_age_days",
+          "level": "note",
+          "message": {
+            "text": "Last verified 142 days ago"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "skills/internal/legacy/SKILL.md"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "properties": {
+            "severity": "warning",
+            "detail": "Review the upstream changelog."
+          }
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "endTimeUtc": "2026-04-18T12:00:00.000Z"
+        }
+      ]
+    }
+  ]
+}"
+`;
+
+exports[`formatPolicySarif > renders multiple violations SARIF snapshot 1`] = `
+"{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "skills-check/policy",
+          "informationUri": "https://skillscheck.ai",
+          "rules": [
+            {
+              "id": "skills-check/policy/content.deny_patterns",
+              "shortDescription": {
+                "text": "content.deny_patterns"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "skills-check/policy/content.require_patterns",
+              "shortDescription": {
+                "text": "content.require_patterns"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "skills-check/policy/content.deny_patterns",
+          "level": "warning",
+          "message": {
+            "text": "Contains denied pattern: exec"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "skills/internal/deploy/SKILL.md"
+                },
+                "region": {
+                  "startLine": 14
+                }
+              }
+            }
+          ],
+          "properties": {
+            "severity": "violation",
+            "detail": "Runtime shell execution is not allowed."
+          }
+        },
+        {
+          "ruleId": "skills-check/policy/content.require_patterns",
+          "level": "warning",
+          "message": {
+            "text": "Missing required pattern: rollback"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "skills/internal/deploy/SKILL.md"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "properties": {
+            "severity": "violation",
+            "detail": "Deployment skills must document rollback steps."
+          }
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "endTimeUtc": "2026-04-18T12:00:00.000Z"
+        }
+      ]
+    }
+  ]
+}"
+`;

--- a/packages/cli/src/policy/reporters/__snapshots__/terminal.snapshots.test.ts.snap
+++ b/packages/cli/src/policy/reporters/__snapshots__/terminal.snapshots.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`formatPolicyTerminal snapshots > renders clean output 1`] = `
+"
+Policy Check: .skill-policy.yml
+==================================================
+
+REQUIRED (all satisfied):
+  + security-review installed
+
+All skills comply with policy.
+
+  2 file(s) checked
+"
+`;
+
+exports[`formatPolicyTerminal snapshots > renders mixed severities and required skill failures 1`] = `
+"
+Policy Check: .skill-policy.yml
+==================================================
+
+BLOCKED (1):
+  X skills/vendor/rogue/SKILL.md
+    Source "evil/skills" is in the deny list
+
+VIOLATIONS (1):
+  ! skills/internal/deploy/SKILL.md (line 14)
+    Contains denied pattern: exec
+    Runtime shell execution is not allowed.
+
+WARNINGS (1):
+  * skills/internal/legacy/SKILL.md
+    Last verified 142 days ago
+    Review the upstream changelog.
+
+REQUIRED:
+  + security-review installed
+  X incident-response MISSING
+
+Summary: 1 blocked, 1 violation(s), 1 warning(s). Policy check FAILED.
+"
+`;
+
+exports[`formatPolicyTerminal snapshots > renders multiple violations from the same reporter 1`] = `
+"
+Policy Check: .skill-policy.yml
+==================================================
+
+VIOLATIONS (2):
+  ! skills/internal/deploy/SKILL.md (line 14)
+    Contains denied pattern: exec
+    Runtime shell execution is not allowed.
+  ! skills/internal/deploy/SKILL.md
+    Missing required pattern: rollback
+    Deployment skills must document rollback steps.
+
+Summary: 0 blocked, 2 violation(s), 0 warning(s). Policy check FAILED.
+"
+`;

--- a/packages/cli/src/policy/reporters/json.snapshots.test.ts
+++ b/packages/cli/src/policy/reporters/json.snapshots.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { PolicyFinding, PolicyReport } from "../types.ts";
+import { formatPolicyJson } from "./json.ts";
+
+function makeReport(
+	findings: PolicyFinding[],
+	required: PolicyReport["required"] = []
+): PolicyReport {
+	return {
+		policyFile: ".skill-policy.yml",
+		files: 2,
+		findings,
+		required,
+		summary: {
+			blocked: findings.filter((finding) => finding.severity === "blocked").length,
+			violations: findings.filter((finding) => finding.severity === "violation").length,
+			warnings: findings.filter((finding) => finding.severity === "warning").length,
+		},
+		generatedAt: "2026-04-18T12:00:00.000Z",
+	};
+}
+
+describe("formatPolicyJson snapshots", () => {
+	it("renders clean output", () => {
+		const report = makeReport([], [{ skill: "security-review", satisfied: true }]);
+
+		expect(formatPolicyJson(report)).toMatchSnapshot();
+	});
+
+	it("renders multiple violations", () => {
+		const report = makeReport([
+			{
+				file: "skills/internal/deploy/SKILL.md",
+				severity: "violation",
+				rule: "content.deny_patterns",
+				message: "Contains denied pattern: exec",
+				detail: "Runtime shell execution is not allowed.",
+				line: 14,
+			},
+			{
+				file: "skills/internal/deploy/SKILL.md",
+				severity: "violation",
+				rule: "content.require_patterns",
+				message: "Missing required pattern: rollback",
+				detail: "Deployment skills must document rollback steps.",
+			},
+		]);
+
+		expect(formatPolicyJson(report)).toMatchSnapshot();
+	});
+
+	it("renders mixed severities", () => {
+		const report = makeReport(
+			[
+				{
+					file: "skills/vendor/rogue/SKILL.md",
+					severity: "blocked",
+					rule: "sources.deny",
+					message: 'Source "evil/skills" is in the deny list',
+				},
+				{
+					file: "skills/internal/deploy/SKILL.md",
+					severity: "violation",
+					rule: "content.deny_patterns",
+					message: "Contains denied pattern: exec",
+					detail: "Runtime shell execution is not allowed.",
+					line: 14,
+				},
+				{
+					file: "skills/internal/legacy/SKILL.md",
+					severity: "warning",
+					rule: "freshness.max_age_days",
+					message: "Last verified 142 days ago",
+					detail: "Review the upstream changelog.",
+				},
+			],
+			[{ skill: "incident-response", satisfied: false }]
+		);
+
+		expect(formatPolicyJson(report)).toMatchSnapshot();
+	});
+});

--- a/packages/cli/src/policy/reporters/json.test.ts
+++ b/packages/cli/src/policy/reporters/json.test.ts
@@ -5,6 +5,27 @@ import { formatPolicyJson } from "./json.js";
 describe("formatPolicyJson", () => {
 	it("produces valid JSON", () => {
 		const report: PolicyReport = {
+			exemptedViolations: [
+				{
+					file: "test.md",
+					severity: "blocked",
+					rule: "sources.deny",
+					message: "Denied but exempted",
+					skill: "internal/deploy",
+					exemption: {
+						skill: "internal/*",
+						rule: "sources.deny",
+						reason: "Approved exception",
+					},
+				},
+			],
+			exemptions: [
+				{
+					skill: "internal/*",
+					rule: "sources.deny",
+					reason: "Approved exception",
+				},
+			],
 			policyFile: ".skill-policy.yml",
 			files: 2,
 			findings: [
@@ -24,13 +45,17 @@ describe("formatPolicyJson", () => {
 		const parsed = JSON.parse(output);
 
 		expect(parsed.policyFile).toBe(".skill-policy.yml");
-		expect(parsed.files).toBe(2);
-		expect(parsed.findings).toHaveLength(1);
-		expect(parsed.required).toHaveLength(1);
+			expect(parsed.files).toBe(2);
+			expect(parsed.findings).toHaveLength(1);
+			expect(parsed.required).toHaveLength(1);
+			expect(parsed.exemptions).toHaveLength(1);
+			expect(parsed.exemptedViolations).toHaveLength(1);
 	});
 
 	it("pretty-prints with indentation", () => {
 		const report: PolicyReport = {
+			exemptedViolations: [],
+			exemptions: [],
 			policyFile: ".skill-policy.yml",
 			files: 0,
 			findings: [],

--- a/packages/cli/src/policy/reporters/json.ts
+++ b/packages/cli/src/policy/reporters/json.ts
@@ -1,5 +1,13 @@
 import type { PolicyReport } from "../types.js";
 
 export function formatPolicyJson(report: PolicyReport): string {
-	return JSON.stringify(report, null, 2);
+	return JSON.stringify(
+		{
+			...report,
+			exemptedViolations: report.exemptedViolations ?? [],
+			exemptions: report.exemptions ?? [],
+		},
+		null,
+		2
+	);
 }

--- a/packages/cli/src/policy/reporters/markdown.test.ts
+++ b/packages/cli/src/policy/reporters/markdown.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { PolicyFinding, PolicyReport } from "../types.ts";
+import { formatPolicyMarkdown } from "./markdown.ts";
+
+function makeReport(
+	findings: PolicyFinding[],
+	required: PolicyReport["required"] = []
+): PolicyReport {
+	return {
+		policyFile: ".skill-policy.yml",
+		files: 2,
+		findings,
+		required,
+		summary: {
+			blocked: findings.filter((finding) => finding.severity === "blocked").length,
+			violations: findings.filter((finding) => finding.severity === "violation").length,
+			warnings: findings.filter((finding) => finding.severity === "warning").length,
+		},
+		generatedAt: "2026-04-18T12:00:00.000Z",
+	};
+}
+
+describe("formatPolicyMarkdown", () => {
+	it("renders clean output snapshot", () => {
+		const report = makeReport([], [{ skill: "security-review", satisfied: true }]);
+
+		expect(formatPolicyMarkdown(report)).toMatchSnapshot();
+	});
+
+	it("renders multiple violations snapshot", () => {
+		const report = makeReport([
+			{
+				file: "skills/internal/deploy/SKILL.md",
+				severity: "violation",
+				rule: "content.deny_patterns",
+				message: "Contains denied pattern: exec",
+				detail: "Runtime shell execution is not allowed.",
+				line: 14,
+			},
+			{
+				file: "skills/internal/deploy/SKILL.md",
+				severity: "violation",
+				rule: "content.require_patterns",
+				message: "Missing required pattern: rollback | recovery",
+				detail: "Deployment skills must document rollback steps.",
+			},
+		]);
+
+		expect(formatPolicyMarkdown(report)).toMatchSnapshot();
+	});
+
+	it("renders mixed severities snapshot", () => {
+		const report = makeReport(
+			[
+				{
+					file: "skills/vendor/rogue/SKILL.md",
+					severity: "blocked",
+					rule: "sources.deny",
+					message: 'Source "evil/skills" is in the deny list',
+				},
+				{
+					file: "skills/internal/deploy/SKILL.md",
+					severity: "violation",
+					rule: "content.deny_patterns",
+					message: "Contains denied pattern: exec",
+					detail: "Runtime shell execution is not allowed.",
+					line: 14,
+				},
+				{
+					file: "skills/internal/legacy/SKILL.md",
+					severity: "warning",
+					rule: "freshness.max_age_days",
+					message: "Last verified 142 days ago",
+					detail: "Review the upstream changelog.",
+				},
+			],
+			[
+				{ skill: "security-review", satisfied: true },
+				{ skill: "incident-response", satisfied: false },
+			]
+		);
+
+		expect(formatPolicyMarkdown(report)).toMatchSnapshot();
+	});
+});

--- a/packages/cli/src/policy/reporters/markdown.ts
+++ b/packages/cli/src/policy/reporters/markdown.ts
@@ -3,6 +3,7 @@ import type { PolicyReport, PolicySeverity } from "../types.js";
 export function formatPolicyMarkdown(report: PolicyReport): string {
 	const lines: string[] = [];
 	const now = report.generatedAt.split("T")[0];
+	const exemptedViolations = report.exemptedViolations ?? [];
 
 	lines.push("# Skills Check Policy Report");
 	lines.push("");
@@ -18,6 +19,7 @@ export function formatPolicyMarkdown(report: PolicyReport): string {
 	lines.push(`| Blocked | ${report.summary.blocked} |`);
 	lines.push(`| Violations | ${report.summary.violations} |`);
 	lines.push(`| Warnings | ${report.summary.warnings} |`);
+	lines.push(`| Exempted | ${exemptedViolations.length} |`);
 	const total = report.summary.blocked + report.summary.violations + report.summary.warnings;
 	lines.push(`| **Total** | **${total}** |`);
 	lines.push("");
@@ -26,6 +28,12 @@ export function formatPolicyMarkdown(report: PolicyReport): string {
 
 	if (report.findings.length === 0 && report.required.every((r) => r.satisfied)) {
 		lines.push("All skills comply with policy.");
+		if (exemptedViolations.length > 0 && !report.showExemptions) {
+			lines.push("");
+			lines.push(
+				`${exemptedViolations.length} finding(s) were exempted. Re-run with --show-exemptions to display.`
+			);
+		}
 		lines.push("");
 		return lines.join("\n");
 	}
@@ -52,6 +60,32 @@ export function formatPolicyMarkdown(report: PolicyReport): string {
 		}
 
 		lines.push("");
+	}
+
+	if (exemptedViolations.length > 0) {
+		lines.push("## Exempted Findings");
+		lines.push("");
+
+		if (!report.showExemptions) {
+			lines.push(
+				`${exemptedViolations.length} finding(s) were exempted. Re-run with --show-exemptions to display.`
+			);
+			lines.push("");
+		} else {
+			lines.push("| Skill | File | Rule | Reason | Expires |");
+			lines.push("|-------|------|------|--------|---------|");
+
+			for (const finding of exemptedViolations) {
+				const skill = finding.skill ?? finding.exemption.skill;
+				const reason = finding.exemption.reason.replace(/\|/g, "\\|");
+				const lineRef = finding.line ? ` (line ${finding.line})` : "";
+				lines.push(
+					`| ${skill} | ${finding.file}${lineRef} | ${finding.rule} | ${reason} | ${finding.exemption.expires ?? ""} |`
+				);
+			}
+
+			lines.push("");
+		}
 	}
 
 	// Required skills section

--- a/packages/cli/src/policy/reporters/sarif.test.ts
+++ b/packages/cli/src/policy/reporters/sarif.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import type { PolicyFinding, PolicyReport } from "../types.ts";
+import { formatPolicySarif } from "./sarif.ts";
+
+interface SarifLog {
+	$schema: string;
+	runs: Array<{
+		invocations: Array<{ endTimeUtc: string; executionSuccessful: boolean }>;
+		results: Array<{
+			level: "error" | "warning" | "note";
+			locations: Array<{
+				physicalLocation: {
+					artifactLocation: { uri: string };
+					region: { startLine: number };
+				};
+			}>;
+			message: { text: string };
+			properties: { detail?: string; severity: string };
+			ruleId: string;
+		}>;
+		tool: {
+			driver: {
+				informationUri: string;
+				name: string;
+				rules: Array<{
+					defaultConfiguration: { level: "error" | "warning" | "note" };
+					id: string;
+					shortDescription: { text: string };
+				}>;
+			};
+		};
+	}>;
+	version: "2.1.0";
+}
+
+const SARIF_TIMESTAMP_RE = /^2026-04-18T12:00:00.000Z$/;
+const SARIF_RULE_ID_RE = /^skills-check\/policy\//;
+
+function makeReport(
+	findings: PolicyFinding[],
+	required: PolicyReport["required"] = []
+): PolicyReport {
+	return {
+		policyFile: ".skill-policy.yml",
+		files: 2,
+		findings,
+		required,
+		summary: {
+			blocked: findings.filter((finding) => finding.severity === "blocked").length,
+			violations: findings.filter((finding) => finding.severity === "violation").length,
+			warnings: findings.filter((finding) => finding.severity === "warning").length,
+		},
+		generatedAt: "2026-04-18T12:00:00.000Z",
+	};
+}
+
+function parseSarif(report: PolicyReport): SarifLog {
+	return JSON.parse(formatPolicySarif(report)) as SarifLog;
+}
+
+function validateSarif21Structure(sarif: SarifLog): void {
+	if (sarif.version !== "2.1.0") {
+		throw new Error(`Unexpected SARIF version: ${sarif.version}`);
+	}
+	if (sarif.$schema !== "https://json.schemastore.org/sarif-2.1.0.json") {
+		throw new Error(`Unexpected SARIF schema: ${sarif.$schema}`);
+	}
+	if (sarif.runs.length !== 1) {
+		throw new Error(`Expected one SARIF run, got ${sarif.runs.length}`);
+	}
+
+	const [run] = sarif.runs;
+	if (run.tool.driver.name !== "skills-check/policy") {
+		throw new Error(`Unexpected tool name: ${run.tool.driver.name}`);
+	}
+	if (run.tool.driver.informationUri !== "https://skillscheck.ai") {
+		throw new Error(`Unexpected tool URI: ${run.tool.driver.informationUri}`);
+	}
+	if (run.invocations.length !== 1) {
+		throw new Error(`Expected one invocation, got ${run.invocations.length}`);
+	}
+	if (!run.invocations[0].executionSuccessful) {
+		throw new Error("Expected successful SARIF invocation");
+	}
+	if (!SARIF_TIMESTAMP_RE.test(run.invocations[0].endTimeUtc)) {
+		throw new Error(`Unexpected invocation timestamp: ${run.invocations[0].endTimeUtc}`);
+	}
+
+	for (const result of run.results) {
+		if (!SARIF_RULE_ID_RE.test(result.ruleId)) {
+			throw new Error(`Unexpected rule id: ${result.ruleId}`);
+		}
+		if (!["error", "warning", "note"].includes(result.level)) {
+			throw new Error(`Unexpected SARIF level: ${result.level}`);
+		}
+		if (result.locations.length !== 1) {
+			throw new Error(`Expected one location for ${result.ruleId}`);
+		}
+		if (result.locations[0].physicalLocation.artifactLocation.uri.length === 0) {
+			throw new Error(`Missing artifact URI for ${result.ruleId}`);
+		}
+		if (result.locations[0].physicalLocation.region.startLine < 1) {
+			throw new Error(`Invalid start line for ${result.ruleId}`);
+		}
+		if (result.message.text.length === 0) {
+			throw new Error(`Missing message text for ${result.ruleId}`);
+		}
+		if (!["blocked", "violation", "warning"].includes(result.properties.severity)) {
+			throw new Error(`Unexpected severity property: ${result.properties.severity}`);
+		}
+	}
+
+	const ruleIds = run.tool.driver.rules.map((rule) => rule.id);
+	if (new Set(ruleIds).size !== ruleIds.length) {
+		throw new Error("Expected SARIF rules to be unique");
+	}
+}
+
+describe("formatPolicySarif", () => {
+	it("renders clean SARIF snapshot", () => {
+		const report = makeReport([], [{ skill: "security-review", satisfied: true }]);
+		const sarif = parseSarif(report);
+
+		expect(() => validateSarif21Structure(sarif)).not.toThrow();
+		expect(formatPolicySarif(report)).toMatchSnapshot();
+	});
+
+	it("renders multiple violations SARIF snapshot", () => {
+		const report = makeReport([
+			{
+				file: "skills/internal/deploy/SKILL.md",
+				severity: "violation",
+				rule: "content.deny_patterns",
+				message: "Contains denied pattern: exec",
+				detail: "Runtime shell execution is not allowed.",
+				line: 14,
+			},
+			{
+				file: "skills/internal/deploy/SKILL.md",
+				severity: "violation",
+				rule: "content.require_patterns",
+				message: "Missing required pattern: rollback",
+				detail: "Deployment skills must document rollback steps.",
+			},
+		]);
+		const sarif = parseSarif(report);
+
+		expect(() => validateSarif21Structure(sarif)).not.toThrow();
+		expect(sarif.runs[0].results).toHaveLength(2);
+		expect(formatPolicySarif(report)).toMatchSnapshot();
+	});
+
+	it("renders mixed severities with SARIF 2.1.0 level mapping", () => {
+		const report = makeReport(
+			[
+				{
+					file: "skills/vendor/rogue/SKILL.md",
+					severity: "blocked",
+					rule: "sources.deny",
+					message: 'Source "evil/skills" is in the deny list',
+				},
+				{
+					file: "skills/internal/deploy/SKILL.md",
+					severity: "violation",
+					rule: "content.deny_patterns",
+					message: "Contains denied pattern: exec",
+					detail: "Runtime shell execution is not allowed.",
+					line: 14,
+				},
+				{
+					file: "skills/internal/legacy/SKILL.md",
+					severity: "warning",
+					rule: "freshness.max_age_days",
+					message: "Last verified 142 days ago",
+					detail: "Review the upstream changelog.",
+				},
+			],
+			[{ skill: "incident-response", satisfied: false }]
+		);
+		const sarif = parseSarif(report);
+
+		expect(() => validateSarif21Structure(sarif)).not.toThrow();
+		expect(sarif.runs[0].results.map((result) => result.level)).toEqual([
+			"error",
+			"warning",
+			"note",
+		]);
+		expect(formatPolicySarif(report)).toMatchSnapshot();
+	});
+});

--- a/packages/cli/src/policy/reporters/sarif.ts
+++ b/packages/cli/src/policy/reporters/sarif.ts
@@ -1,4 +1,9 @@
-import type { PolicyFinding, PolicyReport, PolicySeverity } from "../types.js";
+import type {
+	PolicyExemptedViolation,
+	PolicyFinding,
+	PolicyReport,
+	PolicySeverity,
+} from "../types.js";
 
 function toSarifLevel(severity: PolicySeverity): "error" | "warning" | "note" {
 	switch (severity) {
@@ -32,8 +37,8 @@ function buildRules(findings: PolicyFinding[]): object[] {
 	return rules;
 }
 
-function buildResults(findings: PolicyFinding[]): object[] {
-	return findings.map((f) => ({
+function buildResults(findings: PolicyFinding[], exempted: PolicyExemptedViolation[]): object[] {
+	const activeResults = findings.map((f) => ({
 		ruleId: `skills-check/policy/${f.rule}`,
 		level: toSarifLevel(f.severity),
 		message: { text: f.message },
@@ -50,9 +55,39 @@ function buildResults(findings: PolicyFinding[]): object[] {
 			detail: f.detail,
 		},
 	}));
+
+	const suppressedResults = exempted.map((f) => ({
+		ruleId: `skills-check/policy/${f.rule}`,
+		level: toSarifLevel(f.severity),
+		message: { text: f.message },
+		locations: [
+			{
+				physicalLocation: {
+					artifactLocation: { uri: f.file },
+					region: { startLine: f.line ?? 1 },
+				},
+			},
+		],
+		suppressions: [
+			{
+				kind: "external",
+				justification: f.exemption.reason,
+			},
+		],
+		properties: {
+			detail: f.detail,
+			exempted: true,
+			exemption: f.exemption,
+			severity: f.severity,
+		},
+	}));
+
+	return [...activeResults, ...suppressedResults];
 }
 
 export function formatPolicySarif(report: PolicyReport): string {
+	const exemptedViolations = report.exemptedViolations ?? [];
+	const allFindings: PolicyFinding[] = [...report.findings, ...exemptedViolations];
 	const sarif = {
 		$schema: "https://json.schemastore.org/sarif-2.1.0.json",
 		version: "2.1.0",
@@ -62,10 +97,10 @@ export function formatPolicySarif(report: PolicyReport): string {
 					driver: {
 						name: "skills-check/policy",
 						informationUri: "https://skillscheck.ai",
-						rules: buildRules(report.findings),
+						rules: buildRules(allFindings),
 					},
 				},
-				results: buildResults(report.findings),
+				results: buildResults(report.findings, exemptedViolations),
 				invocations: [
 					{
 						executionSuccessful: true,

--- a/packages/cli/src/policy/reporters/terminal.snapshots.test.ts
+++ b/packages/cli/src/policy/reporters/terminal.snapshots.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { PolicyFinding, PolicyReport } from "../types.ts";
+import { formatPolicyTerminal } from "./terminal.ts";
+
+function makeReport(
+	findings: PolicyFinding[],
+	required: PolicyReport["required"] = []
+): PolicyReport {
+	return {
+		policyFile: ".skill-policy.yml",
+		files: 2,
+		findings,
+		required,
+		summary: {
+			blocked: findings.filter((finding) => finding.severity === "blocked").length,
+			violations: findings.filter((finding) => finding.severity === "violation").length,
+			warnings: findings.filter((finding) => finding.severity === "warning").length,
+		},
+		generatedAt: "2026-04-18T12:00:00.000Z",
+	};
+}
+
+describe("formatPolicyTerminal snapshots", () => {
+	it("renders clean output", () => {
+		const report = makeReport([], [{ skill: "security-review", satisfied: true }]);
+
+		expect(formatPolicyTerminal(report)).toMatchSnapshot();
+	});
+
+	it("renders multiple violations from the same reporter", () => {
+		const report = makeReport([
+			{
+				file: "skills/internal/deploy/SKILL.md",
+				severity: "violation",
+				rule: "content.deny_patterns",
+				message: "Contains denied pattern: exec",
+				detail: "Runtime shell execution is not allowed.",
+				line: 14,
+			},
+			{
+				file: "skills/internal/deploy/SKILL.md",
+				severity: "violation",
+				rule: "content.require_patterns",
+				message: "Missing required pattern: rollback",
+				detail: "Deployment skills must document rollback steps.",
+			},
+		]);
+
+		expect(formatPolicyTerminal(report)).toMatchSnapshot();
+	});
+
+	it("renders mixed severities and required skill failures", () => {
+		const report = makeReport(
+			[
+				{
+					file: "skills/vendor/rogue/SKILL.md",
+					severity: "blocked",
+					rule: "sources.deny",
+					message: 'Source "evil/skills" is in the deny list',
+				},
+				{
+					file: "skills/internal/deploy/SKILL.md",
+					severity: "violation",
+					rule: "content.deny_patterns",
+					message: "Contains denied pattern: exec",
+					detail: "Runtime shell execution is not allowed.",
+					line: 14,
+				},
+				{
+					file: "skills/internal/legacy/SKILL.md",
+					severity: "warning",
+					rule: "freshness.max_age_days",
+					message: "Last verified 142 days ago",
+					detail: "Review the upstream changelog.",
+				},
+			],
+			[
+				{ skill: "security-review", satisfied: true },
+				{ skill: "incident-response", satisfied: false },
+			]
+		);
+
+		expect(formatPolicyTerminal(report)).toMatchSnapshot();
+	});
+});

--- a/packages/cli/src/policy/reporters/terminal.test.ts
+++ b/packages/cli/src/policy/reporters/terminal.test.ts
@@ -4,6 +4,8 @@ import { formatPolicyTerminal } from "./terminal.js";
 
 function makeReport(overrides?: Partial<PolicyReport>): PolicyReport {
 	return {
+		exemptedViolations: [],
+		exemptions: [],
 		policyFile: ".skill-policy.yml",
 		files: 1,
 		findings: [],
@@ -119,5 +121,56 @@ describe("formatPolicyTerminal", () => {
 		});
 		const output = formatPolicyTerminal(report);
 		expect(output).toContain("Bypasses safety checks");
+	});
+
+	it("shows exempted summary hint by default", () => {
+		const output = formatPolicyTerminal(
+			makeReport({
+				exemptedViolations: [
+					{
+						file: "skills/internal/SKILL.md",
+						severity: "blocked",
+						rule: "sources.allow",
+						message: "Source is not in the allow list",
+						skill: "internal/deploy",
+						exemption: {
+							skill: "internal/*",
+							rule: "sources.allow",
+							reason: "Private registry",
+						},
+					},
+				],
+			})
+		);
+
+		expect(output).toContain("finding(s) exempted");
+		expect(output).toContain("--show-exemptions");
+	});
+
+	it("shows exempted findings when requested", () => {
+		const output = formatPolicyTerminal(
+			makeReport({
+				showExemptions: true,
+				exemptedViolations: [
+					{
+						file: "skills/internal/SKILL.md",
+						severity: "blocked",
+						rule: "sources.allow",
+						message: "Source is not in the allow list",
+						skill: "internal/deploy",
+						exemption: {
+							skill: "internal/*",
+							rule: "sources.allow",
+							reason: "Private registry",
+							expires: "2026-12-31",
+						},
+					},
+				],
+			})
+		);
+
+		expect(output).toContain("EXEMPTED FINDINGS (1)");
+		expect(output).toContain("Private registry");
+		expect(output).toContain("2026-12-31");
 	});
 });

--- a/packages/cli/src/policy/reporters/terminal.ts
+++ b/packages/cli/src/policy/reporters/terminal.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import type { PolicyFinding, PolicyReport } from "../types.js";
+import type { PolicyExemptedViolation, PolicyFinding, PolicyReport } from "../types.js";
 
 function groupByFile(findings: PolicyFinding[]): Map<string, PolicyFinding[]> {
 	const groups = new Map<string, PolicyFinding[]>();
@@ -7,6 +7,18 @@ function groupByFile(findings: PolicyFinding[]): Map<string, PolicyFinding[]> {
 		const existing = groups.get(f.file) ?? [];
 		existing.push(f);
 		groups.set(f.file, existing);
+	}
+	return groups;
+}
+
+function groupExemptedByFile(
+	findings: PolicyExemptedViolation[]
+): Map<string, PolicyExemptedViolation[]> {
+	const groups = new Map<string, PolicyExemptedViolation[]>();
+	for (const finding of findings) {
+		const existing = groups.get(finding.file) ?? [];
+		existing.push(finding);
+		groups.set(finding.file, existing);
 	}
 	return groups;
 }
@@ -23,6 +35,7 @@ export function formatPolicyTerminal(report: PolicyReport): string {
 	const blocked = report.findings.filter((f) => f.severity === "blocked");
 	const violations = report.findings.filter((f) => f.severity === "violation");
 	const warnings = report.findings.filter((f) => f.severity === "warning");
+	const exemptedViolations = report.exemptedViolations ?? [];
 
 	// BLOCKED section
 	if (blocked.length > 0) {
@@ -72,6 +85,34 @@ export function formatPolicyTerminal(report: PolicyReport): string {
 			}
 		}
 		lines.push("");
+	}
+
+	if (exemptedViolations.length > 0) {
+		if (report.showExemptions) {
+			lines.push(chalk.dim.italic(`EXEMPTED FINDINGS (${exemptedViolations.length}):`));
+			const grouped = groupExemptedByFile(exemptedViolations);
+			for (const [file, findings] of grouped) {
+				for (const finding of findings) {
+					const lineRef = finding.line ? ` (line ${finding.line})` : "";
+					lines.push(`  ${chalk.dim("-")} ${chalk.dim(file)}${lineRef}`);
+					lines.push(`    ${chalk.dim(finding.message)}`);
+					lines.push(
+						`    ${chalk.dim(`exempted by ${finding.exemption.skill} → ${finding.exemption.reason}`)}`
+					);
+					if (finding.exemption.expires) {
+						lines.push(`    ${chalk.dim(`expires ${finding.exemption.expires}`)}`);
+					}
+				}
+			}
+			lines.push("");
+		} else {
+			lines.push(
+				chalk.dim(
+					`${exemptedViolations.length} finding(s) exempted. Re-run with --show-exemptions to display.`
+				)
+			);
+			lines.push("");
+		}
 	}
 
 	// REQUIRED section

--- a/packages/cli/src/policy/types.ts
+++ b/packages/cli/src/policy/types.ts
@@ -1,3 +1,5 @@
+import type { PolicyExemption } from "@skills-check/schema";
+
 export interface SkillPolicy {
 	audit?: {
 		require_clean?: boolean;
@@ -8,6 +10,7 @@ export interface SkillPolicy {
 		deny_patterns?: Array<{ pattern: string; reason: string }>;
 		require_patterns?: Array<{ pattern: string; reason: string }>;
 	};
+	exemptions?: PolicyExemption[];
 	freshness?: {
 		max_age_days?: number;
 		max_version_drift?: "major" | "minor" | "patch";
@@ -34,14 +37,22 @@ export interface PolicyFinding {
 	message: string;
 	rule: string;
 	severity: PolicySeverity;
+	skill?: string;
+}
+
+export interface PolicyExemptedViolation extends PolicyFinding {
+	exemption: PolicyExemption;
 }
 
 export interface PolicyReport {
+	exemptedViolations?: PolicyExemptedViolation[];
+	exemptions?: PolicyExemption[];
 	files: number;
 	findings: PolicyFinding[];
 	generatedAt: string;
 	policyFile: string;
 	required: Array<{ skill: string; satisfied: boolean }>;
+	showExemptions?: boolean;
 	summary: { blocked: number; violations: number; warnings: number };
 }
 
@@ -51,5 +62,6 @@ export interface PolicyOptions {
 	format?: "terminal" | "json" | "markdown" | "sarif";
 	output?: string;
 	policy?: string;
+	showExemptions?: boolean;
 	skill?: string;
 }

--- a/packages/cli/src/revocation/index.test.ts
+++ b/packages/cli/src/revocation/index.test.ts
@@ -1,0 +1,151 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	checkRevocations,
+	createRevocationAuditFindings,
+	readRevocationList,
+} from "./index.js";
+
+describe("revocation", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skills-check-revocations-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("reads a valid revocation list", async () => {
+		const filePath = join(tempDir, ".skill-revocations.json");
+		await writeFile(
+			filePath,
+			JSON.stringify(
+				{
+					revocationVersion: 1,
+					updatedAt: "2026-04-18T00:00:00Z",
+					entries: [
+						{
+							skill: "bad-skill",
+							reason: "Compromised prompt",
+							revokedAt: "2026-04-17T00:00:00Z",
+							severity: "critical",
+						},
+					],
+				},
+				null,
+				2
+			),
+			"utf-8"
+		);
+
+		expect(readRevocationList(filePath)).toEqual({
+			revocationVersion: 1,
+			updatedAt: "2026-04-18T00:00:00Z",
+			entries: [
+				{
+					skill: "bad-skill",
+					reason: "Compromised prompt",
+					revokedAt: "2026-04-17T00:00:00Z",
+					severity: "critical",
+				},
+			],
+		});
+	});
+
+	it("returns null when the revocation file is missing", () => {
+		expect(readRevocationList(join(tempDir, "missing.json"))).toBeNull();
+	});
+
+	it("matches revoked skills and preserves severity", () => {
+		const matches = checkRevocations(
+			["safe-skill", "bad-skill", "legacy-skill"],
+			{
+				revocationVersion: 1,
+				updatedAt: "2026-04-18T00:00:00Z",
+				entries: [
+					{
+						skill: "bad-skill",
+						reason: "Compromised prompt",
+						revokedAt: "2026-04-17T00:00:00Z",
+						severity: "critical",
+					},
+					{
+						skill: "legacy-skill",
+						reason: "Unsafe legacy workflow",
+						revokedAt: "2026-04-16T00:00:00Z",
+						severity: "high",
+					},
+				],
+			}
+		);
+
+		expect(matches).toEqual([
+			{
+				skill: "bad-skill",
+				entry: {
+					skill: "bad-skill",
+					reason: "Compromised prompt",
+					revokedAt: "2026-04-17T00:00:00Z",
+					severity: "critical",
+				},
+			},
+			{
+				skill: "legacy-skill",
+				entry: {
+					skill: "legacy-skill",
+					reason: "Unsafe legacy workflow",
+					revokedAt: "2026-04-16T00:00:00Z",
+					severity: "high",
+				},
+			},
+		]);
+	});
+
+	it("builds audit findings for revoked fingerprint entries", () => {
+		const findings = createRevocationAuditFindings(
+			{
+				version: 1,
+				generatedAt: "2026-04-18T00:00:00Z",
+				entries: [
+					{
+						skillId: "bad-skill",
+						path: "/skills/bad-skill/SKILL.md",
+						version: "1.0.0",
+						frontmatterHash: "frontmatter",
+						contentHash: "content",
+						prefixHash: "prefix",
+					},
+				],
+			},
+			{
+				revocationVersion: 1,
+				updatedAt: "2026-04-18T00:00:00Z",
+				entries: [
+					{
+						skill: "bad-skill",
+						reason: "Compromised prompt",
+						revokedAt: "2026-04-17T00:00:00Z",
+						severity: "critical",
+						advisory: "https://example.com/SK-1",
+					},
+				],
+			}
+		);
+
+		expect(findings).toEqual([
+			{
+				category: "revoked-skill",
+				evidence: "Compromised prompt",
+				file: "/skills/bad-skill/SKILL.md",
+				line: 1,
+				message: 'Skill "bad-skill" has been revoked',
+				note: "revoked at 2026-04-17T00:00:00Z; advisory: https://example.com/SK-1",
+				severity: "critical",
+			},
+		]);
+	});
+});

--- a/packages/cli/src/revocation/index.ts
+++ b/packages/cli/src/revocation/index.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from "node:fs";
+import type {
+	FingerprintRegistry,
+	RevocationEntry,
+	RevocationList,
+} from "@skills-check/schema";
+import type { AuditFinding } from "../audit/types.js";
+
+export interface RevocationMatch {
+	entry: RevocationEntry;
+	skill: string;
+}
+
+export function readRevocationList(path: string): RevocationList | null {
+	let raw: string;
+
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch {
+		return null;
+	}
+
+	let data: unknown;
+	try {
+		data = JSON.parse(raw);
+	} catch {
+		throw new Error(`Invalid JSON in revocation list: ${path}`);
+	}
+
+	return validateRevocationList(data, path);
+}
+
+export function checkRevocations(skills: string[], revocations: RevocationList): RevocationMatch[] {
+	const knownSkills = new Set(skills);
+
+	return revocations.entries
+		.filter((entry) => knownSkills.has(entry.skill))
+		.map((entry) => ({
+			entry,
+			skill: entry.skill,
+		}));
+}
+
+export function createRevocationAuditFindings(
+	registry: FingerprintRegistry,
+	revocations: RevocationList
+): AuditFinding[] {
+	const pathBySkill = new Map(registry.entries.map((entry) => [entry.skillId, entry.path]));
+
+	return checkRevocations(
+		registry.entries.map((entry) => entry.skillId),
+		revocations
+	).map(({ skill, entry }) => ({
+		category: "revoked-skill",
+		evidence: entry.reason,
+		file: pathBySkill.get(skill) ?? skill,
+		line: 1,
+		message: `Skill "${skill}" has been revoked`,
+		note: buildRevocationNote(entry),
+		severity: entry.severity,
+	}));
+}
+
+function buildRevocationNote(entry: RevocationEntry): string {
+	const parts = [`revoked at ${entry.revokedAt}`];
+
+	if (entry.advisory) {
+		parts.push(`advisory: ${entry.advisory}`);
+	}
+
+	return parts.join("; ");
+}
+
+function validateRevocationList(data: unknown, path: string): RevocationList {
+	if (!data || typeof data !== "object") {
+		throw new Error(`Revocation list is not a valid object: ${path}`);
+	}
+
+	const revocations = data as Record<string, unknown>;
+
+	if (revocations.revocationVersion !== 1) {
+		throw new Error(
+			`Unsupported revocation list version: ${String(revocations.revocationVersion)} (expected 1)`
+		);
+	}
+
+	if (typeof revocations.updatedAt !== "string") {
+		throw new Error(`Revocation list is missing "updatedAt": ${path}`);
+	}
+
+	if (!Array.isArray(revocations.entries)) {
+		throw new Error(`Revocation list is missing "entries" array: ${path}`);
+	}
+
+	for (const [index, entry] of revocations.entries.entries()) {
+		validateRevocationEntry(entry, index);
+	}
+
+	return revocations as unknown as RevocationList;
+}
+
+function validateRevocationEntry(entry: unknown, index: number): void {
+	if (!entry || typeof entry !== "object") {
+		throw new Error(`Invalid revocation entry at index ${index}`);
+	}
+
+	const revocation = entry as Record<string, unknown>;
+	const requiredFields = ["skill", "reason", "revokedAt", "severity"] as const;
+
+	for (const field of requiredFields) {
+		if (typeof revocation[field] !== "string" || revocation[field].length === 0) {
+			throw new Error(`Revocation entry ${index} is missing required field: ${field}`);
+		}
+	}
+
+	if (!isRevocationSeverity(revocation.severity)) {
+		throw new Error(`Invalid revocation severity at index ${index}: ${String(revocation.severity)}`);
+	}
+
+	if (
+		revocation.advisory !== undefined &&
+		(typeof revocation.advisory !== "string" || revocation.advisory.length === 0)
+	) {
+		throw new Error(`Revocation entry ${index} has invalid advisory`);
+	}
+}
+
+function isRevocationSeverity(value: unknown): value is RevocationEntry["severity"] {
+	return value === "critical" || value === "high" || value === "medium" || value === "low";
+}

--- a/packages/cli/src/scanner.test.ts
+++ b/packages/cli/src/scanner.test.ts
@@ -1,6 +1,49 @@
-import { describe, expect, it } from "vitest";
-import { groupSkills } from "./scanner.js";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { groupSkills, scanSkills } from "./scanner.js";
 import type { ScannedSkill } from "./types.js";
+
+describe("scanSkills", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skills-check-scanner-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("parses deprecated frontmatter", async () => {
+		const skillDir = join(tempDir, "old-skill");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: old-skill
+product-version: "1.0.0"
+deprecated: true
+deprecatedMessage: Use new-skill instead.
+---
+
+# Old Skill
+`,
+			"utf-8"
+		);
+
+		const skills = await scanSkills(tempDir);
+
+		expect(skills).toEqual([
+			expect.objectContaining({
+				name: "old-skill",
+				status: "deprecated",
+				deprecatedMessage: "Use new-skill instead.",
+			}),
+		]);
+	});
+});
 
 describe("groupSkills", () => {
 	it("groups skills with shared prefix and same version", () => {

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -2,6 +2,7 @@ import { lstat, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import matter from "gray-matter";
 import { extractVersionedPackages, parseCompatibility } from "./compatibility/index.js";
+import { resolveSkillLifecycle } from "./skill-io.js";
 import type { ScannedSkill } from "./types.js";
 
 /**
@@ -60,9 +61,11 @@ export async function scanSkills(skillsDir: string): Promise<ScannedSkill[]> {
 
 			try {
 				const { data } = matter(content);
+				const lifecycle = resolveSkillLifecycle(data);
 				const skill: ScannedSkill = {
 					name: (data.name as string) ?? entry,
 					path: skillPath,
+					...lifecycle,
 				};
 
 				// Top-level product-version (most common format)

--- a/packages/cli/src/skill-io.test.ts
+++ b/packages/cli/src/skill-io.test.ts
@@ -52,6 +52,24 @@ Some content here.
 		it("throws for missing file", async () => {
 			await expect(readSkillFile(join(tempDir, "missing.md"))).rejects.toThrow();
 		});
+
+		it("parses deprecated lifecycle metadata", async () => {
+			const content = `---
+name: old-skill
+deprecated: true
+deprecatedMessage: Use new-skill instead.
+---
+
+# Old Skill
+`;
+			const filePath = join(tempDir, "SKILL.md");
+			await writeFile(filePath, content, "utf-8");
+
+			const result = await readSkillFile(filePath);
+
+			expect(result.status).toBe("deprecated");
+			expect(result.deprecatedMessage).toBe("Use new-skill instead.");
+		});
 	});
 
 	describe("writeSkillFile", () => {

--- a/packages/cli/src/skill-io.ts
+++ b/packages/cli/src/skill-io.ts
@@ -3,9 +3,27 @@ import matter from "gray-matter";
 
 export interface SkillFile {
 	content: string;
+	deprecatedMessage?: string;
 	frontmatter: Record<string, unknown>;
 	path: string;
 	raw: string;
+	status?: "active" | "deprecated" | "revoked";
+}
+
+export function resolveSkillLifecycle(frontmatter: Record<string, unknown>): Pick<
+	SkillFile,
+	"deprecatedMessage" | "status"
+> {
+	if (frontmatter.deprecated !== true) {
+		return {};
+	}
+
+	return {
+		status: "deprecated",
+		...(typeof frontmatter.deprecatedMessage === "string"
+			? { deprecatedMessage: frontmatter.deprecatedMessage }
+			: {}),
+	};
 }
 
 /**
@@ -14,12 +32,14 @@ export interface SkillFile {
 export async function readSkillFile(filePath: string): Promise<SkillFile> {
 	const raw = await readFile(filePath, "utf-8");
 	const { data, content } = matter(raw);
+	const lifecycle = resolveSkillLifecycle(data);
 
 	return {
 		path: filePath,
 		frontmatter: data,
 		content,
 		raw,
+		...lifecycle,
 	};
 }
 

--- a/packages/cli/src/testing/harness/generic.test.ts
+++ b/packages/cli/src/testing/harness/generic.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
-// Mock child_process.exec
+// Mock child_process.execFile
 vi.mock("node:child_process", () => ({
-	exec: vi.fn((_cmd, opts, cb) => {
+	execFile: vi.fn((_cmd, _args, opts, cb) => {
 		if (typeof opts === "function") {
 			opts(null, "generic output", "");
 		} else if (typeof cb === "function") {
@@ -22,7 +22,34 @@ vi.mock("node:fs/promises", async () => {
 	};
 });
 
-import { GenericHarness } from "./generic.js";
+import { execFile } from "node:child_process";
+import { GenericHarness, parseCommandTemplate } from "./generic.js";
+
+const mockedExecFile = vi.mocked(execFile);
+
+describe("parseCommandTemplate", () => {
+	it("parses simple command", () => {
+		const result = parseCommandTemplate("echo {prompt}");
+		expect(result.cmd).toBe("echo");
+		expect(result.argTemplate).toEqual(["{prompt}"]);
+	});
+
+	it("parses command with multiple args", () => {
+		const result = parseCommandTemplate("my-agent --prompt {prompt} --verbose");
+		expect(result.cmd).toBe("my-agent");
+		expect(result.argTemplate).toEqual(["--prompt", "{prompt}", "--verbose"]);
+	});
+
+	it("throws on empty template", () => {
+		expect(() => parseCommandTemplate("")).toThrow("Command template must not be empty");
+	});
+
+	it("handles extra whitespace", () => {
+		const result = parseCommandTemplate("  echo   {prompt}  ");
+		expect(result.cmd).toBe("echo");
+		expect(result.argTemplate).toEqual(["{prompt}"]);
+	});
+});
 
 describe("GenericHarness", () => {
 	it("has correct name", () => {
@@ -35,9 +62,8 @@ describe("GenericHarness", () => {
 		expect(await harness.available()).toBe(true);
 	});
 
-	it("uses default command template", async () => {
-		const { exec } = await import("node:child_process");
-		const mockedExec = vi.mocked(exec);
+	it("uses default command template with execFile", async () => {
+		mockedExecFile.mockClear();
 
 		const harness = new GenericHarness();
 		await harness.execute("Hello world", {
@@ -45,24 +71,26 @@ describe("GenericHarness", () => {
 			timeout: 30,
 		});
 
-		const calledCommand = mockedExec.mock.calls[0][0] as string;
-		expect(calledCommand).toContain("Hello world");
+		// execFile should be called with cmd and args array, not a shell string
+		const calledCmd = mockedExecFile.mock.calls[0][0] as string;
+		const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(calledCmd).toBe("echo");
+		expect(calledArgs).toEqual(["Hello world"]);
 	});
 
 	it("uses custom command template", async () => {
-		const { exec } = await import("node:child_process");
-		const mockedExec = vi.mocked(exec);
-		mockedExec.mockClear();
+		mockedExecFile.mockClear();
 
-		const harness = new GenericHarness('codex exec "{prompt}"');
+		const harness = new GenericHarness("codex exec --prompt {prompt}");
 		await harness.execute("Create a file", {
 			workDir: "/tmp/test",
 			timeout: 30,
 		});
 
-		const calledCommand = mockedExec.mock.calls[0][0] as string;
-		expect(calledCommand).toContain("codex exec");
-		expect(calledCommand).toContain("Create a file");
+		const calledCmd = mockedExecFile.mock.calls[0][0] as string;
+		const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+		expect(calledCmd).toBe("codex");
+		expect(calledArgs).toEqual(["exec", "--prompt", "Create a file"]);
 	});
 
 	it("returns execution result", async () => {
@@ -75,5 +103,113 @@ describe("GenericHarness", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.transcript).toBe("generic output");
 		expect(result.duration).toBeGreaterThanOrEqual(0);
+	});
+
+	it("sets SKILLS_CHECK_PROMPT environment variable", async () => {
+		mockedExecFile.mockClear();
+
+		const harness = new GenericHarness();
+		await harness.execute("my prompt value", {
+			workDir: "/tmp/test",
+			timeout: 30,
+		});
+
+		const calledOpts = mockedExecFile.mock.calls[0][2] as { env?: Record<string, string> };
+		expect(calledOpts.env?.SKILLS_CHECK_PROMPT).toBe("my prompt value");
+	});
+
+	describe("command injection safety", () => {
+		it("does not execute shell metacharacters via $(...)", async () => {
+			mockedExecFile.mockClear();
+
+			const harness = new GenericHarness();
+			await harness.execute("$(rm -rf /)", {
+				workDir: "/tmp/test",
+				timeout: 30,
+			});
+
+			// The prompt is passed as a direct argument, not shell-interpolated
+			const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+			expect(calledArgs).toEqual(["$(rm -rf /)"]);
+			// execFile does NOT pass through a shell, so this is a literal string
+		});
+
+		it("does not execute backtick injection", async () => {
+			mockedExecFile.mockClear();
+
+			const harness = new GenericHarness();
+			await harness.execute("`whoami`", {
+				workDir: "/tmp/test",
+				timeout: 30,
+			});
+
+			const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+			expect(calledArgs).toEqual(["`whoami`"]);
+		});
+
+		it("does not execute semicolon injection", async () => {
+			mockedExecFile.mockClear();
+
+			const harness = new GenericHarness();
+			await harness.execute("hello; rm -rf /", {
+				workDir: "/tmp/test",
+				timeout: 30,
+			});
+
+			const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+			expect(calledArgs).toEqual(["hello; rm -rf /"]);
+		});
+
+		it("does not execute pipe injection", async () => {
+			mockedExecFile.mockClear();
+
+			const harness = new GenericHarness();
+			await harness.execute("hello | cat /etc/passwd", {
+				workDir: "/tmp/test",
+				timeout: 30,
+			});
+
+			const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+			expect(calledArgs).toEqual(["hello | cat /etc/passwd"]);
+		});
+
+		it("does not execute && injection", async () => {
+			mockedExecFile.mockClear();
+
+			const harness = new GenericHarness();
+			await harness.execute("hello && curl evil.com", {
+				workDir: "/tmp/test",
+				timeout: 30,
+			});
+
+			const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+			expect(calledArgs).toEqual(["hello && curl evil.com"]);
+		});
+
+		it("handles prompt with single quotes safely", async () => {
+			mockedExecFile.mockClear();
+
+			const harness = new GenericHarness();
+			await harness.execute("it's a test", {
+				workDir: "/tmp/test",
+				timeout: 30,
+			});
+
+			const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+			expect(calledArgs).toEqual(["it's a test"]);
+		});
+
+		it("handles prompt with double quotes safely", async () => {
+			mockedExecFile.mockClear();
+
+			const harness = new GenericHarness();
+			await harness.execute('say "hello"', {
+				workDir: "/tmp/test",
+				timeout: 30,
+			});
+
+			const calledArgs = mockedExecFile.mock.calls[0][1] as string[];
+			expect(calledArgs).toEqual(['say "hello"']);
+		});
 	});
 });

--- a/packages/cli/src/testing/harness/generic.ts
+++ b/packages/cli/src/testing/harness/generic.ts
@@ -36,15 +36,41 @@ async function listFilesRecursive(dir: string): Promise<Set<string>> {
 	return files;
 }
 
-const WHITESPACE_RE = /\s+/;
-
 /**
  * Parse a command template string into an executable and argument template array.
- * The template is split on whitespace; `{prompt}` tokens in the args are replaced
- * at execution time with the actual prompt value — never shell-interpolated.
+ * Handles quoted segments (single and double quotes) so paths with spaces work.
+ * `{prompt}` tokens in the args are replaced at execution time with the actual
+ * prompt value — never shell-interpolated.
  */
 export function parseCommandTemplate(template: string): { cmd: string; argTemplate: string[] } {
-	const parts = template.split(WHITESPACE_RE).filter(Boolean);
+	const parts: string[] = [];
+	let current = "";
+	let inQuote: string | null = null;
+
+	for (let i = 0; i < template.length; i++) {
+		const ch = template[i];
+
+		if (inQuote) {
+			if (ch === inQuote) {
+				inQuote = null;
+			} else {
+				current += ch;
+			}
+		} else if (ch === '"' || ch === "'") {
+			inQuote = ch;
+		} else if (ch === " " || ch === "\t") {
+			if (current.length > 0) {
+				parts.push(current);
+				current = "";
+			}
+		} else {
+			current += ch;
+		}
+	}
+	if (current.length > 0) {
+		parts.push(current);
+	}
+
 	if (parts.length === 0) {
 		throw new Error("Command template must not be empty");
 	}

--- a/packages/cli/src/testing/harness/generic.ts
+++ b/packages/cli/src/testing/harness/generic.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { lstat, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { AgentExecution } from "../types.js";
@@ -36,16 +36,32 @@ async function listFilesRecursive(dir: string): Promise<Set<string>> {
 	return files;
 }
 
+const WHITESPACE_RE = /\s+/;
+
 /**
- * Generic shell-based agent harness.
- * Uses a configurable command template where {prompt} is replaced with the actual prompt.
+ * Parse a command template string into an executable and argument template array.
+ * The template is split on whitespace; `{prompt}` tokens in the args are replaced
+ * at execution time with the actual prompt value — never shell-interpolated.
+ */
+export function parseCommandTemplate(template: string): { cmd: string; argTemplate: string[] } {
+	const parts = template.split(WHITESPACE_RE).filter(Boolean);
+	if (parts.length === 0) {
+		throw new Error("Command template must not be empty");
+	}
+	return { cmd: parts[0], argTemplate: parts.slice(1) };
+}
+
+/**
+ * Generic agent harness that executes commands without a shell.
+ * Uses execFile() instead of exec() to prevent command injection from untrusted prompts.
+ * The {prompt} placeholder is replaced in the argument array, never shell-interpolated.
  */
 export class GenericHarness implements AgentHarness {
 	readonly name = "generic";
 	private readonly commandTemplate: string;
 
 	constructor(commandTemplate?: string) {
-		this.commandTemplate = commandTemplate ?? 'echo "{prompt}"';
+		this.commandTemplate = commandTemplate ?? "echo {prompt}";
 	}
 
 	// biome-ignore lint/suspicious/useAwait: interface contract requires async
@@ -60,18 +76,21 @@ export class GenericHarness implements AgentHarness {
 		const beforeFiles = await listFilesRecursive(options.workDir);
 		const start = Date.now();
 
-		// Replace {prompt} placeholder with the actual prompt, escaping shell characters
-		const escapedPrompt = prompt.replace(/'/g, "'\\''");
-		const command = this.commandTemplate.replace("{prompt}", escapedPrompt);
+		const { cmd, argTemplate } = parseCommandTemplate(this.commandTemplate);
+		const args = argTemplate.map((a) =>
+			a === "{prompt}" ? prompt : a.replaceAll("{prompt}", prompt)
+		);
 
 		const result = await new Promise<{ exitCode: number; stdout: string; stderr: string }>(
 			(resolve) => {
-				exec(
-					command,
+				execFile(
+					cmd,
+					args,
 					{
 						cwd: options.workDir,
 						timeout: options.timeout * 1000,
 						maxBuffer: 10 * 1024 * 1024,
+						env: { ...process.env, SKILLS_CHECK_PROMPT: prompt },
 					},
 					(error, stdout, stderr) => {
 						resolve({

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -31,12 +31,14 @@ export interface ScannedSkill {
 	allowedTools?: string;
 	compatibility?: string;
 	compatibilityEntries?: CompatibilityEntry[];
+	deprecatedMessage?: string;
 	name: string;
 	path: string;
 	product?: string;
 	/** @deprecated Use `resolvedPackages` from compatibility field instead */
 	productVersion?: string;
 	resolvedPackages?: CompatibilityEntry[];
+	status?: "active" | "deprecated" | "revoked";
 }
 
 /**

--- a/packages/cli/src/usage/readers/sqlite.test.ts
+++ b/packages/cli/src/usage/readers/sqlite.test.ts
@@ -1,0 +1,241 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SkillTelemetryEvent } from "@skills-check/schema";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { analyzeUsage } from "../analyzer.ts";
+import { JSONLReader } from "./jsonl.ts";
+import { SQLiteReader } from "./sqlite.ts";
+
+const SQLITE_ERROR =
+	"SQLite reader requires Node.js 22+ with built-in sqlite module. Use a JSONL telemetry store instead, or upgrade Node.js.";
+
+function makeEvent(overrides?: Partial<SkillTelemetryEvent>): SkillTelemetryEvent {
+	return {
+		schemaVersion: 1,
+		timestamp: "2026-03-08T08:00:00.000Z",
+		detection: "watermark",
+		confidence: 1,
+		skillId: "react-patterns",
+		version: "19.1.0",
+		registry: "skills.sh",
+		requestId: "req-1",
+		model: "claude-sonnet-4-6",
+		skillTokens: 1200,
+		totalPromptTokens: 4500,
+		team: "platform",
+		project: "skills-check",
+		user: "alice",
+		...overrides,
+	};
+}
+
+function sortEvents(events: SkillTelemetryEvent[]): SkillTelemetryEvent[] {
+	return [...events].sort((left, right) => {
+		const timestampOrder = right.timestamp.localeCompare(left.timestamp);
+		if (timestampOrder !== 0) {
+			return timestampOrder;
+		}
+
+		const requestOrder = (left.requestId ?? "").localeCompare(right.requestId ?? "");
+		if (requestOrder !== 0) {
+			return requestOrder;
+		}
+
+		return left.detection.localeCompare(right.detection);
+	});
+}
+
+describe("SQLiteReader", () => {
+	let tempDir: string;
+	let dbPath: string;
+	let jsonlPath: string;
+	let events: SkillTelemetryEvent[];
+
+	beforeAll(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skills-check-sqlite-reader-"));
+		dbPath = join(tempDir, "telemetry.db");
+		jsonlPath = join(tempDir, "telemetry.jsonl");
+
+		events = [
+			makeEvent({
+				timestamp: "2026-02-01T00:00:00.000Z",
+				requestId: "req-0",
+				skillTokens: 900,
+				totalPromptTokens: 3200,
+				user: "zoe",
+			}),
+			makeEvent({
+				timestamp: "2026-03-08T08:00:00.000Z",
+				requestId: "req-1",
+				detection: "watermark",
+				confidence: 1,
+				skillTokens: 1200,
+			}),
+			makeEvent({
+				timestamp: "2026-03-08T08:00:00.000Z",
+				requestId: "req-1",
+				detection: "content_hash",
+				confidence: 0.6,
+				skillTokens: 1100,
+			}),
+			makeEvent({
+				timestamp: "2026-03-09T12:30:00.000Z",
+				requestId: "req-2",
+				skillId: "vue-patterns",
+				version: "3.5.0",
+				model: "gpt-4o",
+				skillTokens: 1500,
+				team: "frontend",
+				user: "bob",
+			}),
+			makeEvent({
+				timestamp: "2026-03-10T15:45:00.000Z",
+				requestId: "req-3",
+				skillId: "react-patterns",
+				version: "19.2.0",
+				detection: "prefix_hash",
+				confidence: 0.8,
+				skillTokens: 1800,
+				totalPromptTokens: 5100,
+				user: "carol",
+			}),
+		];
+
+		// biome-ignore lint/correctness/noUnresolvedImports: Node 22 built-in sqlite module is available at runtime
+		const { DatabaseSync } = await import("node:sqlite");
+		const db = new DatabaseSync(dbPath);
+		db.exec(
+			`CREATE TABLE skill_events (
+				timestamp TEXT NOT NULL,
+				detection TEXT NOT NULL,
+				confidence REAL NOT NULL,
+				skill_id TEXT NOT NULL,
+				skill_version TEXT NOT NULL,
+				registry TEXT,
+				request_id TEXT,
+				model TEXT,
+				skill_tokens INTEGER,
+				total_prompt_tokens INTEGER,
+				team TEXT,
+				project TEXT,
+				user TEXT
+			)`
+		);
+
+		const insert = db.prepare(
+			`INSERT INTO skill_events (
+				timestamp,
+				detection,
+				confidence,
+				skill_id,
+				skill_version,
+				registry,
+				request_id,
+				model,
+				skill_tokens,
+				total_prompt_tokens,
+				team,
+				project,
+				user
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		);
+
+		for (const event of events) {
+			insert.run(
+				event.timestamp,
+				event.detection,
+				event.confidence,
+				event.skillId,
+				event.version,
+				event.registry ?? null,
+				event.requestId ?? null,
+				event.model ?? null,
+				event.skillTokens ?? null,
+				event.totalPromptTokens ?? null,
+				event.team ?? null,
+				event.project ?? null,
+				event.user ?? null
+			);
+		}
+
+		db.close();
+
+		await writeFile(jsonlPath, events.map((event) => JSON.stringify(event)).join("\n"), "utf-8");
+	});
+
+	afterAll(async () => {
+		await rm(tempDir, { force: true, recursive: true });
+	});
+
+	it("reads telemetry events from a real SQLite database", async () => {
+		const reader = new SQLiteReader(dbPath);
+		const result = await reader.read();
+		await reader.close();
+
+		expect(result).toHaveLength(events.length);
+		expect(result).toEqual(sortEvents(events));
+	});
+
+	it("cross-validates SQLite output against the JSONL reader for the same dataset", async () => {
+		const sqliteReader = new SQLiteReader(dbPath);
+		const jsonlReader = new JSONLReader(jsonlPath);
+
+		const [sqliteEvents, jsonlEvents] = await Promise.all([
+			sqliteReader.read(),
+			jsonlReader.read(),
+		]);
+
+		await Promise.all([sqliteReader.close(), jsonlReader.close()]);
+
+		expect(sortEvents(sqliteEvents)).toEqual(sortEvents(jsonlEvents));
+	});
+
+	it("supports date range filtering against the real database", async () => {
+		const reader = new SQLiteReader(dbPath);
+		const result = await reader.read({
+			since: new Date("2026-03-08T00:00:00.000Z"),
+			until: new Date("2026-03-09T23:59:59.999Z"),
+		});
+		await reader.close();
+
+		expect(result).toEqual(
+			sortEvents(
+				events.filter(
+					(event) =>
+						event.timestamp >= "2026-03-08T00:00:00.000Z" &&
+						event.timestamp <= "2026-03-09T23:59:59.999Z"
+				)
+			)
+		);
+	});
+
+	it("preserves duplicate detections so downstream usage analysis can deduplicate them", async () => {
+		const reader = new SQLiteReader(dbPath);
+		const sqliteEvents = await reader.read();
+		await reader.close();
+
+		const usageReport = analyzeUsage(sqliteEvents);
+		const reactSkill = usageReport.skills.find((skill) => skill.name === "react-patterns");
+
+		expect(sqliteEvents.filter((event) => event.requestId === "req-1")).toHaveLength(2);
+		expect(reactSkill).toMatchObject({
+			hasVersionDrift: true,
+			totalCalls: 3,
+			versions: ["19.1.0", "19.2.0"],
+		});
+		expect(usageReport.totalCalls).toBe(4);
+	});
+
+	it("fails with a helpful error for missing or corrupt SQLite files", async () => {
+		const missingReader = new SQLiteReader(join(tempDir, "missing.db"));
+		const corruptPath = join(tempDir, "corrupt.db");
+		await writeFile(corruptPath, "not a sqlite database", "utf-8");
+		const corruptReader = new SQLiteReader(corruptPath);
+
+		await expect(missingReader.read()).rejects.toThrow(SQLITE_ERROR);
+		await expect(corruptReader.read()).rejects.toThrow(SQLITE_ERROR);
+
+		await Promise.all([missingReader.close(), corruptReader.close()]);
+	});
+});

--- a/packages/cli/src/usage/readers/sqlite.ts
+++ b/packages/cli/src/usage/readers/sqlite.ts
@@ -1,5 +1,9 @@
 import type { SkillTelemetryEvent, TelemetryReader, TelemetryReaderOptions } from "./types.js";
 
+const SQLITE_ERROR =
+	"SQLite reader requires Node.js 22+ with built-in sqlite module. " +
+	"Use a JSONL telemetry store instead, or upgrade Node.js.";
+
 /**
  * Read telemetry events from a SQLite database.
  * Uses Node 22 built-in node:sqlite module.
@@ -10,6 +14,10 @@ export class SQLiteReader implements TelemetryReader {
 
 	constructor(dbPath: string) {
 		this.dbPath = dbPath;
+	}
+
+	private toSqliteError(): Error {
+		return new Error(SQLITE_ERROR);
 	}
 
 	private async getDb(): Promise<{
@@ -23,10 +31,7 @@ export class SQLiteReader implements TelemetryReader {
 			this.db = new DatabaseSync(this.dbPath, { readOnly: true });
 			return this.db as never;
 		} catch {
-			throw new Error(
-				"SQLite reader requires Node.js 22+ with built-in sqlite module. " +
-					"Use a JSONL telemetry store instead, or upgrade Node.js."
-			);
+			throw this.toSqliteError();
 		}
 	}
 
@@ -45,10 +50,15 @@ export class SQLiteReader implements TelemetryReader {
 			params.push(options.until.toISOString());
 		}
 
-		sql += " ORDER BY timestamp DESC";
+		sql += " ORDER BY timestamp DESC, request_id ASC, detection ASC";
 
-		const stmt = db.prepare(sql);
-		const rows = stmt.all(...params) as Record<string, unknown>[];
+		let rows: Record<string, unknown>[];
+		try {
+			const stmt = db.prepare(sql);
+			rows = stmt.all(...params) as Record<string, unknown>[];
+		} catch {
+			throw this.toSqliteError();
+		}
 
 		return rows.map((row) => ({
 			schemaVersion: 1 as const,

--- a/packages/cli/src/verify/index.ts
+++ b/packages/cli/src/verify/index.ts
@@ -1,7 +1,10 @@
+import { dirname } from "node:path";
 import { readFile } from "node:fs/promises";
 import matter from "gray-matter";
 import { major, minor, patch } from "semver";
 import { extractVersionedPackages, parseCompatibility } from "../compatibility/index.js";
+import { runFingerprint } from "../fingerprint/index.js";
+import { readLockFile, verifyIntegrity } from "../lockfile/index.js";
 import { normalizeVersion } from "../severity.js";
 import { discoverSkillFiles } from "../shared/discovery.js";
 import { readSkillFile } from "../skill-io.js";
@@ -70,6 +73,29 @@ function resolveVersion(parsed: matter.GrayMatterFile<string>): string | null {
 		return String(parsed.data["product-version"]);
 	}
 	return null;
+}
+
+function resolveIntegrityDir(skill?: string): string {
+	if (!skill) {
+		return ".";
+	}
+
+	return skill.endsWith(".md") ? dirname(dirname(skill)) : skill;
+}
+
+function summarizeIntegrity(results: ReturnType<typeof verifyIntegrity>): {
+	missing: number;
+	modified: number;
+	new: number;
+	ok: number;
+} {
+	return results.reduce(
+		(summary, result) => {
+			summary[result.status] += 1;
+			return summary;
+		},
+		{ ok: 0, modified: 0, missing: 0, new: 0 }
+	);
 }
 
 async function verifyPair(
@@ -154,6 +180,7 @@ async function verifyPair(
  */
 export async function runVerify(options: VerifyOptions): Promise<VerifyReport> {
 	const results: VerifyResult[] = [];
+	let integrity: VerifyReport["integrity"];
 
 	if (options.before && options.after) {
 		// Mode 1: Explicit path comparison
@@ -203,6 +230,18 @@ export async function runVerify(options: VerifyOptions): Promise<VerifyReport> {
 			const result = await verifyPair(previousContent, skillFile.raw, filePath, options);
 			results.push(result);
 		}
+
+		if (options.checkIntegrity) {
+			const fingerprintRegistry = await runFingerprint(files.length > 0 ? files : [dir]);
+			const lock = readLockFile(resolveIntegrityDir(options.skill));
+			const integrityResults = lock ? verifyIntegrity(lock, fingerprintRegistry) : [];
+
+			integrity = {
+				lockFound: lock !== null,
+				results: integrityResults,
+				summary: summarizeIntegrity(integrityResults),
+			};
+		}
 	}
 
 	const passed = results.filter((r) => r.match).length;
@@ -210,6 +249,7 @@ export async function runVerify(options: VerifyOptions): Promise<VerifyReport> {
 	const skipped = results.filter((r) => !r.match && r.declaredBump === null).length;
 
 	return {
+		integrity,
 		results,
 		summary: { passed, failed, skipped },
 		generatedAt: new Date().toISOString(),

--- a/packages/cli/src/verify/reporters/json.test.ts
+++ b/packages/cli/src/verify/reporters/json.test.ts
@@ -35,8 +35,36 @@ describe("formatVerifyJson", () => {
 
 		expect(parsed.results).toHaveLength(1);
 		expect(parsed.results[0].skill).toBe("test");
+		expect(parsed.integrity).toBeUndefined();
 		expect(parsed.summary.passed).toBe(1);
 		expect(parsed.generatedAt).toBe("2026-03-03T00:00:00.000Z");
+	});
+
+	it("includes integrity results when present", () => {
+		const report: VerifyReport = {
+			results: [],
+			summary: { passed: 0, failed: 0, skipped: 0 },
+			generatedAt: "2026-03-03T00:00:00.000Z",
+			integrity: {
+				lockFound: true,
+				results: [
+					{
+						skill: "react-patterns",
+						status: "modified",
+						field: "contentHash",
+						expected: "old",
+						actual: "new",
+					},
+				],
+				summary: { ok: 0, modified: 1, missing: 0, new: 0 },
+			},
+		};
+
+		const output = formatVerifyJson(report);
+		const parsed = JSON.parse(output);
+
+		expect(parsed.integrity.lockFound).toBe(true);
+		expect(parsed.integrity.results[0].field).toBe("contentHash");
 	});
 
 	it("produces pretty-printed JSON with 2-space indent", () => {

--- a/packages/cli/src/verify/reporters/markdown.ts
+++ b/packages/cli/src/verify/reporters/markdown.ts
@@ -91,5 +91,23 @@ export function formatVerifyMarkdown(report: VerifyReport): string {
 		lines.push(...formatResult(result));
 	}
 
+	if (report.integrity) {
+		lines.push("## Integrity");
+		lines.push("");
+		if (!report.integrity.lockFound) {
+			lines.push("skills-lock.json not found.");
+			lines.push("");
+		} else {
+			lines.push("| Skill | Status | Field | Expected | Actual |");
+			lines.push("|-------|--------|-------|----------|--------|");
+			for (const result of report.integrity.results) {
+				lines.push(
+					`| ${result.skill} | ${result.status} | ${result.field ?? ""} | ${result.expected ?? ""} | ${result.actual ?? ""} |`
+				);
+			}
+			lines.push("");
+		}
+	}
+
 	return lines.join("\n");
 }

--- a/packages/cli/src/verify/reporters/sarif.ts
+++ b/packages/cli/src/verify/reporters/sarif.ts
@@ -1,23 +1,61 @@
+import type { IntegrityResult } from "../../lockfile/index.js";
 import type { VerifyReport, VerifyResult } from "../types.js";
 
 function toSarifLevel(result: VerifyResult): "error" | "warning" | "note" {
 	return result.match ? "note" : "error";
 }
 
-function buildRules(results: VerifyResult[]): object[] {
+function integritySarifLevel(result: IntegrityResult): "error" | "warning" | "note" {
+	switch (result.status) {
+		case "missing":
+			return "error";
+		case "modified":
+		case "new":
+			return "warning";
+		default:
+			return "note";
+	}
+}
+
+function integrityRuleId(status: IntegrityResult["status"]): string {
+	return `skills-check/integrity/${status}`;
+}
+
+function buildRules(report: VerifyReport): object[] {
 	const seen = new Set<string>();
 	const rules: object[] = [];
 
-	for (const r of results) {
-		const ruleId = `skills-check/verify/${r.match ? "pass" : "mismatch"}`;
+	for (const result of report.results) {
+		const ruleId = `skills-check/verify/${result.match ? "pass" : "mismatch"}`;
 		if (!seen.has(ruleId)) {
 			seen.add(ruleId);
 			rules.push({
 				id: ruleId,
 				shortDescription: {
-					text: r.match ? "Version bump matches content" : "Version bump mismatch",
+					text: result.match ? "Version bump matches content" : "Version bump mismatch",
 				},
-				defaultConfiguration: { level: toSarifLevel(r) },
+				defaultConfiguration: { level: toSarifLevel(result) },
+			});
+		}
+	}
+
+	if (report.integrity && !report.integrity.lockFound) {
+		seen.add("skills-check/integrity/lockfile-missing");
+		rules.push({
+			id: "skills-check/integrity/lockfile-missing",
+			shortDescription: { text: "skills-lock.json is missing" },
+			defaultConfiguration: { level: "error" as const },
+		});
+	}
+
+	for (const result of report.integrity?.results ?? []) {
+		const ruleId = integrityRuleId(result.status);
+		if (!seen.has(ruleId)) {
+			seen.add(ruleId);
+			rules.push({
+				id: ruleId,
+				shortDescription: { text: `Integrity status: ${result.status}` },
+				defaultConfiguration: { level: integritySarifLevel(result) },
 			});
 		}
 	}
@@ -25,26 +63,60 @@ function buildRules(results: VerifyResult[]): object[] {
 	return rules;
 }
 
-function buildResults(results: VerifyResult[]): object[] {
-	return results
-		.filter((r) => !r.match)
-		.map((r) => ({
-			ruleId: "skills-check/verify/mismatch",
-			level: "error" as const,
-			message: { text: r.explanation },
-			locations: [
-				{
-					physicalLocation: {
-						artifactLocation: { uri: r.file },
-						region: { startLine: 1 },
-					},
+function buildVerifyResults(results: VerifyResult[]): object[] {
+	return results.filter((result) => !result.match).map((result) => ({
+		ruleId: "skills-check/verify/mismatch",
+		level: "error" as const,
+		message: { text: result.explanation },
+		locations: [
+			{
+				physicalLocation: {
+					artifactLocation: { uri: result.file },
+					region: { startLine: 1 },
 				},
-			],
+			},
+		],
+		properties: {
+			skill: result.skill,
+			declaredBump: result.declaredBump,
+			assessedBump: result.assessedBump,
+			llmUsed: result.llmUsed,
+		},
+	}));
+}
+
+function buildIntegrityResults(report: VerifyReport): object[] {
+	if (!report.integrity) {
+		return [];
+	}
+
+	if (!report.integrity.lockFound) {
+		return [
+			{
+				ruleId: "skills-check/integrity/lockfile-missing",
+				level: "error" as const,
+				message: { text: "skills-lock.json not found" },
+			},
+		];
+	}
+
+	return report.integrity.results
+		.filter((result) => result.status !== "ok")
+		.map((result) => ({
+			ruleId: integrityRuleId(result.status),
+			level: integritySarifLevel(result),
+			message: {
+				text:
+					result.status === "modified"
+						? `${result.skill} modified (${result.field}: ${result.expected ?? "<missing>"} -> ${result.actual ?? "<missing>"})`
+						: `${result.skill} ${result.status}`,
+			},
 			properties: {
-				skill: r.skill,
-				declaredBump: r.declaredBump,
-				assessedBump: r.assessedBump,
-				llmUsed: r.llmUsed,
+				skill: result.skill,
+				status: result.status,
+				field: result.field,
+				expected: result.expected,
+				actual: result.actual,
 			},
 		}));
 }
@@ -59,10 +131,10 @@ export function formatVerifySarif(report: VerifyReport): string {
 					driver: {
 						name: "skills-check/verify",
 						informationUri: "https://skillscheck.ai",
-						rules: buildRules(report.results),
+						rules: buildRules(report),
 					},
 				},
-				results: buildResults(report.results),
+				results: [...buildVerifyResults(report.results), ...buildIntegrityResults(report)],
 				invocations: [
 					{
 						executionSuccessful: true,

--- a/packages/cli/src/verify/reporters/terminal.test.ts
+++ b/packages/cli/src/verify/reporters/terminal.test.ts
@@ -139,4 +139,28 @@ describe("formatVerifyTerminal", () => {
 		expect(output).toContain("2");
 		expect(output).toContain("1");
 	});
+
+	it("shows integrity results when present", () => {
+		const output = formatVerifyTerminal(
+			makeReport({
+				integrity: {
+					lockFound: true,
+					results: [
+						{
+							skill: "react-patterns",
+							status: "modified",
+							field: "contentHash",
+							expected: "old",
+							actual: "new",
+						},
+					],
+					summary: { ok: 0, modified: 1, missing: 0, new: 0 },
+				},
+			})
+		);
+
+		expect(output).toContain("Integrity");
+		expect(output).toContain("react-patterns: modified");
+		expect(output).toContain("contentHash");
+	});
 });

--- a/packages/cli/src/verify/reporters/terminal.ts
+++ b/packages/cli/src/verify/reporters/terminal.ts
@@ -1,6 +1,17 @@
 import chalk from "chalk";
 import type { VerifyReport, VerifyResult } from "../types.js";
 
+function integrityIcon(status: "ok" | "modified" | "missing" | "new"): string {
+	switch (status) {
+		case "ok":
+			return chalk.green("✓");
+		case "missing":
+			return chalk.red("✗");
+		default:
+			return chalk.yellow("⚠");
+	}
+}
+
 function assessmentIcon(match: boolean): string {
 	return match ? chalk.green("[PASS]") : chalk.red("[FAIL]");
 }
@@ -79,7 +90,7 @@ export function formatVerifyTerminal(report: VerifyReport): string {
 	lines.push("=".repeat(50));
 	lines.push("");
 
-	if (report.results.length === 0) {
+	if (report.results.length === 0 && !report.integrity) {
 		lines.push(chalk.dim("No skills found to verify."));
 		lines.push("");
 		return lines.join("\n");
@@ -87,6 +98,23 @@ export function formatVerifyTerminal(report: VerifyReport): string {
 
 	for (const result of report.results) {
 		lines.push(...formatResult(result));
+	}
+
+	if (report.integrity) {
+		lines.push(chalk.bold("Integrity"));
+		lines.push("-".repeat(50));
+		if (!report.integrity.lockFound) {
+			lines.push(chalk.red("  skills-lock.json not found"));
+		} else {
+			for (const result of report.integrity.results) {
+				const detail =
+					result.status === "modified"
+						? ` (${result.field}: ${result.expected ?? "<missing>"} -> ${result.actual ?? "<missing>"})`
+						: "";
+				lines.push(`  ${integrityIcon(result.status)} ${result.skill}: ${result.status}${detail}`);
+			}
+		}
+		lines.push("");
 	}
 
 	// Summary

--- a/packages/cli/src/verify/types.ts
+++ b/packages/cli/src/verify/types.ts
@@ -1,3 +1,5 @@
+import type { IntegrityResult } from "../lockfile/index.js";
+
 export type VersionBump = "major" | "minor" | "patch";
 
 export interface ChangeSignal {
@@ -22,6 +24,11 @@ export interface VerifyResult {
 
 export interface VerifyReport {
 	generatedAt: string;
+	integrity?: {
+		lockFound: boolean;
+		results: IntegrityResult[];
+		summary: { missing: number; modified: number; new: number; ok: number };
+	};
 	results: VerifyResult[];
 	summary: { passed: number; failed: number; skipped: number };
 }
@@ -30,6 +37,7 @@ export interface VerifyOptions {
 	after?: string;
 	all?: boolean;
 	before?: string;
+	checkIntegrity?: boolean;
 	format?: "terminal" | "json" | "markdown" | "sarif";
 	model?: string;
 	output?: string;

--- a/packages/cli/test/e2e/health-pipeline.test.ts
+++ b/packages/cli/test/e2e/health-pipeline.test.ts
@@ -1,0 +1,152 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { healthCommand } from "../../src/commands/health.ts";
+
+const FINDING_SUMMARY_RE = /\d+ finding\(s\)/;
+const TOKENS_RE = /tokens/;
+
+interface HealthJsonResult {
+	results: Array<{
+		command: "audit" | "budget" | "integrity" | "lint" | "policy";
+		exitCode: number;
+		status?: string;
+		summary: string;
+	}>;
+}
+
+describe("health command E2E pipeline", () => {
+	let fixtureRoot: string;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeAll(async () => {
+		fixtureRoot = await mkdtemp(join(tmpdir(), "skills-check-health-e2e-"));
+
+		const validSkillDir = join(fixtureRoot, "security-review");
+		const invalidSkillDir = join(fixtureRoot, "rogue-deploy");
+
+		await Promise.all([mkdir(validSkillDir), mkdir(invalidSkillDir)]);
+
+		await writeFile(
+			join(fixtureRoot, ".skill-policy.yml"),
+			[
+				"version: 1",
+				"required:",
+				"  - skill: security-review",
+				"sources:",
+				"  allow:",
+				"    - internal/*",
+				"content:",
+				"  deny_patterns:",
+				"    - pattern: rm\\s+-rf\\s+/",
+				'      reason: "Destructive shell commands are not allowed in skills."',
+			].join("\n"),
+			"utf-8"
+		);
+
+		await writeFile(
+			join(validSkillDir, "SKILL.md"),
+			[
+				"---",
+				"name: security-review",
+				"description: Review changes for security risks before deployment.",
+				"author: Security Team",
+				"license: MIT",
+				"repository: https://github.com/acme/security-review",
+				"source: internal/security-review",
+				"spec-version: v1",
+				"keywords:",
+				"  - security",
+				"  - review",
+				"compatibility: github@^1.0.0",
+				"---",
+				"# Security Review",
+				"",
+				"Check changes, note risky dependencies, and document mitigation steps.",
+			].join("\n"),
+			"utf-8"
+		);
+
+		await writeFile(
+			join(invalidSkillDir, "SKILL.md"),
+			[
+				"---",
+				"name: rogue-deploy",
+				"author: Platform Team",
+				"license: MIT",
+				"repository: https://github.com/acme/rogue-deploy",
+				"source: evil/skills",
+				"spec-version: v1",
+				"keywords:",
+				"  - deploy",
+				"compatibility: github@^1.0.0",
+				"---",
+				"# Rogue Deploy",
+				"",
+				"```bash",
+				"rm -rf /",
+				"```",
+			].join("\n"),
+			"utf-8"
+		);
+	});
+
+	afterEach(() => {
+		logSpy?.mockRestore();
+		errorSpy?.mockRestore();
+	});
+
+	afterAll(async () => {
+		await rm(fixtureRoot, { force: true, recursive: true });
+	});
+
+	it("runs audit, lint, budget, and policy against real skill fixtures", async () => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+		const exitCode = await healthCommand(fixtureRoot, { format: "json" });
+
+		expect(exitCode).toBe(1);
+		expect(logSpy).toHaveBeenCalledTimes(1);
+
+		const output = JSON.parse(logSpy.mock.calls[0][0] as string) as HealthJsonResult;
+		expect(output.results.map((result) => result.command)).toEqual([
+			"lint",
+			"audit",
+			"budget",
+			"integrity",
+			"policy",
+		]);
+
+		const byCommand = new Map(output.results.map((result) => [result.command, result]));
+
+		expect(byCommand.get("lint")).toMatchObject({
+			exitCode: 1,
+		});
+		expect(byCommand.get("lint")?.summary).toMatch(FINDING_SUMMARY_RE);
+
+		expect(byCommand.get("audit")).toMatchObject({
+			exitCode: 1,
+		});
+		expect(byCommand.get("audit")?.summary).toMatch(FINDING_SUMMARY_RE);
+
+		expect(byCommand.get("budget")).toMatchObject({
+			exitCode: 0,
+		});
+		expect(byCommand.get("budget")?.summary).toMatch(TOKENS_RE);
+
+		expect(byCommand.get("integrity")).toMatchObject({
+			exitCode: 0,
+			status: "warning",
+		});
+
+		expect(byCommand.get("policy")).toEqual({
+			command: "policy",
+			exitCode: 1,
+			status: "failure",
+			summary: "2 finding(s)",
+		});
+	});
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,7 +1,12 @@
 export type {
 	FingerprintEntry,
 	FingerprintRegistry,
+	PolicyExemption,
 	Registry,
 	RegistryProduct,
+	RevocationEntry,
+	RevocationList,
 	SkillTelemetryEvent,
+	SkillsLockFile,
+	SkillsLockFileEntry,
 } from "./types.js";

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -118,4 +118,111 @@ export interface FingerprintEntry {
 	version: string;
 	/** Watermark string if present */
 	watermark?: string;
+	/** Skill status for lifecycle management */
+	status?: "active" | "deprecated" | "revoked";
+	/** Deprecation message when status is deprecated */
+	deprecatedMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Lock file format: skills-lock.json (v2)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single skill entry in the lock file, capturing the full fingerprint
+ * state at the time of resolution.
+ */
+export interface SkillsLockFileEntry {
+	/** SHA-256 content hash from fingerprint */
+	contentHash: string;
+	/** Deprecation message if status is deprecated */
+	deprecatedMessage?: string;
+	/** Deprecation sunset date (ISO 8601) if status is deprecated */
+	deprecatedSunsetDate?: string;
+	/** SHA-256 frontmatter hash from fingerprint */
+	frontmatterHash: string;
+	/** Skill name (directory basename or frontmatter name) */
+	name: string;
+	/** SHA-256 prefix hash from fingerprint */
+	prefixHash: string;
+	/** ISO 8601 timestamp when this entry was resolved */
+	resolvedAt: string;
+	/** Resolved source URI (file path, git URL, registry URL) */
+	source: string;
+	/** Skill status */
+	status?: "active" | "deprecated" | "revoked";
+	/** Estimated token count at time of lock */
+	tokenCount?: number;
+	/** Semver version from frontmatter, if present */
+	version?: string;
+	/** Watermark string injected by fingerprint command */
+	watermark?: string;
+}
+
+/**
+ * Lock file format for deterministic skill resolution.
+ * Analogous to package-lock.json / Cargo.lock for skills.
+ */
+export interface SkillsLockFile {
+	/** ISO 8601 timestamp of last generation */
+	generatedAt: string;
+	/** Tool and version that generated this lock file */
+	generatedBy: string;
+	/** Lock file format version for forward compatibility */
+	lockfileVersion: 2;
+	/** Map of skill name → locked entry */
+	skills: Record<string, SkillsLockFileEntry>;
+}
+
+// ---------------------------------------------------------------------------
+// Policy exemptions
+// ---------------------------------------------------------------------------
+
+/**
+ * An exemption entry that suppresses a specific policy violation
+ * for a skill (or glob pattern of skills).
+ */
+export interface PolicyExemption {
+	/** ISO 8601 expiry date — exemption auto-expires and violation becomes active */
+	expires?: string;
+	/** Who granted the exemption */
+	grantedBy?: string;
+	/** Human-readable reason for the exemption */
+	reason: string;
+	/** Validator rule ID to exempt (e.g. "banned-pattern", "source-not-allowed") */
+	rule: string;
+	/** Skill name or glob pattern (e.g. "my-skill" or "internal/*") */
+	skill: string;
+}
+
+// ---------------------------------------------------------------------------
+// Revocation list: .skill-revocations.json
+// ---------------------------------------------------------------------------
+
+/**
+ * A single revocation entry marking a skill as compromised.
+ */
+export interface RevocationEntry {
+	/** Link to advisory or disclosure */
+	advisory?: string;
+	/** Human-readable reason for revocation */
+	reason: string;
+	/** ISO 8601 timestamp of when the skill was revoked */
+	revokedAt: string;
+	/** Severity of the revocation */
+	severity: "critical" | "high" | "medium" | "low";
+	/** Skill name or identifier */
+	skill: string;
+}
+
+/**
+ * Local revocation list for marking skills as compromised.
+ */
+export interface RevocationList {
+	/** Revocation entries */
+	entries: RevocationEntry[];
+	/** Format version for forward compatibility */
+	revocationVersion: 1;
+	/** ISO 8601 timestamp of last update */
+	updatedAt: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
@@ -166,6 +169,27 @@ packages:
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
   '@biomejs/biome@2.4.7':
@@ -892,6 +916,15 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+    peerDependencies:
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
@@ -909,6 +942,9 @@ packages:
   '@vitest/pretty-format@4.1.0':
     resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
   '@vitest/runner@4.1.0':
     resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
@@ -920,6 +956,9 @@ packages:
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -944,6 +983,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1090,9 +1132,28 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1100,6 +1161,9 @@ packages:
 
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -1211,6 +1275,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -1412,6 +1483,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1657,6 +1732,21 @@ snapshots:
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.4.7':
     optionalDependencies:
@@ -2115,6 +2205,20 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))
+
   '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2133,6 +2237,10 @@ snapshots:
       vite: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
@@ -2156,6 +2264,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn@8.16.0: {}
 
   ai@6.0.116(zod@3.25.76):
@@ -2175,6 +2289,12 @@ snapshots:
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@4.0.4: {}
 
@@ -2304,13 +2424,32 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
   is-extendable@0.1.1: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   joycon@3.1.1: {}
 
   js-tiktoken@1.0.21:
     dependencies:
       base64-js: 1.5.1
+
+  js-tokens@10.0.0: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -2389,6 +2528,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   minimatch@10.2.4:
     dependencies:
@@ -2626,6 +2775,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   thenify-all@1.6.0:
     dependencies:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,10 +1,15 @@
 {
-  "version": 1,
+  "lockfileVersion": 2,
+  "generatedBy": "skills-check@1.3.0",
+  "generatedAt": "2026-04-18T00:00:00.000Z",
   "skills": {
     "beads": {
+      "name": "beads",
       "source": "steveyegge/beads",
-      "sourceType": "github",
-      "computedHash": "10444b40c8c9d10ea36d585273cf1cb0d8e8c5a83df2f2b2e6d5ee4d47a48f7e"
+      "contentHash": "10444b40c8c9d10ea36d585273cf1cb0d8e8c5a83df2f2b2e6d5ee4d47a48f7e",
+      "frontmatterHash": "10444b40c8c9d10ea36d585273cf1cb0d8e8c5a83df2f2b2e6d5ee4d47a48f7e",
+      "prefixHash": "10444b40c8c9d10ea36d585273cf1cb0d8e8c5a83df2f2b2e6d5ee4d47a48f7e",
+      "resolvedAt": "2026-04-18T00:00:00.000Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements the complete Phase 1 roadmap to make skills-check trustworthy in real CI pipelines. After this PR, teams can add `skills-check health --frozen-lockfile` to CI and enforce skill governance with exemptions, tamper detection, and deprecation controls.

**67 files changed** | **+5,584 / -208** | **123 test files / 991 tests (was 111/920)**

## What's included

### Lock File v2 Overhaul
- New `packages/cli/src/lockfile/` module (read/write/diff/migrate)
- `skills-lock.json` v2 format aligned with `FingerprintRegistry` schema
- Auto-update on `fingerprint` and `refresh` commands
- `--frozen-lockfile` flag on `health` for CI gates (hard-fail on drift)
- v1 → v2 migration with auto-detection

### Policy Exemption System
- `exemptions` section in `.skill-policy.yml` (cargo-deny style)
- `applyExemptions()` filters violations **after** validators run (keeps validators pure)
- Glob matching for skill names, automatic expiry enforcement
- All 4 reporters updated: terminal (dimmed), JSON, SARIF (`suppressions`), markdown
- `--show-exemptions` flag on `policy` command

### Tamper Detection
- `verifyIntegrity()` compares current hashes against lock file entries
- Integrated into `health` pipeline (after fingerprinting, before policy)
- `--check-integrity` flag on `verify` command
- Reports `modified | missing | new` with specific hash field identification

### Revocation & Deprecation
- Local `.skill-revocations.json` format with severity levels
- `deprecated` / `deprecatedMessage` frontmatter parsing
- Revoked skills → audit failure (critical finding)
- Deprecated skills → lint warnings
- `--check-revocations <path>` on `audit` and `health` commands

### Schema Types (`@skills-check/schema`)
- `SkillsLockFile`, `SkillsLockFileEntry`, `PolicyExemption`
- `RevocationList`, `RevocationEntry`
- `FingerprintEntry.status` and `deprecatedMessage` fields

### Test Coverage (+71 tests)
- SQLiteReader integration tests (real databases, not mocks)
- Reporter snapshot tests for all 4 policy reporters
- E2E health pipeline test with real SKILL.md fixtures
- Lockfile, revocation, deprecation, integrity unit + integration tests

### Housekeeping
- Replaced all beads/bd references with GitHub Issues
- Phase 1 implementation plan at `.sisyphus/plans/phase-1-production-ready.md`

## New CLI flags

| Command | Flag | Behavior |
|---------|------|----------|
| `health` | `--frozen-lockfile` | Fail if lock file missing or would change |
| `health` | `--check-revocations <path>` | Check skills against revocation list |
| `audit` | `--check-revocations <path>` | Check skills against revocation list |
| `verify` | `--check-integrity` | Compare current hashes vs lock file |
| `policy` | `--show-exemptions` | Display exempted violations |

## Verification

- Build: ✅ ESM + DTS success
- Tests: ✅ 123 files / 991 tests all passing
- Typecheck: Pre-existing `generate.ts` errors only (no new errors)